### PR TITLE
fix: 메인페이지 조회 API에 미션 관련 세부 정보 추가

### DIFF
--- a/src/main/java/gravit/code/mainPage/controller/docs/MainPageControllerDocs.java
+++ b/src/main/java/gravit/code/mainPage/controller/docs/MainPageControllerDocs.java
@@ -1,8 +1,8 @@
 package gravit.code.mainPage.controller.docs;
 
 import gravit.code.auth.domain.LoginUser;
-import gravit.code.mainPage.dto.response.MainPageResponse;
 import gravit.code.global.exception.domain.ErrorResponse;
+import gravit.code.mainPage.dto.response.MainPageResponse;
 import io.swagger.v3.oas.annotations.Operation;
 import io.swagger.v3.oas.annotations.media.Content;
 import io.swagger.v3.oas.annotations.media.ExampleObject;

--- a/src/main/java/gravit/code/mainPage/dto/MainPageSummary.java
+++ b/src/main/java/gravit/code/mainPage/dto/MainPageSummary.java
@@ -1,0 +1,18 @@
+package gravit.code.mainPage.dto;
+
+public record MainPageSummary(
+
+        String nickname,
+        String leagueName,
+        int xp,
+        int level,
+        int planetConquestRate,
+        int consecutiveDays,
+        long chapterId,
+        String chapterName,
+        String chapterDescription,
+        long totalUnits,
+        long completedUnits
+
+) {
+}

--- a/src/main/java/gravit/code/mainPage/dto/response/MainPageResponse.java
+++ b/src/main/java/gravit/code/mainPage/dto/response/MainPageResponse.java
@@ -1,11 +1,12 @@
 package gravit.code.mainPage.dto.response;
 
-import gravit.code.mission.domain.MissionType;
+import gravit.code.mainPage.dto.MainPageSummary;
+import gravit.code.mission.dto.MissionSummary;
 import io.swagger.v3.oas.annotations.media.Schema;
+import lombok.Builder;
 
-@Schema(description = "메인페이지 정보 Response")
+@Builder
 public record MainPageResponse(
-
         @Schema(
                 description = "닉네임",
                 example = "삼준서"
@@ -29,12 +30,6 @@ public record MainPageResponse(
                 example = "12"
         )
         int level,
-
-        @Schema(
-                description = "미션 타입",
-                example = "COMPLETE_LESSON_ONE"
-        )
-        MissionType missionType,
 
         @Schema(
                 description = "행성 정복율",
@@ -76,7 +71,43 @@ public record MainPageResponse(
                 description = "완료한 유닛수",
                 example = "8"
         )
-        long completedUnits
+        long completedUnits,
 
+        @Schema(
+                description = "미션 이름",
+                example = "레슨 1개 완료하기"
+        )
+        String missionName,
+
+        @Schema(
+                description = "보상 xp",
+                example = "40"
+        )
+        int awardXp,
+
+        @Schema(
+                description = "완료 여부",
+                example = "false"
+        )
+        boolean isCompleted
 ) {
+
+    public static MainPageResponse create(MainPageSummary mainPageSummary, MissionSummary missionSummary) {
+        return MainPageResponse.builder()
+                .nickname(mainPageSummary.nickname())
+                .leagueName(mainPageSummary.leagueName())
+                .xp(mainPageSummary.xp())
+                .level(mainPageSummary.level())
+                .planetConquestRate(mainPageSummary.planetConquestRate())
+                .consecutiveDays(mainPageSummary.consecutiveDays())
+                .chapterId(mainPageSummary.chapterId())
+                .chapterName(mainPageSummary.chapterName())
+                .chapterDescription(mainPageSummary.chapterDescription())
+                .totalUnits(mainPageSummary.totalUnits())
+                .completedUnits(mainPageSummary.completedUnits())
+                .missionName(missionSummary.missionType().getDescription())
+                .awardXp(missionSummary.missionType().getAwardXp())
+                .isCompleted(missionSummary.isCompleted())
+                .build();
+    }
 }

--- a/src/main/java/gravit/code/mission/domain/MissionRepository.java
+++ b/src/main/java/gravit/code/mission/domain/MissionRepository.java
@@ -1,6 +1,8 @@
 package gravit.code.mission.domain;
 
+import gravit.code.mission.dto.MissionSummary;
 import org.springframework.data.domain.Pageable;
+
 import java.util.List;
 import java.util.Optional;
 
@@ -8,4 +10,5 @@ public interface MissionRepository {
     Optional<Mission> findByUserId(long userId);
     Mission save(Mission mission);
     List<Mission> findAll(Pageable pageable);
+    MissionSummary findMissionSummaryByUserId(long userId);
 }

--- a/src/main/java/gravit/code/mission/dto/MissionSummary.java
+++ b/src/main/java/gravit/code/mission/dto/MissionSummary.java
@@ -1,0 +1,9 @@
+package gravit.code.mission.dto;
+
+import gravit.code.mission.domain.MissionType;
+
+public record MissionSummary(
+        MissionType missionType,
+        boolean isCompleted
+) {
+}

--- a/src/main/java/gravit/code/mission/infrastructure/MissionJpaRepository.java
+++ b/src/main/java/gravit/code/mission/infrastructure/MissionJpaRepository.java
@@ -1,12 +1,14 @@
 package gravit.code.mission.infrastructure;
 
 import gravit.code.mission.domain.Mission;
+import gravit.code.mission.dto.MissionSummary;
 import jakarta.persistence.LockModeType;
 import org.springframework.data.domain.Page;
+import org.springframework.data.domain.Pageable;
 import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.data.jpa.repository.Lock;
-
-import org.springframework.data.domain.Pageable;
+import org.springframework.data.jpa.repository.Query;
+import org.springframework.data.repository.query.Param;
 
 import java.util.Optional;
 
@@ -15,4 +17,11 @@ public interface MissionJpaRepository extends JpaRepository<Mission, Long> {
 
     @Lock(LockModeType.OPTIMISTIC)
     Page<Mission> findAll(Pageable pageable);
+
+    @Query("""
+        SELECT new gravit.code.mission.dto.MissionSummary(m.missionType, m.isCompleted)
+        FROM Mission m
+        WHERE m.userId = :userId
+    """)
+    MissionSummary findMissionSummaryByUserId(@Param("userid") long userId);
 }

--- a/src/main/java/gravit/code/mission/infrastructure/MissionRepositoryImpl.java
+++ b/src/main/java/gravit/code/mission/infrastructure/MissionRepositoryImpl.java
@@ -2,6 +2,7 @@ package gravit.code.mission.infrastructure;
 
 import gravit.code.mission.domain.Mission;
 import gravit.code.mission.domain.MissionRepository;
+import gravit.code.mission.dto.MissionSummary;
 import lombok.RequiredArgsConstructor;
 import org.springframework.data.domain.Pageable;
 import org.springframework.stereotype.Repository;
@@ -27,5 +28,10 @@ public class MissionRepositoryImpl implements MissionRepository {
     @Override
     public List<Mission> findAll(Pageable pageable) {
         return missionJpaRepository.findAll(pageable).getContent();
+    }
+
+    @Override
+    public MissionSummary findMissionSummaryByUserId(long userId){
+        return missionJpaRepository.findMissionSummaryByUserId(userId);
     }
 }

--- a/src/main/java/gravit/code/mission/service/MissionService.java
+++ b/src/main/java/gravit/code/mission/service/MissionService.java
@@ -6,6 +6,7 @@ import gravit.code.global.exception.domain.RestApiException;
 import gravit.code.mission.domain.Mission;
 import gravit.code.mission.domain.MissionRepository;
 import gravit.code.mission.domain.MissionType;
+import gravit.code.mission.dto.MissionSummary;
 import gravit.code.mission.dto.event.CreateMissionEvent;
 import gravit.code.mission.dto.event.FollowMissionEvent;
 import gravit.code.mission.dto.event.LessonMissionEvent;
@@ -53,6 +54,18 @@ public class MissionService {
 
             page++;
         }
+    }
+
+    @Retryable(
+            retryFor = {ObjectOptimisticLockingFailureException.class},
+            maxAttempts = 10,
+            backoff = @Backoff(
+                    delay = 100,
+                    random = true
+            )
+    )
+    public MissionSummary getMissionSummary(long userId){
+        return missionRepository.findMissionSummaryByUserId(userId);
     }
 
     @Retryable(

--- a/src/main/java/gravit/code/user/domain/UserRepository.java
+++ b/src/main/java/gravit/code/user/domain/UserRepository.java
@@ -1,6 +1,6 @@
 package gravit.code.user.domain;
 
-import gravit.code.mainPage.dto.response.MainPageResponse;
+import gravit.code.mainPage.dto.MainPageSummary;
 import gravit.code.user.dto.response.MyPageResponse;
 
 import java.util.Optional;
@@ -12,6 +12,6 @@ public interface UserRepository {
     boolean existsById(long id);
     boolean existsByHandle(String handle);
     Optional<MyPageResponse> findMyPageByUserId(long userId);
-    MainPageResponse findMainPageByUserId(long userId);
+    MainPageSummary findMainPageByUserId(long userId);
     void deleteById(long id);
 }

--- a/src/main/java/gravit/code/user/infrastructure/UserJpaRepository.java
+++ b/src/main/java/gravit/code/user/infrastructure/UserJpaRepository.java
@@ -1,6 +1,6 @@
 package gravit.code.user.infrastructure;
 
-import gravit.code.mainPage.dto.response.MainPageResponse;
+import gravit.code.mainPage.dto.MainPageSummary;
 import gravit.code.user.domain.User;
 import gravit.code.user.dto.response.MyPageResponse;
 import org.springframework.data.jpa.repository.JpaRepository;
@@ -14,12 +14,11 @@ public interface UserJpaRepository extends JpaRepository<User, Long> {
     Optional<User> findByProviderId(String providerId);
 
     @Query("""
-        SELECT new gravit.code.mainPage.dto.response.MainPageResponse(
+        SELECT new gravit.code.mainPage.dto.MainPageSummary(
             u.nickname,
             league.name,
             u.level.xp,
             u.level.level,
-            m.missionType,
             l.planetConquestRate,
             l.consecutiveDays,
             CAST(CASE WHEN l.recentChapterId = 0 THEN 0 ELSE COALESCE(c.id, 0) END AS long),
@@ -30,14 +29,13 @@ public interface UserJpaRepository extends JpaRepository<User, Long> {
         )
         FROM User u
         LEFT JOIN Learning l ON l.userId = u.id
-        LEFT JOIN Mission m ON m.userId = u.id
         LEFT JOIN UserLeague ul ON ul.user.id = u.id
         LEFT JOIN League league ON league.id = ul.league.id
         LEFT JOIN Chapter c ON c.id = l.recentChapterId AND l.recentChapterId != 0
         LEFT JOIN ChapterProgress cp ON cp.chapterId = c.id AND cp.userId = u.id
         WHERE u.id = :userId
     """)
-    MainPageResponse findMainPageByUserId(@Param("userId") long userId);
+    MainPageSummary findMainPageByUserId(@Param("userId") long userId);
 
     boolean existsById(long id);
 

--- a/src/main/java/gravit/code/user/infrastructure/UserRepositoryImpl.java
+++ b/src/main/java/gravit/code/user/infrastructure/UserRepositoryImpl.java
@@ -1,6 +1,6 @@
 package gravit.code.user.infrastructure;
 
-import gravit.code.mainPage.dto.response.MainPageResponse;
+import gravit.code.mainPage.dto.MainPageSummary;
 import gravit.code.user.domain.User;
 import gravit.code.user.domain.UserRepository;
 import gravit.code.user.dto.response.MyPageResponse;
@@ -35,7 +35,7 @@ public class UserRepositoryImpl implements UserRepository {
     }
 
     @Override
-    public MainPageResponse findMainPageByUserId(long userId){
+    public MainPageSummary findMainPageByUserId(long userId){
         return jpaRepository.findMainPageByUserId(userId);
     }
 

--- a/src/test/java/gravit/code/user/domain/UserRepositoryTest.java
+++ b/src/test/java/gravit/code/user/domain/UserRepositoryTest.java
@@ -6,7 +6,7 @@ import gravit.code.learning.domain.Chapter;
 import gravit.code.learning.domain.Learning;
 import gravit.code.learning.infrastructure.ChapterJpaRepository;
 import gravit.code.learning.infrastructure.LearningJpaRepository;
-import gravit.code.mainPage.dto.response.MainPageResponse;
+import gravit.code.mainPage.dto.MainPageSummary;
 import gravit.code.mission.domain.Mission;
 import gravit.code.mission.domain.MissionType;
 import gravit.code.mission.infrastructure.MissionJpaRepository;
@@ -156,7 +156,7 @@ class UserRepositoryTest {
             Long userId = 1L;
 
             // when
-            MainPageResponse response = userRepository.findMainPageByUserId(userId);
+            MainPageSummary response = userRepository.findMainPageByUserId(userId);
 
             // then
             assertThat(response).isNotNull();
@@ -177,7 +177,7 @@ class UserRepositoryTest {
             Long userId = 2L;
 
             // when
-            MainPageResponse response = userRepository.findMainPageByUserId(userId);
+            MainPageSummary response = userRepository.findMainPageByUserId(userId);
 
             // then
             assertThat(response).isNotNull();

--- a/src/test/java/gravit/code/user/domain/UserRepositoryTest.java
+++ b/src/test/java/gravit/code/user/domain/UserRepositoryTest.java
@@ -183,7 +183,6 @@ class UserRepositoryTest {
             assertThat(response).isNotNull();
             assertThat(response.nickname()).isEqualTo("test2");
             assertThat(response.leagueName()).isEqualTo("브론즈");
-            assertThat(response.missionType()).isEqualTo(MissionType.COMPLETE_LESSON_ONE);
             assertThat(response.consecutiveDays()).isEqualTo(1);
             assertThat(response.planetConquestRate()).isEqualTo(15);
             assertThat(response.chapterId()).isEqualTo(1L);


### PR DESCRIPTION
## 📋 이슈 번호
- close #154 

## 🛠 구현 사항
메인페이지 조회 API에서 미션의 세부 정보도 함께 추가하였습니다.

## 🤔 추가 고려 사항

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- New Features
  - 리그 홈 조회 API 추가(/api/v1/league/home): 현재 시즌 정보와 지난 시즌 결과 팝업(최초 1회 노출) 제공
  - 메인페이지 응답에 미션명, 보상 XP, 완료 여부 추가

- Changes
  - 메인페이지 응답 스키마 변경: missionType 삭제, missionName/awardXp/isCompleted로 대체
  - 오류 메시지 수정: “마감 대상 ACTIVE 시즌이 없습니다。” → “ACTIVE 시즌이 없습니다.”

- Refactor
  - ID·수치 필드에 원시 타입 적용으로 일관성 및 안정성 개선

- Documentation
  - 리그 홈 조회 API 스웨거 문서화 추가

<!-- end of auto-generated comment: release notes by coderabbit.ai -->