### PR TITLE
feat: Friend, User, OAuth, Jwt 예외 처리 RestApiException 사용

### DIFF
--- a/src/main/java/gravit/code/auth/jwt/JwtProvider.java
+++ b/src/main/java/gravit/code/auth/jwt/JwtProvider.java
@@ -3,7 +3,10 @@ package gravit.code.auth.jwt;
 import gravit.code.auth.oauth.LoginUser;
 import gravit.code.domain.user.domain.User;
 import gravit.code.domain.user.domain.UserRepository;
+import gravit.code.global.exception.domain.CustomErrorCode;
+import gravit.code.global.exception.domain.RestApiException;
 import io.jsonwebtoken.*;
+import io.jsonwebtoken.security.SignatureException;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.beans.factory.annotation.Value;
 import org.springframework.security.authentication.UsernamePasswordAuthenticationToken;
@@ -14,31 +17,32 @@ import javax.crypto.SecretKey;
 import javax.crypto.spec.SecretKeySpec;
 import java.nio.charset.StandardCharsets;
 import java.util.Date;
+import java.util.function.Function;
+
+import static io.jsonwebtoken.Jwts.SIG.HS256;
 
 @Component
 @Slf4j
 public class JwtProvider {
     private final UserRepository userRepository;
 
-    private SecretKey secretKey;
+    private final SecretKey secretKey;
+    public int validTime;
 
-    @Value("${jwt.valid-time}")
-    public Long VALID_TIME;
-
-    private JwtProvider(UserRepository userRepository, @Value("${jwt.secret}") String secret){
+    private JwtProvider(UserRepository userRepository,
+                        @Value("${jwt.secret}") String secret,
+                        @Value("${jwt.valid-time}")int validTime){
         this.userRepository = userRepository;
-        secretKey = new SecretKeySpec(secret.getBytes(StandardCharsets.UTF_8), Jwts.SIG.HS256.key().build().getAlgorithm());
+        this.validTime = validTime;
+        this.secretKey = new SecretKeySpec(secret.getBytes(StandardCharsets.UTF_8), "HmacSHA256");
     }
 
     public String createAccessToken(Long userId){
-        Date timeNow = new Date(System.currentTimeMillis());
-        Date expirationTime = new Date(timeNow.getTime() + VALID_TIME);
-
         return Jwts.builder()
                 .claim("userId", userId)
-                .setIssuedAt(timeNow)
-                .setExpiration(expirationTime)
-                .signWith(secretKey, SignatureAlgorithm.HS256)
+                .expiration(new Date(System.currentTimeMillis() + validTime))
+                .issuedAt(new Date())
+                .signWith(secretKey, HS256)
                 .compact();
     }
 
@@ -46,37 +50,49 @@ public class JwtProvider {
         Long userId = getUserId(token);
         User user = userRepository.findById(userId).orElseThrow(RuntimeException::new);
         LoginUser loginUser = new LoginUser(user.getId(),user.getProviderId(),null);
+
         return new UsernamePasswordAuthenticationToken(loginUser, "",
                 loginUser.getAuthorities());
     }
 
     public Long getUserId(String token) {
-        return Jwts.parser().verifyWith(secretKey).build().parseSignedClaims(token).getPayload().get("userId", Long.class);
+        Claims claims = extractClaims(token);
+        return claims.get("userId", Long.class);
     }
 
-    public String getRole(String token) {
-        return Jwts.parser().verifyWith(secretKey).build().parseSignedClaims(token).getPayload().get("role", String.class);
+    private Claims extractClaims(String token) {
+        return handleJwtException(token, (value) ->
+                Jwts.parser()
+                        .verifyWith(secretKey)
+                        .build()
+                        .parseSignedClaims(value).getPayload()
+        );
     }
 
     public boolean isValidToken(String token){
-        //log.info("토큰 유효성 검증 시작");
-        return valid(secretKey, token);
+        return handleJwtException(token, (value) -> {
+            Jws<Claims> claims = Jwts.parser()
+                    .verifyWith(secretKey)
+                    .build()
+                    .parseSignedClaims(value);
+            Date expiration = claims.getPayload().getExpiration();
+            return expiration.after(new Date());
+        });
     }
 
-    private boolean valid(SecretKey secretKey, String token){
+    private <T> T handleJwtException(String token, Function<String, T> function){
         try{
-            Jws<Claims> claims = Jwts.parser().verifyWith(secretKey).build().parseSignedClaims(token);
-            Date expiration = claims.getBody().getExpiration();
-            return expiration.after(new Date());
-        }catch (SignatureException ex){
-            throw new RuntimeException();
-        }catch (MalformedJwtException ex){
-            throw new RuntimeException();
-        }catch (ExpiredJwtException ex){
-            throw new RuntimeException();
-        }catch (IllegalArgumentException ex){
-            throw new RuntimeException();
+            return function.apply(token);
+        }catch (MalformedJwtException malformedJwtException){
+            throw new RestApiException(CustomErrorCode.TOKEN_INVALID);
+        }catch (ExpiredJwtException expiredJwtException){
+            throw new RestApiException(CustomErrorCode.TOKEN_EXPIRED);
+        }catch (IllegalArgumentException illegalArgumentException){
+            throw new RestApiException(CustomErrorCode.TOKEN_EMPTY);
+        }catch (SignatureException signatureException){
+            throw new RestApiException(CustomErrorCode.TOKEN_NOT_SIGNED);
+        }catch (JwtException jwtException){
+            throw new RestApiException(CustomErrorCode.INTERNAL_SERVER_ERROR);
         }
     }
-
 }

--- a/src/main/java/gravit/code/auth/oauth/OAuthConstants.java
+++ b/src/main/java/gravit/code/auth/oauth/OAuthConstants.java
@@ -1,0 +1,7 @@
+package gravit.code.auth.oauth;
+
+import java.util.List;
+
+public final class OAuthConstants {
+    public static final List<String> OAUTH_PROVIDERS = List.of("naver", "kakao", "google");
+}

--- a/src/main/java/gravit/code/auth/oauth/controller/OAuthController.java
+++ b/src/main/java/gravit/code/auth/oauth/controller/OAuthController.java
@@ -1,5 +1,6 @@
 package gravit.code.auth.oauth.controller;
 
+import gravit.code.auth.oauth.controller.docs.OAuthControllerDocs;
 import gravit.code.auth.oauth.dto.AuthCodeRequest;
 import gravit.code.auth.oauth.dto.LoginResponse;
 import gravit.code.auth.oauth.dto.OAuthUserInfo;
@@ -16,7 +17,7 @@ import java.util.Map;
 @RestController
 @RequiredArgsConstructor
 @RequestMapping("/api/v1/oauth")
-public class OAuthController {
+public class OAuthController implements OAuthControllerDocs {
     private final OAuthClientService oAuthClientService;
     private final OAuthLoginProcessor oAuthLoginProcessor;
     private final OAuthLoginUrlService oAuthLoginUrlService;
@@ -33,7 +34,6 @@ public class OAuthController {
     /**
      * auth code 를 기반으로 소셜 로그인 시도 한 유져의 정보를 가져와 회원가입 및 로그인을 처리합니다.
      */
-
     @PostMapping("/{provider}")
     public ResponseEntity<LoginResponse> oauthLogin(@PathVariable("provider") String provider,
                                                     @RequestBody AuthCodeRequest request){

--- a/src/main/java/gravit/code/auth/oauth/controller/OAuthController.java
+++ b/src/main/java/gravit/code/auth/oauth/controller/OAuthController.java
@@ -37,14 +37,8 @@ public class OAuthController implements OAuthControllerDocs {
     @PostMapping("/{provider}")
     public ResponseEntity<LoginResponse> oauthLogin(@PathVariable("provider") String provider,
                                                     @RequestBody AuthCodeRequest request){
-        String code = request.code();
-
-        if(code == null){
-            return  ResponseEntity.badRequest().build();
-        }
-
+        String code = request.authCode();
         OAuthUserInfo userInfo = oAuthClientService.getUserInfo(code, provider);
-
         LoginResponse loginResponse = oAuthLoginProcessor.process(userInfo);
 
         return ResponseEntity.status(HttpStatus.OK).body(loginResponse);

--- a/src/main/java/gravit/code/auth/oauth/controller/docs/OAuthControllerDocs.java
+++ b/src/main/java/gravit/code/auth/oauth/controller/docs/OAuthControllerDocs.java
@@ -1,0 +1,39 @@
+package gravit.code.auth.oauth.controller.docs;
+
+import gravit.code.auth.oauth.dto.AuthCodeRequest;
+import gravit.code.auth.oauth.dto.LoginResponse;
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.Parameter;
+import io.swagger.v3.oas.annotations.responses.ApiResponse;
+import io.swagger.v3.oas.annotations.responses.ApiResponses;
+import io.swagger.v3.oas.annotations.tags.Tag;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.PathVariable;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestBody;
+
+import java.util.Map;
+
+@Tag(name = "OAuth API", description = "OAuth 관련 API 명세")
+public interface OAuthControllerDocs {
+
+    // OAuth 로그인 URL 생성
+    @Operation(summary = "로그인 URL 생성", description = "OAuth 정보를 바탕으로 로그인 URL을 생성합니다.")
+    @ApiResponses(
+            @ApiResponse(responseCode = "201", description = "로그인 URL 생성 성공")
+    )
+    @GetMapping("/login-url/{provider}")
+    ResponseEntity<Map<String, String>> authorizeUrl(@Parameter(description = "제공자(kakao, naver, google) 이름") @PathVariable("provider") String provider);
+
+    // OAuth 회원가입/로그인 처리
+    @Operation(summary = "OAuth 회원가입/로그인 처리", description = "AuthCode 를 기반으로 사용자 정보를 조회하고 회원가입 및 로그인 처리를 합니다.")
+    @ApiResponses(
+            @ApiResponse(responseCode = "201", description = "OAuth 회원가입/로그인 성공")
+    )
+    @PostMapping("/{provider}")
+    ResponseEntity<LoginResponse> oauthLogin(@Parameter(description = "제공자(kakao, naver, google) 이름") @PathVariable("provider") String provider,
+                                             @RequestBody AuthCodeRequest request);
+
+
+}

--- a/src/main/java/gravit/code/auth/oauth/dto/AuthCodeRequest.java
+++ b/src/main/java/gravit/code/auth/oauth/dto/AuthCodeRequest.java
@@ -1,6 +1,6 @@
 package gravit.code.auth.oauth.dto;
 
 public record AuthCodeRequest(
-        String code
+        String authCode
 ){
 }

--- a/src/main/java/gravit/code/auth/oauth/service/OAuthClientService.java
+++ b/src/main/java/gravit/code/auth/oauth/service/OAuthClientService.java
@@ -43,7 +43,7 @@ public class OAuthClientService {
         String decodedCode = URLDecoder.decode(authCode, StandardCharsets.UTF_8);
 
         // OAuth 설정 정보 가져오기
-        ClientRegistration registration = clientRegistrationRepository.findByRegistrationId(provider);
+        ClientRegistration registration = clientRegistrationRepository.findByRegistrationId(provider.toLowerCase());
 
         // 토큰 요청
         String accessToken = getAccessToken(registration, decodedCode);

--- a/src/main/java/gravit/code/auth/oauth/service/OAuthClientService.java
+++ b/src/main/java/gravit/code/auth/oauth/service/OAuthClientService.java
@@ -2,7 +2,10 @@ package gravit.code.auth.oauth.service;
 
 import gravit.code.auth.oauth.dto.OAuthUserInfo;
 import gravit.code.auth.oauth.startegy.OAuthResponseFactory;
+import gravit.code.global.exception.domain.CustomErrorCode;
+import gravit.code.global.exception.domain.RestApiException;
 import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
 import org.springframework.core.ParameterizedTypeReference;
 import org.springframework.http.HttpHeaders;
 import org.springframework.http.MediaType;
@@ -13,54 +16,118 @@ import org.springframework.util.LinkedMultiValueMap;
 import org.springframework.util.MultiValueMap;
 import org.springframework.web.reactive.function.BodyInserters;
 import org.springframework.web.reactive.function.client.WebClient;
+import org.springframework.web.reactive.function.client.WebClientException;
+import org.springframework.web.reactive.function.client.WebClientResponseException;
 
 import java.net.URLDecoder;
 import java.nio.charset.StandardCharsets;
 import java.util.Map;
 
+import static gravit.code.auth.oauth.OAuthConstants.OAUTH_PROVIDERS;
+
 @Service
 @RequiredArgsConstructor
+@Slf4j
 public class OAuthClientService {
+    private final static String GRANT_TYPE = "authorization_code";
+
     private final ClientRegistrationRepository clientRegistrationRepository;
     private final OAuthResponseFactory oAuthResponseFactory;
     private final WebClient webClient;
 
-    public OAuthUserInfo getUserInfo(String code, String provider) {
-        String decodedCode = URLDecoder.decode(code, StandardCharsets.UTF_8);
+    public OAuthUserInfo getUserInfo(String authCode, String provider) {
+        validateProvider(provider);
+        validateAuthCode(authCode);
 
+        // 웹에서 특수 문자나 공백 등이 URL 인코딩 된 상태로 전달되는 문제를 해결하기 위함
+        String decodedCode = URLDecoder.decode(authCode, StandardCharsets.UTF_8);
+
+        // OAuth 설정 정보 가져오기
         ClientRegistration registration = clientRegistrationRepository.findByRegistrationId(provider);
 
         // 토큰 요청
+        String accessToken = getAccessToken(registration, decodedCode);
+
+        // 사용자 정보 요청
+        Map<String, Object> userInfo = getUserInfo(registration, accessToken);
+
+        return oAuthResponseFactory.createOAuthUserInfo(provider, userInfo);
+    }
+
+    private Map<String, Object> getUserInfo(ClientRegistration registration, String accessToken) {
+
+        // 사용자 정보를 조회하기 위한 엔드포인트
+        String userInfoUri = registration.getProviderDetails().getUserInfoEndpoint().getUri();
+
+        Map<String, Object> userInfo;
+        try{
+            userInfo = webClient.get()
+                    .uri(userInfoUri)
+                    .header(HttpHeaders.AUTHORIZATION, "Bearer " + accessToken)
+                    .retrieve()
+                    .bodyToMono(new ParameterizedTypeReference<Map<String,Object>>() {})
+                    .blockOptional()
+                    .orElseThrow(()-> new RestApiException(CustomErrorCode.OAUTH_SERVER_ERROR));
+        }catch (WebClientResponseException.BadRequest e){
+            log.warn("유효하지 않은 AccessToken 요청 : {}", e.getCause().getMessage());
+            throw new RestApiException(CustomErrorCode.OAUTH_ACCESS_TOKEN_INVALID);
+        }catch (WebClientException e){
+            log.error("OAuth 서버 통신 오류", e);
+            throw new RestApiException(CustomErrorCode.OAUTH_SERVER_ERROR);
+        }
+
+        return userInfo;
+    }
+
+    private String getAccessToken(ClientRegistration registration, String decodedCode) {
+        
+        // 요청 만들기
         MultiValueMap<String, String> tokenRequest = new LinkedMultiValueMap<>();
-        tokenRequest.add("grant_type", "authorization_code");
+        tokenRequest.add("grant_type", GRANT_TYPE);
         tokenRequest.add("client_id", registration.getClientId());
         tokenRequest.add("client_secret", registration.getClientSecret());
         tokenRequest.add("redirect_uri", registration.getRedirectUri());
         tokenRequest.add("code", decodedCode);
 
+        // AccessToken 을 발급받기 위한 엔드포인트
         String tokenUri = registration.getProviderDetails().getTokenUri();
-        Map<String, Object> tokenResponse = webClient.post()
-                .uri(tokenUri)
-                .header(HttpHeaders.CONTENT_TYPE, MediaType.APPLICATION_FORM_URLENCODED_VALUE)
-                .body(BodyInserters.fromFormData(tokenRequest))
-                .retrieve()
-                .bodyToMono(new ParameterizedTypeReference<Map<String,Object>>() {})
-                .blockOptional()
-                .orElseThrow(RuntimeException::new);
+
+        Map<String, Object> tokenResponse;
+        try{
+            tokenResponse = webClient.post()
+                    .uri(tokenUri)
+                    .header(HttpHeaders.CONTENT_TYPE, MediaType.APPLICATION_FORM_URLENCODED_VALUE)
+                    .body(BodyInserters.fromFormData(tokenRequest))
+                    .retrieve()
+                    .bodyToMono(new ParameterizedTypeReference<Map<String,Object>>() {})
+                    .blockOptional()
+                    .orElseThrow(()-> new RestApiException(CustomErrorCode.OAUTH_SERVER_ERROR));
+        }catch (WebClientResponseException.BadRequest e){
+            log.warn("유효하지 않은 AuthCode 요청 : {}",e.getCause().getMessage());
+            throw new RestApiException(CustomErrorCode.AUTH_CODE_INVALID);
+        }catch (WebClientException e){
+            log.error("OAuth 서버 통신 오류", e);
+            throw new RestApiException(CustomErrorCode.OAUTH_SERVER_ERROR);
+        }
+
+        return (String) tokenResponse.get("access_token");
+    }
 
 
-        String accessToken = (String) tokenResponse.get("access_token");
+    private void validateAuthCode(String authCode) {
+        if(authCode == null || authCode.isBlank()){
+            throw new RestApiException(CustomErrorCode.PROVIDER_INVALID);
+        }
+    }
 
-        // 사용자 정보 요청
-        String userInfoUri = registration.getProviderDetails().getUserInfoEndpoint().getUri();
-        Map<String, Object> userInfo = webClient.get()
-                .uri(userInfoUri)
-                .header(HttpHeaders.AUTHORIZATION, "Bearer " + accessToken)
-                .retrieve()
-                .bodyToMono(new ParameterizedTypeReference<Map<String,Object>>() {})
-                .blockOptional()
-                .orElseThrow(RuntimeException::new);
+    private void validateProvider(String provider) {
+        if(provider == null || provider.isBlank()){
+            throw new RestApiException(CustomErrorCode.PROVIDER_INVALID);
+        }
 
-        return oAuthResponseFactory.createOAuthUserInfo(provider, userInfo);
+        String lowerCaseProvider = provider.toLowerCase();
+        if(!OAUTH_PROVIDERS.contains(lowerCaseProvider)){
+            throw new RestApiException(CustomErrorCode.PROVIDER_INVALID);
+        }
     }
 }

--- a/src/main/java/gravit/code/auth/oauth/service/OAuthClientService.java
+++ b/src/main/java/gravit/code/auth/oauth/service/OAuthClientService.java
@@ -41,9 +41,10 @@ public class OAuthClientService {
 
         // 웹에서 특수 문자나 공백 등이 URL 인코딩 된 상태로 전달되는 문제를 해결하기 위함
         String decodedCode = URLDecoder.decode(authCode, StandardCharsets.UTF_8);
+        String lowerCaseProvider = provider.toLowerCase();
 
         // OAuth 설정 정보 가져오기
-        ClientRegistration registration = clientRegistrationRepository.findByRegistrationId(provider.toLowerCase());
+        ClientRegistration registration = clientRegistrationRepository.findByRegistrationId(lowerCaseProvider);
 
         // 토큰 요청
         String accessToken = getAccessToken(registration, decodedCode);
@@ -51,7 +52,7 @@ public class OAuthClientService {
         // 사용자 정보 요청
         Map<String, Object> userInfo = getUserInfo(registration, accessToken);
 
-        return oAuthResponseFactory.createOAuthUserInfo(provider, userInfo);
+        return oAuthResponseFactory.createOAuthUserInfo(lowerCaseProvider, userInfo);
     }
 
     private Map<String, Object> getUserInfo(ClientRegistration registration, String accessToken) {
@@ -126,6 +127,7 @@ public class OAuthClientService {
         }
 
         String lowerCaseProvider = provider.toLowerCase();
+
         if(!OAUTH_PROVIDERS.contains(lowerCaseProvider)){
             throw new RestApiException(CustomErrorCode.PROVIDER_INVALID);
         }

--- a/src/main/java/gravit/code/auth/oauth/service/OAuthClientService.java
+++ b/src/main/java/gravit/code/auth/oauth/service/OAuthClientService.java
@@ -116,7 +116,7 @@ public class OAuthClientService {
 
     private void validateAuthCode(String authCode) {
         if(authCode == null || authCode.isBlank()){
-            throw new RestApiException(CustomErrorCode.PROVIDER_INVALID);
+            throw new RestApiException(CustomErrorCode.AUTH_CODE_INVALID);
         }
     }
 

--- a/src/main/java/gravit/code/auth/oauth/service/OAuthLoginUrlService.java
+++ b/src/main/java/gravit/code/auth/oauth/service/OAuthLoginUrlService.java
@@ -1,10 +1,14 @@
 package gravit.code.auth.oauth.service;
 
+import gravit.code.global.exception.domain.CustomErrorCode;
+import gravit.code.global.exception.domain.RestApiException;
 import lombok.RequiredArgsConstructor;
 import org.springframework.security.oauth2.client.registration.ClientRegistration;
 import org.springframework.security.oauth2.client.registration.ClientRegistrationRepository;
 import org.springframework.stereotype.Service;
 import org.springframework.web.util.UriComponentsBuilder;
+
+import static gravit.code.auth.oauth.OAuthConstants.OAUTH_PROVIDERS;
 
 @RequiredArgsConstructor
 @Service
@@ -13,14 +17,31 @@ public class OAuthLoginUrlService {
     private final ClientRegistrationRepository clientRegistrationRepository;
 
     public String generateLoginUrl(String provider) {
-        ClientRegistration registration = clientRegistrationRepository.findByRegistrationId(provider);
+        validateProvider(provider);
 
+        ClientRegistration registration = clientRegistrationRepository.findByRegistrationId(provider);
+        String authorizationUri = registration.getProviderDetails().getAuthorizationUri();
+        String clientId = registration.getClientId();
+        String responseType = "code";
         String redirectUri = registration.getRedirectUri();
-        return UriComponentsBuilder.fromUriString(registration.getProviderDetails().getAuthorizationUri())
-                .queryParam("client_id", registration.getClientId())
-                .queryParam("response_type", "code")
+        String scope = String.join(" ", registration.getScopes()); // 공백이 표준
+
+        return UriComponentsBuilder.fromUriString(authorizationUri)
+                .queryParam("client_id", clientId)
+                .queryParam("response_type", responseType)
                 .queryParam("redirect_uri", redirectUri)
-                .queryParam("scope",String.join(" ", registration.getScopes()))
+                .queryParam("scope",scope)
                 .build().toUriString();
+    }
+
+    private void validateProvider(String provider) {
+        if(provider == null || provider.isBlank()){
+            throw new RestApiException(CustomErrorCode.PROVIDER_INVALID);
+        }
+
+        String lowerCaseProvider = provider.toLowerCase();
+        if(!OAUTH_PROVIDERS.contains(lowerCaseProvider)){
+            throw new RestApiException(CustomErrorCode.PROVIDER_INVALID);
+        }
     }
 }

--- a/src/main/java/gravit/code/auth/oauth/service/OAuthLoginUrlService.java
+++ b/src/main/java/gravit/code/auth/oauth/service/OAuthLoginUrlService.java
@@ -19,7 +19,7 @@ public class OAuthLoginUrlService {
     public String generateLoginUrl(String provider) {
         validateProvider(provider);
 
-        ClientRegistration registration = clientRegistrationRepository.findByRegistrationId(provider);
+        ClientRegistration registration = clientRegistrationRepository.findByRegistrationId(provider.toLowerCase());
         String authorizationUri = registration.getProviderDetails().getAuthorizationUri();
         String clientId = registration.getClientId();
         String responseType = "code";

--- a/src/main/java/gravit/code/auth/oauth/startegy/OAuthResponseFactory.java
+++ b/src/main/java/gravit/code/auth/oauth/startegy/OAuthResponseFactory.java
@@ -1,6 +1,8 @@
 package gravit.code.auth.oauth.startegy;
 
 import gravit.code.auth.oauth.dto.OAuthUserInfo;
+import gravit.code.global.exception.domain.CustomErrorCode;
+import gravit.code.global.exception.domain.RestApiException;
 import org.springframework.stereotype.Component;
 
 import java.util.List;
@@ -22,7 +24,7 @@ public class OAuthResponseFactory {
     public OAuthUserInfo createOAuthUserInfo(String registrationId, Map<String, Object> attributes){
         OAuthResponseStrategy strategy = strategies.get(registrationId);
         System.out.println(strategy);
-        if(Objects.equals(strategy,null)) throw new IllegalStateException("지원하지 않는 provider 입니다.");
+        if(Objects.equals(strategy,null)) throw new RestApiException(CustomErrorCode.PROVIDER_INVALID);
         return strategy.createOAuthUserInfo(attributes);
     }
 }

--- a/src/main/java/gravit/code/domain/friend/controller/FriendController.java
+++ b/src/main/java/gravit/code/domain/friend/controller/FriendController.java
@@ -1,6 +1,7 @@
 package gravit.code.domain.friend.controller;
 
 import gravit.code.auth.oauth.LoginUser;
+import gravit.code.domain.friend.controller.docs.FriendControllerDocs;
 import gravit.code.domain.friend.dto.response.FollowerResponse;
 import gravit.code.domain.friend.dto.response.FollowingResponse;
 import gravit.code.domain.friend.service.FriendService;
@@ -17,7 +18,7 @@ import java.util.List;
 @RestController
 @RequestMapping("/api/v1/friends")
 @RequiredArgsConstructor
-public class FriendController {
+public class FriendController implements FriendControllerDocs {
 
     private final FriendService friendService;
 

--- a/src/main/java/gravit/code/domain/friend/controller/docs/FriendControllerDocs.java
+++ b/src/main/java/gravit/code/domain/friend/controller/docs/FriendControllerDocs.java
@@ -1,0 +1,61 @@
+package gravit.code.domain.friend.controller.docs;
+
+import gravit.code.auth.oauth.LoginUser;
+import gravit.code.domain.friend.dto.response.FollowerResponse;
+import gravit.code.domain.friend.dto.response.FollowingResponse;
+import gravit.code.domain.friend.dto.response.FriendResponse;
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.Parameter;
+import io.swagger.v3.oas.annotations.media.Content;
+import io.swagger.v3.oas.annotations.media.Schema;
+import io.swagger.v3.oas.annotations.responses.ApiResponse;
+import io.swagger.v3.oas.annotations.responses.ApiResponses;
+import io.swagger.v3.oas.annotations.tags.Tag;
+import org.springframework.http.ResponseEntity;
+import org.springframework.security.core.annotation.AuthenticationPrincipal;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.PathVariable;
+import org.springframework.web.bind.annotation.PostMapping;
+
+import java.util.List;
+
+@Tag(name = "Friend API", description = "팔로우/언팔로우 및 친구 목록 조회 API")
+public interface FriendControllerDocs {
+    // 팔로잉
+    @Operation(summary = "팔로잉", description = "다른 사용자를 팔로잉합니다.")
+    @ApiResponses({
+            @ApiResponse(responseCode = "200", description = "팔로잉 성공")
+    })
+    @PostMapping("/following/{followeeId}")
+    ResponseEntity<FriendResponse> following(
+            @Parameter(description = "팔로잉할 대상 유저 ID") @PathVariable("followeeId") Long followeeId,
+            @AuthenticationPrincipal LoginUser loginUser);
+
+    // 언팔로잉
+    @Operation(summary = "언팔로잉", description = "다른 사용자에 대한 팔로잉를 취소합니다.")
+    @ApiResponses({
+            @ApiResponse(responseCode = "200", description = "언팔로잉 성공")
+    })
+    @PostMapping("/unfollowing/{followeeId}")
+    ResponseEntity<String> unFollowing(
+            @Parameter(description = "언팔로잉할 대상 유저 ID") @PathVariable("followeeId") Long followeeId,
+            @AuthenticationPrincipal LoginUser loginUser);
+
+    // 내 팔로워들 조회
+    @Operation(summary = "팔로워 목록 조회", description = "현재 사용자를 팔로우하고 있는 사용자 목록을 조회합니다.")
+    @ApiResponses({
+            @ApiResponse(responseCode = "200", description = "팔로워 목록 조회 성공")
+    })
+    @GetMapping("/follower")
+    ResponseEntity<List<FollowerResponse>> getFollowers(
+            @AuthenticationPrincipal LoginUser loginUser);
+
+    // 내 팔로잉들 조회
+    @Operation(summary = "팔로잉 목록 조회", description = "현재 사용자가 팔로잉하고 있는 사용자 목록을 조회합니다.")
+    @ApiResponses({
+            @ApiResponse(responseCode = "200", description = "팔로잉 목록 조회 성공")
+    })
+    @GetMapping("/following")
+    ResponseEntity<List<FollowingResponse>> getFollowings(
+            @AuthenticationPrincipal LoginUser loginUser);
+}

--- a/src/main/java/gravit/code/domain/user/controller/UserController.java
+++ b/src/main/java/gravit/code/domain/user/controller/UserController.java
@@ -1,6 +1,7 @@
 package gravit.code.domain.user.controller;
 
 import gravit.code.auth.oauth.LoginUser;
+import gravit.code.domain.user.controller.docs.UserControllerDocs;
 import gravit.code.domain.user.dto.request.OnboardingRequest;
 import gravit.code.domain.user.dto.response.MyPageResponse;
 import gravit.code.domain.user.dto.response.UserResponse;
@@ -13,7 +14,7 @@ import org.springframework.web.bind.annotation.*;
 @RestController
 @RequiredArgsConstructor
 @RequestMapping("/api/v1/users")
-public class UserController {
+public class UserController implements UserControllerDocs {
 
     private final UserService userService;
 

--- a/src/main/java/gravit/code/domain/user/controller/docs/UserControllerDocs.java
+++ b/src/main/java/gravit/code/domain/user/controller/docs/UserControllerDocs.java
@@ -1,0 +1,47 @@
+package gravit.code.domain.user.controller.docs;
+
+import gravit.code.auth.oauth.LoginUser;
+import gravit.code.domain.user.dto.request.OnboardingRequest;
+import gravit.code.domain.user.dto.response.MyPageResponse;
+import gravit.code.domain.user.dto.response.UserResponse;
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.Parameter;
+import io.swagger.v3.oas.annotations.responses.ApiResponse;
+import io.swagger.v3.oas.annotations.responses.ApiResponses;
+import io.swagger.v3.oas.annotations.tags.Tag;
+import org.springframework.http.ResponseEntity;
+import org.springframework.security.core.annotation.AuthenticationPrincipal;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.PatchMapping;
+import org.springframework.web.bind.annotation.RequestBody;
+
+@Tag(name = "User API", description = "유저 관련 API (정보 조회, 온보딩 등)")
+public interface UserControllerDocs {
+    // 유저 정보 조회
+    @Operation(summary = "유저 정보 조회", description = "로그인한 사용자의 정보를 조회합니다.")
+    @ApiResponses({
+            @ApiResponse(responseCode = "200", description = "조회 성공")
+    })
+    @GetMapping
+    ResponseEntity<UserResponse> getUser(
+            @AuthenticationPrincipal LoginUser loginUser);
+
+    // 온보딩 정보 등록
+    @Operation(summary = "온보딩 정보 등록", description = "최초 로그인 시 사용자 온보딩 정보를 저장합니다.")
+    @ApiResponses({
+            @ApiResponse(responseCode = "200", description = "온보딩 완료")
+    })
+    @PatchMapping("/onboarding")
+    ResponseEntity<UserResponse> onboardUser(
+            @AuthenticationPrincipal LoginUser loginUser,
+            @RequestBody OnboardingRequest request);
+
+    // 마이 페이지 조회
+    @Operation(summary = "마이페이지 조회", description = "사용자의 마이페이지 정보를 조회합니다.")
+    @ApiResponses({
+            @ApiResponse(responseCode = "200", description = "조회 성공")
+    })
+    @GetMapping("/my-page")
+    ResponseEntity<MyPageResponse> getMyPage(
+            @AuthenticationPrincipal LoginUser loginUser);
+}

--- a/src/main/java/gravit/code/domain/user/domain/User.java
+++ b/src/main/java/gravit/code/domain/user/domain/User.java
@@ -1,5 +1,7 @@
 package gravit.code.domain.user.domain;
 
+import gravit.code.global.exception.domain.CustomErrorCode;
+import gravit.code.global.exception.domain.RestApiException;
 import jakarta.persistence.*;
 import lombok.AccessLevel;
 import lombok.Builder;
@@ -74,8 +76,26 @@ public class User {
     }
 
     public void onboard(String nickname, int profileImgNumber){
+        validateOnboard(nickname, profileImgNumber);
         this.nickname = nickname;
         this.profileImgNumber = profileImgNumber;
+    }
+
+    private void validateOnboard(String nickname, int profileImgNumber) {
+        validateNickname(nickname);
+        validateProfileNum(profileImgNumber);
+    }
+
+    private void validateProfileNum(int profileImgNumber) {
+        if(profileImgNumber < 1 || profileImgNumber > 20){
+            throw new RestApiException(CustomErrorCode.PROFILE_IMG_NUM_INVALID);
+        }
+    }
+
+    private void validateNickname(String nickname) {
+        if(nickname == null || nickname.isBlank()){
+            throw new RestApiException(CustomErrorCode.NICKNAME_INVALID);
+        }
     }
 
     public void updateXp(Integer xp){

--- a/src/main/java/gravit/code/domain/user/service/UserService.java
+++ b/src/main/java/gravit/code/domain/user/service/UserService.java
@@ -21,20 +21,20 @@ public class UserService {
 
     @Transactional(readOnly = true)
     public UserResponse findById(Long userId) {
-        User user = userRepository.findById(userId).orElseThrow(RuntimeException::new);
+        User user = userRepository.findById(userId).orElseThrow(()-> new RestApiException(CustomErrorCode.USER_NOT_FOUND));
         return UserResponse.from(user);
     }
 
     @Transactional
     public UserResponse onboarding(Long userId, OnboardingRequest request) {
-        User user = userRepository.findById(userId).orElseThrow(RuntimeException::new);
+        User user = userRepository.findById(userId).orElseThrow(()-> new RestApiException(CustomErrorCode.USER_NOT_FOUND));
 
         if(user.isOnboarded()){
-            throw new RuntimeException("이미 추가 정보 입력이 완료된 사용자 입니다.");
+            throw new RestApiException(CustomErrorCode.ALREADY_ONBOARDING);
         }
 
         if(userRepository.existsByNickname(request.nickname())){
-            throw new RuntimeException("이미 사용 중인 닉네임 입니다.");
+            throw new RestApiException(CustomErrorCode.USER_NICKNAME_CONFLICT);
         }
 
         user.onboard(request.nickname(), request.avatarId());
@@ -43,7 +43,7 @@ public class UserService {
     }
 
     public MyPageResponse getMyPage(Long userId) {
-        return userRepository.findMyPageByUserId(userId).orElseThrow(RuntimeException::new);
+        return userRepository.findMyPageByUserId(userId).orElseThrow(()-> new RestApiException(CustomErrorCode.USER_PAGE_NOT_FOUND));
     }
 
     public UserLevelResponse updateUserLevel(Long userId){

--- a/src/main/java/gravit/code/global/exception/domain/CustomErrorCode.java
+++ b/src/main/java/gravit/code/global/exception/domain/CustomErrorCode.java
@@ -9,7 +9,25 @@ import org.springframework.http.HttpStatus;
 public enum CustomErrorCode implements ErrorCode {
 
     // User
-    USER_NOT_FOUND(HttpStatus.NOT_FOUND, "USER_4041", "유저 조회 실패"),
+    USER_NOT_FOUND(HttpStatus.NOT_FOUND, "USER_4041", "존재하지 않은 유저입니다."),
+    USER_NICKNAME_CONFLICT(HttpStatus.CONFLICT, "USER_4091", "이미 존재하는 닉네임 입니다."),
+    USER_PAGE_NOT_FOUND(HttpStatus.NOT_FOUND,"USER_PAGE_4041", "유저 페이지가 존재하지 않습니다."),
+    ALREADY_ONBOARDING(HttpStatus.BAD_REQUEST,"USER_4001","이미 온보딩이 완료된 유저입니다."),
+    NICKNAME_INVALID(HttpStatus.BAD_REQUEST,"USER_4002", "유효하지 않은 닉네임 형식입니다."),
+    PROFILE_IMG_NUM_INVALID(HttpStatus.BAD_REQUEST,"USER_4003","유효하지 않은 프로필 이미지 번호입니다."),
+
+    // Auth
+    PROVIDER_INVALID(HttpStatus.BAD_REQUEST, "AUTH_4001","유효하지 않은 OAuth 제공자 이름입니다."),
+    AUTH_CODE_INVALID(HttpStatus.BAD_REQUEST,"AUTH_4002", "유효하지 않은 AuthCode 입니다."),
+    OAUTH_SERVER_ERROR(HttpStatus.BAD_GATEWAY,"AUTH_502","OAuth 인증 서버와의 통신에 실패하였습니다."),
+    OAUTH_ACCESS_TOKEN_INVALID(HttpStatus.BAD_REQUEST,"AUTH4003","유효하지 않은 OAuth AccessToken"),
+
+    // JWT
+    TOKEN_INVALID(HttpStatus.UNAUTHORIZED, "JWT_4011", "유효하지 않은 토큰입니다."),
+    TOKEN_EXPIRED(HttpStatus.UNAUTHORIZED," ","만료된 토큰입니다."),
+    TOKEN_EMPTY(HttpStatus.UNAUTHORIZED,"", "빈 토큰입니다."),
+    TOKEN_NOT_SIGNED(HttpStatus.UNAUTHORIZED," ","서명되지 않은 토큰입니다."),
+    TOKEN_NOT_FOUND(HttpStatus.UNAUTHORIZED, "", "토큰을 찾을 수 없습니다."),
 
     // ChapterProgress
     CHAPTER_PROGRESS_NOT_FOUND(HttpStatus.NOT_FOUND, "CHAPTER_P_4041", "챕터 진행 결과 조회 실패"),


### PR DESCRIPTION
## 📋 이슈 번호
- close #25 

## 🛠 구현 사항
1. Friend, User, OAuth, Jwt 각 도메인에서 예외를 RuntimeException, IllegalStateException 등으로 처리하였었습니다.
모든 예외를 RestApiException 으로 던지도록 수정하였습니다.
 + 각 예외에 맞는 CustomErrorCode 추가하였습니다.
2. UserService, jwtProvider ,OAuthService, OAuthLoginService 등 부족한 예외처리를 추가 하였습니다.

## 🤔 추가 고려 사항