### PR TITLE
fix: Mission 예외 처리 추가 및 JPQL 오탈자 수정 (#157)

### DIFF
--- a/src/main/java/gravit/code/mission/domain/MissionRepository.java
+++ b/src/main/java/gravit/code/mission/domain/MissionRepository.java
@@ -10,5 +10,5 @@ public interface MissionRepository {
     Optional<Mission> findByUserId(long userId);
     Mission save(Mission mission);
     List<Mission> findAll(Pageable pageable);
-    MissionSummary findMissionSummaryByUserId(long userId);
+    Optional<MissionSummary> findMissionSummaryByUserId(long userId);
 }

--- a/src/main/java/gravit/code/mission/infrastructure/MissionJpaRepository.java
+++ b/src/main/java/gravit/code/mission/infrastructure/MissionJpaRepository.java
@@ -23,5 +23,5 @@ public interface MissionJpaRepository extends JpaRepository<Mission, Long> {
         FROM Mission m
         WHERE m.userId = :userId
     """)
-    MissionSummary findMissionSummaryByUserId(@Param("userid") long userId);
+    Optional<MissionSummary> findMissionSummaryByUserId(@Param("userId") long userId);
 }

--- a/src/main/java/gravit/code/mission/infrastructure/MissionRepositoryImpl.java
+++ b/src/main/java/gravit/code/mission/infrastructure/MissionRepositoryImpl.java
@@ -5,6 +5,7 @@ import gravit.code.mission.domain.MissionRepository;
 import gravit.code.mission.dto.MissionSummary;
 import lombok.RequiredArgsConstructor;
 import org.springframework.data.domain.Pageable;
+import org.springframework.data.repository.query.Param;
 import org.springframework.stereotype.Repository;
 
 import java.util.List;
@@ -31,7 +32,7 @@ public class MissionRepositoryImpl implements MissionRepository {
     }
 
     @Override
-    public MissionSummary findMissionSummaryByUserId(long userId){
+    public Optional<MissionSummary> findMissionSummaryByUserId(long userId){
         return missionJpaRepository.findMissionSummaryByUserId(userId);
     }
 }

--- a/src/main/java/gravit/code/mission/service/MissionService.java
+++ b/src/main/java/gravit/code/mission/service/MissionService.java
@@ -65,7 +65,8 @@ public class MissionService {
             )
     )
     public MissionSummary getMissionSummary(long userId){
-        return missionRepository.findMissionSummaryByUserId(userId);
+        return missionRepository.findMissionSummaryByUserId(userId)
+                .orElseThrow(() -> new RestApiException(CustomErrorCode.MISSION_NOT_FOUND));
     }
 
     @Retryable(


### PR DESCRIPTION
## 📋 이슈 번호
- close #157 

## 🛠 구현 사항
Mission 조회 실패에 대한 예외처리를 추가하고 JPQL 오탈자를 수정하였습니다.

## 🤔 추가 고려 사항