### PR TITLE
hotfix: league 조회 기능 추가 및 사용하지 않는 필드 정리

### DIFF
--- a/src/main/java/gravit/code/domain/league/controller/LeagueController.java
+++ b/src/main/java/gravit/code/domain/league/controller/LeagueController.java
@@ -1,0 +1,26 @@
+package gravit.code.domain.league.controller;
+
+
+import gravit.code.domain.league.controller.docs.LeagueControllerSpecification;
+import gravit.code.domain.league.dto.response.LeagueResponse;
+import gravit.code.domain.league.service.LeagueService;
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.PathVariable;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+@RestController
+@RequestMapping("/api/v1/league")
+@RequiredArgsConstructor
+public class LeagueController implements LeagueControllerSpecification {
+
+    private final LeagueService leagueService;
+
+    @GetMapping("/{leagueId}")
+    public ResponseEntity<LeagueResponse> getLeague(@PathVariable("leagueId") Long leagueId) {
+        return ResponseEntity.ok(leagueService.getLeague(leagueId));
+    }
+
+}

--- a/src/main/java/gravit/code/domain/league/controller/docs/LeagueControllerSpecification.java
+++ b/src/main/java/gravit/code/domain/league/controller/docs/LeagueControllerSpecification.java
@@ -1,0 +1,24 @@
+package gravit.code.domain.league.controller.docs;
+
+import gravit.code.domain.league.dto.response.LeagueResponse;
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.responses.ApiResponse;
+import io.swagger.v3.oas.annotations.responses.ApiResponses;
+import io.swagger.v3.oas.annotations.tags.Tag;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.PathVariable;
+
+@Tag(name = "League API", description = "리그 관련 API")
+public interface LeagueControllerSpecification {
+
+    @Operation(
+            summary = "리그 단건 조회",
+            description = "리그 ID로 리그 정보를 조회합니다"
+    )
+    @ApiResponses({
+            @ApiResponse(responseCode = "200", description = "✅ 리그 조회 성공"),
+    })
+    @GetMapping("/{leagueId}")
+    ResponseEntity<LeagueResponse> getLeague(@PathVariable("leagueId") Long leagueId);
+}

--- a/src/main/java/gravit/code/domain/league/domain/League.java
+++ b/src/main/java/gravit/code/domain/league/domain/League.java
@@ -24,27 +24,22 @@ public class League {
     @Column(name = "min_lp", columnDefinition = "integer", nullable = false)
     private Integer minLp;
 
-    @Column(name = "league_img_url", columnDefinition = "varchar(150)", nullable = false)
-    private String leagueImgUrl;
-
     @Column(name = "sort_order", nullable = false, unique = true)
     private Integer sortOrder;
 
     @Builder
-    private League(String name, Integer maxLp, Integer minLp, String leagueImgUrl, int sortOrder) {
+    private League(String name, Integer maxLp, Integer minLp, int sortOrder) {
         this.name = name;
         this.maxLp = maxLp;
         this.minLp = minLp;
-        this.leagueImgUrl = leagueImgUrl;
         this.sortOrder = sortOrder;
     }
 
-    public static League create(String name, Integer maxLp, Integer minLp, String leagueImgUrl, int sortOrder) {
+    public static League create(String name, Integer maxLp, Integer minLp, int sortOrder) {
         return League.builder()
                 .name(name)
                 .maxLp(maxLp)
                 .minLp(minLp)
-                .leagueImgUrl(leagueImgUrl)
                 .sortOrder(sortOrder)
                 .build();
     }

--- a/src/main/java/gravit/code/domain/league/dto/response/LeagueResponse.java
+++ b/src/main/java/gravit/code/domain/league/dto/response/LeagueResponse.java
@@ -1,0 +1,17 @@
+package gravit.code.domain.league.dto.response;
+
+import gravit.code.domain.league.domain.League;
+import lombok.Builder;
+
+@Builder
+public record LeagueResponse(
+        Long leagueId,
+        String name
+) {
+    public static LeagueResponse from(League league) {
+        return LeagueResponse.builder()
+                .leagueId(league.getId())
+                .name(league.getName())
+                .build();
+    }
+}

--- a/src/main/java/gravit/code/domain/league/service/LeagueService.java
+++ b/src/main/java/gravit/code/domain/league/service/LeagueService.java
@@ -1,0 +1,23 @@
+package gravit.code.domain.league.service;
+
+import gravit.code.domain.league.domain.League;
+import gravit.code.domain.league.dto.response.LeagueResponse;
+import gravit.code.domain.league.infrastructure.LeagueRepository;
+import gravit.code.global.exception.domain.CustomErrorCode;
+import gravit.code.global.exception.domain.RestApiException;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.stereotype.Service;
+
+@Service
+@RequiredArgsConstructor
+@Slf4j
+public class LeagueService {
+
+    private final LeagueRepository leagueRepository;
+
+    public LeagueResponse getLeague(Long leagueId) {
+        League league = leagueRepository.findById(leagueId).orElseThrow(() -> new RestApiException(CustomErrorCode.LEAGUE_NOT_FOUND));
+        return LeagueResponse.from(league);
+    }
+}

--- a/src/main/resources/sql/005_gravit-leagues.sql
+++ b/src/main/resources/sql/005_gravit-leagues.sql
@@ -1,20 +1,20 @@
-INSERT INTO league (id, name, min_lp, max_lp, sort_order, league_img_url)
-VALUES (1, 'Bronze 1', 0, 100, 1, 'http://localhost:1234/dlfjgrp'),
-       (2, 'Bronze 2', 101, 200, 2, 'http://localhost:1234/dlfjgrp'),
-       (3, 'Bronze 3', 201, 320, 3, 'http://localhost:1234/dlfjgrp'),
+INSERT INTO league (id, name, min_lp, max_lp, sort_order)
+VALUES (1, 'Bronze 1', 0, 100, 1),
+       (2, 'Bronze 2', 101, 200, 2),
+       (3, 'Bronze 3', 201, 320, 3),
 
-       (4, 'Silver 1', 321, 460, 4, 'http://localhost:1234/dlfjgrp'),
-       (5, 'Silver 2', 461, 620, 5, 'http://localhost:1234/dlfjgrp'),
-       (6, 'Silver 3', 621, 800, 6, 'http://localhost:1234/dlfjgrp'),
+       (4, 'Silver 1', 321, 460, 4),
+       (5, 'Silver 2', 461, 620, 5),
+       (6, 'Silver 3', 621, 800, 6),
 
-       (7, 'Gold 1', 801, 1000, 7, 'http://localhost:1234/dlfjgrp'),
-       (8, 'Gold 2', 1001, 1220, 8, 'http://localhost:1234/dlfjgrp'),
-       (9, 'Gold 3', 1221, 1460, 9, 'http://localhost:1234/dlfjgrp'),
+       (7, 'Gold 1', 801, 1000, 7),
+       (8, 'Gold 2', 1001, 1220, 8),
+       (9, 'Gold 3', 1221, 1460, 9),
 
-       (10, 'Platinum 1', 1461, 1720, 10, 'http://localhost:1234/dlfjgrp'),
-       (11, 'Platinum 2', 1721, 2000, 11, 'http://localhost:1234/dlfjgrp'),
-       (12, 'Platinum 3', 2001, 2300, 12, 'http://localhost:1234/dlfjgrp'),
+       (10, 'Platinum 1', 1461, 1720, 10),
+       (11, 'Platinum 2', 1721, 2000, 11),
+       (12, 'Platinum 3', 2001, 2300, 12),
 
-       (13, 'Diamond 1', 2301, 2620, 13, 'http://localhost:1234/dlfjgrp'),
-       (14, 'Diamond 2', 2621, 2960, 14, 'http://localhost:1234/dlfjgrp'),
-       (15, 'Diamond 3', 2961, 9999, 15, 'http://localhost:1234/dlfjgrp');
+       (13, 'Diamond 1', 2301, 2620, 13),
+       (14, 'Diamond 2', 2621, 2960, 14),
+       (15, 'Diamond 3', 2961, 9999, 15);

--- a/src/test/java/gravit/code/domain/league/domain/LeagueTest.java
+++ b/src/test/java/gravit/code/domain/league/domain/LeagueTest.java
@@ -16,14 +16,12 @@ class LeagueTest {
         String name = "브론즈";
         Integer maxXp = 0;
         Integer minYp = 0;
-        String leagueImgUrl = "https://example.com/league1.jpg";
 
         // when
-        League league = League.create(name, maxXp, minYp, leagueImgUrl, 1);
+        League league = League.create(name, maxXp, minYp, 1);
 
         // then
         assertThat(league.getName()).isEqualTo(name);
-        assertThat(league.getLeagueImgUrl()).isEqualTo(leagueImgUrl);
     }
 
 }

--- a/src/test/java/gravit/code/domain/season/batch/SeasonBatchServiceTest.java
+++ b/src/test/java/gravit/code/domain/season/batch/SeasonBatchServiceTest.java
@@ -56,7 +56,7 @@ class SeasonBatchServiceTest {
         when(seasonRepository.findPrepByStartingAt(newNextSeason.getStartsAt())).thenReturn(Optional.empty());
         when(seasonRepository.save(any(Season.class))).thenReturn(newNextSeason);
 
-        League firstLeague = League.create("BRONZE 1", 100,0,"http//:localhost.com", 1);
+        League firstLeague = League.create("BRONZE 1", 100,0, 1);
         when(leagueRepository.findFirstByOrderBySortOrderAsc()).thenReturn(Optional.of(firstLeague));
         when(userLeagueRepository.resetAllForNextSeason(nowSeason,newNextSeason,firstLeague)).thenReturn(12);
 
@@ -89,7 +89,7 @@ class SeasonBatchServiceTest {
         /** PREP 인 다음 시즌이 존재함 **/
         when(seasonRepository.findPrepByStartingAt(nextSeason.getStartsAt())).thenReturn(Optional.of(nextSeason));
 
-        League firstLeague = League.create("BRONZE 1", 100,0,"http//:localhost.com", 1);
+        League firstLeague = League.create("BRONZE 1", 100,0, 1);
         when(leagueRepository.findFirstByOrderBySortOrderAsc()).thenReturn(Optional.of(firstLeague));
         when(userLeagueRepository.resetAllForNextSeason(nowSeason, nextSeason, firstLeague)).thenReturn(12);
 

--- a/src/test/resources/sql/lesson_completed_listener_test.sql
+++ b/src/test/resources/sql/lesson_completed_listener_test.sql
@@ -1,8 +1,8 @@
 -- 브론즈 1, 2 리그 생성
-INSERT INTO league (id, name, min_lp, max_lp, sort_order, league_img_url)
-VALUES (1, 'Bronze 1', 0, 100, 1, 'http://localhost:1234/dlfjgrp');
-INSERT INTO league (id, name, min_lp, max_lp, sort_order, league_img_url)
-VALUES (2, 'Bronze 2', 101, 200, 2, 'http://localhost:1234/dlfjgrp');
+INSERT INTO league (id, name, min_lp, max_lp, sort_order)
+VALUES (1, 'Bronze 1', 0, 100, 1);
+INSERT INTO league (id, name, min_lp, max_lp, sort_order)
+VALUES (2, 'Bronze 2', 101, 200, 2);
 
 -- 시즌 생성
 INSERT INTO season (id,season_key, starts_at, ends_at, status, tz)

--- a/src/test/resources/sql/onboard_league_data.sql
+++ b/src/test/resources/sql/onboard_league_data.sql
@@ -1,5 +1,5 @@
-INSERT INTO league (id, name, min_lp, max_lp, sort_order, league_img_url)
-VALUES (1, 'Bronze 1', 0, 100, 1, 'http://localhost:1234/dlfjgrp');
+INSERT INTO league (id, name, min_lp, max_lp, sort_order)
+VALUES (1, 'Bronze 1', 0, 100, 1);
 
 INSERT INTO season (id,season_key, starts_at, ends_at, status, tz)
 VALUES (1,'2025-W32', '2025-08-04 00:00:00', '2025-08-11 00:00:00', 'ACTIVE', 'Asia/Seoul');

--- a/src/test/resources/sql/user_league_rank_data.sql
+++ b/src/test/resources/sql/user_league_rank_data.sql
@@ -1,10 +1,10 @@
 -- 리그 데이터 (최소 1개)
 -- 브론즈 1 리그
-INSERT INTO league (id, name, min_lp, max_lp, sort_order, league_img_url)
-VALUES (1, 'Bronze 1', 0, 100, 1, 'http://localhost:1234/dlfjgrp');
+INSERT INTO league (id, name, min_lp, max_lp, sort_order)
+VALUES (1, 'Bronze 1', 0, 100, 1);
 -- 실버 1 리그
-INSERT INTO league (id, name, min_lp, max_lp, sort_order, league_img_url)
-VALUES (4, 'Silver 1', 321, 460, 4, 'http://localhost:1234/silver1');
+INSERT INTO league (id, name, min_lp, max_lp, sort_order)
+VALUES (4, 'Silver 1', 321, 460, 4);
 
 -- 시즌 생성
 INSERT INTO season (id,season_key, starts_at, ends_at, status, tz)


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- New Features
  - Added REST endpoint to fetch a single league by ID (/api/v1/league/{leagueId}).
- Refactor
  - Removed league image URL from league data; responses now include only leagueId and name.
  - Updated seed data to match the new league schema.
- Documentation
  - Added API documentation for the league endpoint.
- Tests
  - Updated tests and SQL fixtures to reflect removal of the image URL field.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->