### PR TITLE
feat: nickname, handle 조회 동적으로 결정 로직 추가

### DIFF
--- a/src/main/java/gravit/code/domain/friend/controller/FriendSearchController.java
+++ b/src/main/java/gravit/code/domain/friend/controller/FriendSearchController.java
@@ -23,9 +23,9 @@ public class FriendSearchController implements FriendSearchControllerDocs {
 
     @GetMapping
     public ResponseEntity<PageSearchUserResponse> search(@AuthenticationPrincipal LoginUser loginUser,
-                                                         @RequestParam String handleQuery,
+                                                         @RequestParam String queryText,
                                                          @RequestParam(defaultValue = "0") int page){
-        PageSearchUserResponse pageSearchUserResponse = friendSearchService.searchUsersForFollowing(loginUser.getId(), handleQuery, page);
+        PageSearchUserResponse pageSearchUserResponse = friendSearchService.searchUsersForFollowing(loginUser.getId(), queryText, page);
         return ResponseEntity.ok(pageSearchUserResponse);
     }
 

--- a/src/main/java/gravit/code/domain/friend/dto/SearchPlan.java
+++ b/src/main/java/gravit/code/domain/friend/dto/SearchPlan.java
@@ -1,0 +1,18 @@
+package gravit.code.domain.friend.dto;
+
+public record SearchPlan(
+        String selectSql,
+        String countSql,
+        String cleanText,
+        boolean isQueryNeedContains,
+        boolean isEmpty
+) {
+
+    public static SearchPlan of(String selectSql, String countSql, String cleanText, boolean isQueryNeedContains) {
+        return new SearchPlan(selectSql, countSql, cleanText, isQueryNeedContains, false);
+    }
+
+    public static SearchPlan empty(){
+        return new SearchPlan(null,null,"",false,true);
+    }
+}

--- a/src/main/java/gravit/code/domain/friend/dto/SearchUser.java
+++ b/src/main/java/gravit/code/domain/friend/dto/SearchUser.java
@@ -1,4 +1,4 @@
-package gravit.code.domain.friend.dto.response;
+package gravit.code.domain.friend.dto;
 
 public record SearchUser(
         Long userId,

--- a/src/main/java/gravit/code/domain/friend/dto/response/PageSearchUserResponse.java
+++ b/src/main/java/gravit/code/domain/friend/dto/response/PageSearchUserResponse.java
@@ -1,5 +1,6 @@
 package gravit.code.domain.friend.dto.response;
 
+import gravit.code.domain.friend.dto.SearchUser;
 import lombok.Builder;
 import lombok.extern.slf4j.Slf4j;
 

--- a/src/main/java/gravit/code/domain/friend/infrastructure/sql/FriendsHandleCountQuerySql.java
+++ b/src/main/java/gravit/code/domain/friend/infrastructure/sql/FriendsHandleCountQuerySql.java
@@ -1,13 +1,17 @@
 package gravit.code.domain.friend.infrastructure.sql;
 
-public final class FriendsCountQuerySql {
-    private FriendsCountQuerySql() {
-    }
+import lombok.experimental.UtilityClass;
+
+@UtilityClass
+public class FriendsHandleCountQuerySql {
 
     // --- COUNT: contains 포함 버전 ---
-    public static final String COUNT_WITH_CONTAINS = """
+    public static final String COUNT_WITH_CONTAINS_BY_HANDLE = """
             WITH p AS (
-              SELECT :me::bigint AS me, :q::text AS q
+              SELECT :me::bigint AS me,
+              :q::text AS q,
+              :q_prefix::text AS q_prefix,
+              :q_contains::text AS q_contains
             ),
             exact_cnt AS (
               SELECT count(*) c FROM users u, p
@@ -16,24 +20,25 @@ public final class FriendsCountQuerySql {
             prefix_cnt AS (
               SELECT count(*) c FROM users u, p
               WHERE u.id <> p.me
-                AND u.handle >= p.q
-                AND u.handle <  p.q || '{'
+                AND u.handle LIKE :q_prefix
                 AND u.handle <> p.q
             ),
             contains_cnt AS (
               SELECT count(*) c FROM users u, p
               WHERE u.id <> p.me
-                AND u.handle LIKE :q_contains
+                AND u.handle LIKE p.q_contains
                 AND u.handle <> p.q
-                AND u.handle NOT LIKE p.q || '%%'
+                AND handle NOT LIKE p.q_prefix
             )
             SELECT (SELECT c FROM exact_cnt) + (SELECT c FROM prefix_cnt) + (SELECT c FROM contains_cnt)
             """;
 
     // --- COUNT: contains 없는 버전 ---
-    public static final String COUNT_NO_CONTAINS = """
+    public static final String COUNT_NO_CONTAINS_BY_HANDLE = """
             WITH p AS (
-              SELECT :me::bigint AS me, :q::text AS q
+              SELECT :me::bigint AS me,
+              :q::text AS q,
+              :q_prefix::text AS q_prefix
             ),
             exact_cnt AS (
               SELECT count(*) c FROM users u, p
@@ -42,8 +47,7 @@ public final class FriendsCountQuerySql {
             prefix_cnt AS (
               SELECT count(*) c FROM users u, p
               WHERE u.id <> p.me
-                AND u.handle >= p.q
-                AND u.handle <  p.q || '{'
+                AND u.handle LIKE p.q_prefix
                 AND u.handle <> p.q
             )
             SELECT (SELECT c FROM exact_cnt) + (SELECT c FROM prefix_cnt)

--- a/src/main/java/gravit/code/domain/friend/infrastructure/sql/FriendsHandleSearchQuerySql.java
+++ b/src/main/java/gravit/code/domain/friend/infrastructure/sql/FriendsHandleSearchQuerySql.java
@@ -1,13 +1,19 @@
 package gravit.code.domain.friend.infrastructure.sql;
 
-public final class FriendsSearchQuerySql {
-    private FriendsSearchQuerySql() {
-    }
+import lombok.experimental.UtilityClass;
+
+@UtilityClass
+public class FriendsHandleSearchQuerySql {
 
     // --- Search: contains 포함 버전 ---
-    public static final String SELECT_WITH_CONTAINS = """
+    public static final String SELECT_USER_WITH_CONTAINS_BY_HANDLE = """
             WITH p AS (
-              SELECT :me::bigint AS me, :q::text AS q, :limit::int AS lim, :offset::int AS off
+              SELECT :me::bigint AS me,
+              :q::text AS q,
+              :q_prefix::text AS q_prefix,
+              :q_contains::text AS q_contains,
+              :limit::int AS lim,
+              :offset::int AS off
             ),
             exact AS MATERIALIZED (
               SELECT u.* FROM p
@@ -25,8 +31,7 @@ public final class FriendsSearchQuerySql {
                 SELECT id, profile_img_number, nickname, handle
                 FROM users
                 WHERE id <> p.me
-                  AND handle >= p.q
-                  AND handle <  p.q || '{'
+                  AND handle LIKE p.q_prefix
                   AND handle <> p.q
                 ORDER BY handle, id
                 LIMIT p.lim + p.off
@@ -44,7 +49,6 @@ public final class FriendsSearchQuerySql {
             need_contains AS (
               SELECT GREATEST(0, (SELECT lim+off FROM p) - (SELECT c FROM cnt_exact) - (SELECT c FROM cnt_prefix)) AS need
             ),
-            -- '%q%' 포함: id만 먼저 뽑고 → PK 조인
             contains_ids AS MATERIALIZED (
               SELECT u.id
               FROM p
@@ -52,9 +56,9 @@ public final class FriendsSearchQuerySql {
                 SELECT id
                 FROM users
                 WHERE id <> p.me
-                  AND handle LIKE :q_contains
+                  AND handle LIKE p.q_contains
                   AND handle <> p.q
-                  AND handle NOT LIKE p.q || '%%'
+                  AND handle NOT LIKE p.q_prefix
                 LIMIT GREATEST(1, (SELECT need FROM need_contains)) * 3
               ) u
             ),
@@ -86,9 +90,13 @@ public final class FriendsSearchQuerySql {
             """;
 
     // --- Search: contains 없는 버전 ---
-    public static final String SELECT_NO_CONTAINS = """
+    public static final String SELECT_USER_NO_CONTAINS_BY_HANDLE = """
             WITH p AS (
-              SELECT :me::bigint AS me, :q::text AS q, :limit::int AS lim, :offset::int AS off
+              SELECT :me::bigint AS me,
+              :q::text AS q,
+              :q_prefix::text AS q_prefix,
+              :limit::int AS lim,
+              :offset::int AS off
             ),
             exact AS MATERIALIZED (
               SELECT u.* FROM p
@@ -106,8 +114,7 @@ public final class FriendsSearchQuerySql {
                 SELECT id, profile_img_number, nickname, handle
                 FROM users
                 WHERE id <> p.me
-                  AND handle >= p.q
-                  AND handle <  p.q || '{'
+                  AND handle LIKE p.q_prefix
                   AND handle <> p.q
                 ORDER BY handle, id
                 LIMIT p.lim + p.off

--- a/src/main/java/gravit/code/domain/friend/infrastructure/sql/FriendsNicknameCountQuerySql.java
+++ b/src/main/java/gravit/code/domain/friend/infrastructure/sql/FriendsNicknameCountQuerySql.java
@@ -1,0 +1,58 @@
+package gravit.code.domain.friend.infrastructure.sql;
+
+import lombok.experimental.UtilityClass;
+
+@UtilityClass
+public  class FriendsNicknameCountQuerySql {
+
+    // --- COUNT: contains 포함 버전 ---
+    public static final String COUNT_WITH_CONTAINS_BY_NICKNAME = """
+        WITH p AS (
+          SELECT :me::bigint AS me,
+                 :q::text AS q,
+                 :q_prefix::text AS q_prefix,
+                 :q_contains::text AS q_contains
+        ),
+        exact_cnt AS (
+          SELECT count(*) c FROM users u, p
+          WHERE u.id <> p.me
+            AND lower(u.nickname) = p.q
+        ),
+        prefix_cnt AS (
+          SELECT count(*) c FROM users u, p
+          WHERE u.id <> p.me
+            AND lower(u.nickname) LIKE p.q_prefix
+            AND lower(u.nickname) <> p.q
+        ),
+        contains_cnt AS (
+          SELECT count(*) c FROM users u, p
+          WHERE u.id <> p.me
+            AND u.nickname ILIKE p.q_contains
+            AND lower(u.nickname) <> p.q
+            AND lower(u.nickname) NOT LIKE p.q_prefix
+        )
+        SELECT (SELECT c FROM exact_cnt) + (SELECT c FROM prefix_cnt) + (SELECT c FROM contains_cnt)
+        """;
+
+    // --- COUNT: contains 없는 버전 ---
+    public static final String COUNT_NO_CONTAINS_BY_NICKNAME = """
+        WITH p AS (
+          SELECT :me::bigint AS me,
+                 :q::text AS q,
+                 :q_prefix::text AS q_prefix
+        ),
+        exact_cnt AS (
+          SELECT count(*) c FROM users u, p
+          WHERE u.id <> p.me
+            AND lower(u.nickname) = p.q
+        ),
+        prefix_cnt AS (
+          SELECT count(*) c FROM users u, p
+          WHERE u.id <> p.me
+            AND lower(u.nickname) LIKE p.q_prefix
+            AND lower(u.nickname) <> p.q
+        )
+        SELECT (SELECT c FROM exact_cnt) + (SELECT c FROM prefix_cnt)
+        """;
+
+}

--- a/src/main/java/gravit/code/domain/friend/infrastructure/sql/FriendsNicknameSearchQuerySql.java
+++ b/src/main/java/gravit/code/domain/friend/infrastructure/sql/FriendsNicknameSearchQuerySql.java
@@ -1,0 +1,152 @@
+package gravit.code.domain.friend.infrastructure.sql;
+
+import lombok.experimental.UtilityClass;
+
+@UtilityClass
+public class FriendsNicknameSearchQuerySql {
+
+    // --- Search: contains 포함 (exact/prefix: lower()+LIKE, contains: ILIKE) ---
+    public static final String SELECT_USER_WITH_CONTAINS_BY_NICKNAME = """
+        WITH p AS (
+          SELECT :me::bigint AS me,
+                 :q::text AS q,
+                 :q_prefix::text AS q_prefix,
+                 :q_contains::text AS q_contains,
+                 :limit::int AS lim,
+                 :offset::int AS off
+        ),
+        exact AS MATERIALIZED (
+          SELECT u.* FROM p
+          CROSS JOIN LATERAL (
+            SELECT id, profile_img_number, nickname, handle
+            FROM users
+            WHERE id <> p.me
+              AND lower(nickname) = p.q
+            ORDER BY nickname, id
+            LIMIT p.lim + p.off
+          ) u
+        ),
+        prefix_all AS MATERIALIZED (
+          SELECT u.* FROM p
+          CROSS JOIN LATERAL (
+            SELECT id, profile_img_number, nickname, handle
+            FROM users
+            WHERE id <> p.me
+              AND lower(nickname) LIKE p.q_prefix
+              AND lower(nickname) <> p.q
+            ORDER BY nickname, id
+            LIMIT p.lim + p.off
+          ) u
+        ),
+        cnt_exact AS (SELECT count(*) c FROM exact),
+        need_prefix AS (
+          SELECT GREATEST(0, (SELECT lim+off FROM p) - (SELECT c FROM cnt_exact)) AS need
+        ),
+        prefix AS MATERIALIZED (
+          SELECT * FROM prefix_all
+          LIMIT (SELECT need FROM need_prefix)
+        ),
+        cnt_prefix AS (SELECT count(*) c FROM prefix),
+        need_contains AS (
+          SELECT GREATEST(0, (SELECT lim+off FROM p) - (SELECT c FROM cnt_exact) - (SELECT c FROM cnt_prefix)) AS need
+        ),
+        contains_ids AS MATERIALIZED (
+          SELECT u.id
+          FROM p
+          CROSS JOIN LATERAL (
+            SELECT id
+            FROM users
+            WHERE id <> p.me
+              AND nickname ILIKE p.q_contains
+              AND lower(nickname) <> p.q
+              AND lower(nickname) NOT LIKE p.q_prefix
+            LIMIT GREATEST(1, (SELECT need FROM need_contains)) * 3
+          ) u
+        ),
+        contains AS MATERIALIZED (
+          SELECT u.id, u.profile_img_number, u.nickname, u.handle
+          FROM users u
+          JOIN contains_ids c ON c.id = u.id
+        ),
+        unioned AS (
+          SELECT id, profile_img_number, nickname, handle, 3 AS w FROM exact
+          UNION ALL
+          SELECT id, profile_img_number, nickname, handle, 2 AS w FROM prefix
+          UNION ALL
+          SELECT id, profile_img_number, nickname, handle, 1 AS w FROM contains
+        )
+        SELECT
+          s.id AS user_id,
+          s.profile_img_number,
+          s.nickname,
+          concat('@', s.handle) AS handle,
+          (f.followee_id IS NOT NULL) AS is_following,
+          s.w
+        FROM unioned s
+        LEFT JOIN friends f
+          ON f.follower_id = (SELECT me FROM p)
+         AND f.followee_id = s.id
+        ORDER BY s.w DESC, s.nickname ASC, s.id ASC
+        LIMIT (SELECT lim FROM p) OFFSET (SELECT off FROM p)
+        """;
+
+    // --- Search: contains 없는 버전 (exact/prefix만) ---
+    public static final String SELECT_USER_NO_CONTAINS_BY_NICKNAME = """
+        WITH p AS (
+          SELECT :me::bigint AS me,
+                 :q::text AS q,
+                 :q_prefix::text AS q_prefix,
+                 :limit::int AS lim,
+                 :offset::int AS off
+        ),
+        exact AS MATERIALIZED (
+          SELECT u.* FROM p
+          CROSS JOIN LATERAL (
+            SELECT id, profile_img_number, nickname, handle
+            FROM users
+            WHERE id <> p.me
+              AND lower(nickname) = p.q
+            ORDER BY nickname, id
+            LIMIT p.lim + p.off
+          ) u
+        ),
+        prefix_all AS MATERIALIZED (
+          SELECT u.* FROM p
+          CROSS JOIN LATERAL (
+            SELECT id, profile_img_number, nickname, handle
+            FROM users
+            WHERE id <> p.me
+              AND lower(nickname) LIKE p.q_prefix
+              AND lower(nickname) <> p.q
+            ORDER BY nickname, id
+            LIMIT p.lim + p.off
+          ) u
+        ),
+        cnt_exact AS (SELECT count(*) c FROM exact),
+        need_prefix AS (
+          SELECT GREATEST(0, (SELECT lim+off FROM p) - (SELECT c FROM cnt_exact)) AS need
+        ),
+        prefix AS MATERIALIZED (
+          SELECT * FROM prefix_all
+          LIMIT (SELECT need FROM need_prefix)
+        ),
+        unioned AS (
+          SELECT id, profile_img_number, nickname, handle, 3 AS w FROM exact
+          UNION ALL
+          SELECT id, profile_img_number, nickname, handle, 2 AS w FROM prefix
+        )
+        SELECT
+          s.id AS user_id,
+          s.profile_img_number,
+          s.nickname,
+          concat('@', s.handle) AS handle,
+          (f.followee_id IS NOT NULL) AS is_following,
+          s.w
+        FROM unioned s
+        LEFT JOIN friends f
+          ON f.follower_id = (SELECT me FROM p)
+         AND f.followee_id = s.id
+        ORDER BY s.w DESC, s.nickname ASC, s.id ASC
+        LIMIT (SELECT lim FROM p) OFFSET (SELECT off FROM p)
+        """;
+}

--- a/src/main/java/gravit/code/domain/friend/infrastructure/strategy/FriendsSearchFactory.java
+++ b/src/main/java/gravit/code/domain/friend/infrastructure/strategy/FriendsSearchFactory.java
@@ -1,0 +1,26 @@
+package gravit.code.domain.friend.infrastructure.strategy;
+
+import gravit.code.domain.friend.dto.SearchPlan;
+import gravit.code.global.exception.domain.CustomErrorCode;
+import gravit.code.global.exception.domain.RestApiException;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Component;
+
+import java.util.List;
+
+@Component
+@RequiredArgsConstructor
+public class FriendsSearchFactory {
+    private final List<FriendsSearchStrategy> strategies;
+
+    public FriendsSearchStrategy resolve(String queryText) {
+        return strategies.stream()
+                .filter(s -> s.supports(queryText))
+                .findFirst()
+                .orElseThrow(() -> new RestApiException(CustomErrorCode.FRIEND_QUERY_STRATEGY_TYPE_INVALID));
+    }
+
+    public SearchPlan buildPlan(long requesterId, String raw, int page, int size) {
+        return resolve(raw).buildPlan(requesterId, raw, page, size);
+    }
+}

--- a/src/main/java/gravit/code/domain/friend/infrastructure/strategy/FriendsSearchStrategy.java
+++ b/src/main/java/gravit/code/domain/friend/infrastructure/strategy/FriendsSearchStrategy.java
@@ -1,0 +1,10 @@
+package gravit.code.domain.friend.infrastructure.strategy;
+
+import gravit.code.domain.friend.dto.SearchPlan;
+
+public interface FriendsSearchStrategy {
+
+    boolean supports(String queryText);
+
+    SearchPlan buildPlan(long requesterId, String queryText, int page, int size);
+}

--- a/src/main/java/gravit/code/domain/friend/infrastructure/strategy/HandleSearchStrategy.java
+++ b/src/main/java/gravit/code/domain/friend/infrastructure/strategy/HandleSearchStrategy.java
@@ -1,0 +1,42 @@
+package gravit.code.domain.friend.infrastructure.strategy;
+
+import gravit.code.domain.friend.dto.SearchPlan;
+import gravit.code.domain.friend.infrastructure.sql.FriendsHandleCountQuerySql;
+import gravit.code.domain.friend.infrastructure.sql.FriendsHandleSearchQuerySql;
+import gravit.code.domain.friend.util.QueryNormalizeUtil;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Component;
+
+@Component
+@RequiredArgsConstructor
+public class HandleSearchStrategy implements FriendsSearchStrategy {
+
+    private static final int MIN_CONTAINS_LEN = 3;
+    private static final int INVALID_TEXT_SIZE = 1;
+
+    @Override
+    public boolean supports(String queryText) {
+        return queryText != null && queryText.startsWith("@");
+    }
+
+    @Override
+    public SearchPlan buildPlan(long requesterId, String queryText, int page, int size) {
+        String cleanText = QueryNormalizeUtil.handleNormalize(queryText);
+
+        if(cleanText.length() <= INVALID_TEXT_SIZE){
+            return SearchPlan.empty();
+        }
+
+        boolean isQueryNeedContains = cleanText.length() >= MIN_CONTAINS_LEN;
+
+        final String selectSql = isQueryNeedContains
+                ? FriendsHandleSearchQuerySql.SELECT_USER_WITH_CONTAINS_BY_HANDLE
+                : FriendsHandleSearchQuerySql.SELECT_USER_NO_CONTAINS_BY_HANDLE;
+
+        final String countSql = isQueryNeedContains
+                ? FriendsHandleCountQuerySql.COUNT_WITH_CONTAINS_BY_HANDLE
+                : FriendsHandleCountQuerySql.COUNT_NO_CONTAINS_BY_HANDLE;
+
+        return SearchPlan.of(selectSql, countSql, cleanText, isQueryNeedContains);
+    }
+}

--- a/src/main/java/gravit/code/domain/friend/infrastructure/strategy/NicknameSearchStrategy.java
+++ b/src/main/java/gravit/code/domain/friend/infrastructure/strategy/NicknameSearchStrategy.java
@@ -1,0 +1,42 @@
+package gravit.code.domain.friend.infrastructure.strategy;
+
+import gravit.code.domain.friend.dto.SearchPlan;
+import gravit.code.domain.friend.infrastructure.sql.FriendsNicknameCountQuerySql;
+import gravit.code.domain.friend.infrastructure.sql.FriendsNicknameSearchQuerySql;
+import gravit.code.domain.friend.util.QueryNormalizeUtil;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Component;
+
+@Component
+@RequiredArgsConstructor
+public class NicknameSearchStrategy implements FriendsSearchStrategy {
+
+    private static final int MIN_CONTAINS_LEN = 3;
+    private static final int INVALID_TEXT_SIZE = 1;
+
+    @Override
+    public boolean supports(String queryText) {
+        return queryText != null && !queryText.startsWith("@");
+    }
+
+    @Override
+    public SearchPlan buildPlan(long requesterId, String queryText, int page, int size) {
+        String cleanText = QueryNormalizeUtil.nicknameNormalize(queryText);
+
+        if(cleanText.length() <= INVALID_TEXT_SIZE){
+            return SearchPlan.empty();
+        }
+
+        boolean isQueryNeedContains = cleanText.length() >= MIN_CONTAINS_LEN;
+
+        String selectSql = isQueryNeedContains
+                ? FriendsNicknameSearchQuerySql.SELECT_USER_WITH_CONTAINS_BY_NICKNAME
+                : FriendsNicknameSearchQuerySql.SELECT_USER_NO_CONTAINS_BY_NICKNAME;
+
+        String countSql = isQueryNeedContains
+                ? FriendsNicknameCountQuerySql.COUNT_WITH_CONTAINS_BY_NICKNAME
+                : FriendsNicknameCountQuerySql.COUNT_NO_CONTAINS_BY_NICKNAME;
+
+        return SearchPlan.of(selectSql, countSql, cleanText, isQueryNeedContains);
+    }
+}

--- a/src/main/java/gravit/code/domain/friend/service/FriendSearchService.java
+++ b/src/main/java/gravit/code/domain/friend/service/FriendSearchService.java
@@ -12,9 +12,8 @@ import org.springframework.stereotype.Service;
 public class FriendSearchService {
     private final FriendSearchRepository friendSearchRepository;
 
-    public PageSearchUserResponse searchUsersForFollowing(Long requesterId, String handleQuery, int page){
-        int p = Math.max(0, page);
-        log.info("p : {} ", p);
-        return friendSearchRepository.searchByHandle(requesterId, handleQuery, p);
+    public PageSearchUserResponse searchUsersForFollowing(Long requesterId, String queryText, int page){
+        int safePage = Math.max(0, page);
+        return friendSearchRepository.searchUsersByQueryText(requesterId, queryText, safePage);
     }
 }

--- a/src/main/java/gravit/code/domain/friend/util/QueryNormalizeUtil.java
+++ b/src/main/java/gravit/code/domain/friend/util/QueryNormalizeUtil.java
@@ -1,0 +1,52 @@
+package gravit.code.domain.friend.util;
+
+import lombok.experimental.UtilityClass;
+
+import java.text.Normalizer;
+import java.util.Locale;
+import java.util.regex.Pattern;
+
+@UtilityClass
+public class QueryNormalizeUtil {
+
+    private static final Pattern HANDLE_NOT_ALLOWED    = Pattern.compile("[^a-z0-9]");
+    private static final Pattern NICKNAME_NOT_ALLOWED  = Pattern.compile("[^0-9A-Za-z가-힣]");
+
+    /**
+     * 핸들(태그) 정규화
+     * - 앞의 '@'는 제거 (테이블에는 @까지 저장하지 않음)
+     * - NFKC 정규화 후 공백 양끝 제거
+     * - 전부 소문자로 변환(소문자만 가능함)
+     * - 소문자 알파벳/숫자만 남김
+     * @return 정규화된 핸들 문자열(없으면 빈 문자열)
+     */
+    public static String handleNormalize(String queryText) {
+        if (queryText == null || queryText.isBlank()) return "";
+        String q = Normalizer.normalize(queryText, Normalizer.Form.NFKC).strip();
+
+        // 앞쪽 연속 '@' 제거
+        int i = 0;
+        while (i < q.length() && q.charAt(i) == '@') i++;
+        if (i > 0) q = q.substring(i);
+
+        q = q.toLowerCase(Locale.ROOT);
+        q = HANDLE_NOT_ALLOWED.matcher(q).replaceAll(""); // 소문자/숫자 이외 제거
+        return q;
+    }
+
+    /**
+     * 닉네임 정규화
+     *  - NFKC 정규화 후 공백 양끝 제거
+     *  - (영문 대/소문자, 숫자, 한글)만 남김
+     *  - 대소문자는 보존
+     * @return 정규화된 닉네임 문자열(없으면 빈 문자열)
+     */
+    public static String nicknameNormalize(String queryText) {
+        if (queryText == null || queryText.isBlank()) return "";
+        String q = Normalizer.normalize(queryText, Normalizer.Form.NFKC).strip();
+
+        q = q.toLowerCase(Locale.ROOT);
+        q = NICKNAME_NOT_ALLOWED.matcher(q).replaceAll(""); // 허용 외 문자 제거(공백 포함)
+        return q;
+    }
+}

--- a/src/main/java/gravit/code/global/exception/domain/CustomErrorCode.java
+++ b/src/main/java/gravit/code/global/exception/domain/CustomErrorCode.java
@@ -63,6 +63,7 @@ public enum CustomErrorCode implements ErrorCode {
     FRIEND_NOT_FOUND(HttpStatus.NOT_FOUND, "FRIEND_4041", "팔로우 내역이 존재하지 않습니다."),
     UNABLE_FOLLOWING_YOURSELF(HttpStatus.BAD_REQUEST,"FRIEND_4001", "자기 자신에게 팔로잉은 불가능합니다"),
     FRIEND_CONFLICT(HttpStatus.CONFLICT, "FRIEND_4091","이미 팔로잉을 한 유저입니다."),
+    FRIEND_QUERY_STRATEGY_TYPE_INVALID(HttpStatus.BAD_REQUEST, "FRIEND_4002", "친구 조회에 유효한 전략 타입이 없습니다."),
 
     // LEAGUE
     LEAGUE_NOT_FOUND(HttpStatus.NOT_FOUND, "LEAGUE_4041", "리그 조회에 실패하였습니다."),

--- a/src/main/resources/db/migration/seed/V8__seed_user_leagues.sql
+++ b/src/main/resources/db/migration/seed/V8__seed_user_leagues.sql
@@ -9,7 +9,7 @@ DELETE
 FROM users
 WHERE email LIKE 'seed_%@test.com';
 
--- 1) users: 리그별 30명 생성
+-- 1) users: 리그별 30명 생성 (handle/nickname 규칙 적용)
 WITH RECURSIVE seq(n) AS (SELECT 1
                           UNION ALL
                           SELECT n + 1
@@ -20,26 +20,33 @@ INTO users (
   email, provider_id, nickname, handle,
   level, xp, created_at, profile_img_number, is_onboarded
 )
-SELECT CONCAT('seed_t', l.id, '_u', s.n, '@test.com') AS email,
-       CONCAT('seed_p_t', l.id, '_', s.n)             AS provider_id,
-       CONCAT('유저', l.id, '-', s.n)                   AS nickname,
-       CONCAT('seed_t', l.id, '_u', s.n)              AS handle,
+SELECT CONCAT('seed_t', l.id, '_u', s.n, '@test.com')                               AS email,
+       CONCAT('seed_p_t', l.id, '_', s.n)                                           AS provider_id,
+
+       -- ★ nickname: 한글/영어/숫자만, 공백/특수문자 제거
+       --   예: '유저' || l.id || 'u' || s.n → 정규식으로 불허 문자 제거
+       REGEXP_REPLACE(CONCAT('유저', l.id, 'u', s.n), '[^0-9A-Za-z가-힣]', '', 'g')     AS nickname,
+
+       -- ★ handle: 소문자+숫자만 (언더스코어 등 제거)
+       --   예: seedt10u3 형태
+       LOWER(REGEXP_REPLACE(CONCAT('seedt', l.id, 'u', s.n), '[^a-z0-9]', '', 'g')) AS handle,
+
        CASE
            WHEN l.id BETWEEN 1 AND 3 THEN 3 + (s.n % 3)
            WHEN l.id BETWEEN 4 AND 6 THEN 6 + (s.n % 3)
            WHEN l.id BETWEEN 7 AND 9 THEN 9 + (s.n % 3)
            WHEN l.id BETWEEN 10 AND 12 THEN 12 + (s.n % 3)
            ELSE 15 + (s.n % 3)
-           END                                        AS level,
-       1000 + (l.id * 100) + s.n                      AS xp,
-       NOW()                                          AS created_at,
-       ((s.n - 1) % 10) + 1 AS profile_img_number, TRUE AS is_onboarded -- TRUE 대체
+           END                                                                      AS level,
+       1000 + (l.id * 100) + s.n                                                    AS xp,
+       NOW()                                                                        AS created_at,
+       ((s.n - 1) % 10) + 1 AS profile_img_number, TRUE AS is_onboarded
 FROM league l
     JOIN seq s
-ON 1=1
+ON TRUE
 WHERE l.id BETWEEN 1 AND 15;
 
--- 2) user_league: provider_id로 users를 다시 찾아 연결
+-- 2) user_league: 기존 동일
 WITH RECURSIVE seq(n) AS (SELECT 1
                           UNION ALL
                           SELECT n + 1
@@ -50,10 +57,8 @@ INTO user_league (user_id, season_id, league_id, league_point, updated_at)
 SELECT u.id,
        1    AS season_id,
        l.id AS league_id,
-       (l.min_lp + floor((l.max_lp - l.min_lp) * ((s.n - 1):: numeric / 29)))::int AS league_point,
-        NOW() AS updated_at
+       (l.min_lp + FLOOR((l.max_lp - l.min_lp) * ((s.n - 1):: numeric / 29)))::int AS league_point, NOW() AS updated_at
 FROM league l
          JOIN seq s ON TRUE
-         JOIN users u
-              ON u.provider_id = concat('seed_p_t', l.id, '_', s.n)
+         JOIN users u ON u.provider_id = CONCAT('seed_p_t', l.id, '_', s.n)
 WHERE l.id BETWEEN 1 AND 15;


### PR DESCRIPTION
## 📋 이슈 번호
- close #93 

## 🛠 구현 사항
1. @로 시작하면 handle(태그) 조회, 문자(알파벳, 한글) 나 숫자로 시작하면 nickname 으로 조회하도록 수정
2. if 문으로 분기하여 쿼리를 처리하는 방식이 더 간단 할 수 있으나, 추후 개선 및 가독성 문제로 전략 패턴으로 handle 처리 전략, nickname 처리 전략 을 구현하여 다형성을 지키며 기능을 제공하도록 하였습니다.

## 🤔 추가 고려 사항

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- 신규 기능
  - 친구 검색이 핸들(@username)과 닉네임을 모두 지원하며, 정확 일치/접두/포함 순으로 더 관련성 높은 결과를 제공합니다.
  - 한글/영문 대소문자 정규화로 검색 품질이 개선되었습니다.
  - 잘못된 검색 형식에 대해 더 명확한 오류 응답을 제공합니다.
- 변경 사항
  - 검색 API 쿼리 파라미터가 handleQuery → queryText로 변경되었습니다. (호환성 영향)
- 유지보수
  - 데모/시드 데이터가 확대되어 더 많은 사용자 샘플로 검색을 확인할 수 있습니다.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->