### PR TITLE
fix: 문제 조회, 풀이 결과 제출 API 요청/응답 수정

### DIFF
--- a/src/main/java/gravit/code/learning/domain/LessonRepository.java
+++ b/src/main/java/gravit/code/learning/domain/LessonRepository.java
@@ -10,4 +10,5 @@ public interface LessonRepository {
     long count();
     boolean existsById(Long lessonId);
     LearningIds findLearningIdsByLessonId(long lessonId);
+    Optional<String> findLessonNameById(long lessonId);
 }

--- a/src/main/java/gravit/code/learning/domain/LessonRepository.java
+++ b/src/main/java/gravit/code/learning/domain/LessonRepository.java
@@ -1,9 +1,13 @@
 package gravit.code.learning.domain;
 
+import gravit.code.learning.dto.LearningIds;
+
 import java.util.Optional;
 
 public interface LessonRepository {
     Lesson save(Lesson lesson);
     Optional<Lesson> findById(Long lessonId);
     long count();
+    boolean existsById(Long lessonId);
+    LearningIds findLearningIdsByLessonId(long lessonId);
 }

--- a/src/main/java/gravit/code/learning/dto/LearningIds.java
+++ b/src/main/java/gravit/code/learning/dto/LearningIds.java
@@ -1,0 +1,8 @@
+package gravit.code.learning.dto;
+
+public record LearningIds(
+        long chapterId,
+        long unitId,
+        long lessonId
+) {
+}

--- a/src/main/java/gravit/code/learning/dto/request/LearningResultSaveRequest.java
+++ b/src/main/java/gravit/code/learning/dto/request/LearningResultSaveRequest.java
@@ -11,20 +11,6 @@ import java.util.List;
 public record LearningResultSaveRequest(
 
         @Schema(
-                description = "챕터 아이디",
-                example = "1"
-        )
-        @NotNull(message = "챕터 아이디가 비어있습니다.")
-        Long chapterId,
-
-        @Schema(
-                description = "유닛 아이디",
-                example = "2"
-        )
-        @NotNull(message = "유닛 아이디가 비어있습니다.")
-        Long unitId,
-
-        @Schema(
                 description = "레슨 아이디",
                 example = "2"
         )

--- a/src/main/java/gravit/code/learning/dto/response/LessonResponse.java
+++ b/src/main/java/gravit/code/learning/dto/response/LessonResponse.java
@@ -8,12 +8,14 @@ import java.util.List;
 @Builder
 @Schema(description = "레슨 조회 Response")
 public record LessonResponse(
+        String lessonName,
         List<ProblemResponse> problems,
         int totalProblems
 ) {
 
-    public static LessonResponse create(List<ProblemResponse> problems){
+    public static LessonResponse create(String lessonName, List<ProblemResponse> problems){
         return LessonResponse.builder()
+                .lessonName(lessonName)
                 .problems(problems)
                 .totalProblems(problems.size())
                 .build();

--- a/src/main/java/gravit/code/learning/facade/LearningFacade.java
+++ b/src/main/java/gravit/code/learning/facade/LearningFacade.java
@@ -65,7 +65,8 @@ public class LearningFacade {
 
     @Transactional(readOnly = true)
     public LessonResponse getLesson(long lessonId){
-        return LessonResponse.create(problemService.getAllProblemInLesson(lessonId));
+        String lessonName = lessonService.findLessonName(lessonId);
+        return LessonResponse.create(lessonName, problemService.getAllProblemInLesson(lessonId));
     }
 
     @Transactional

--- a/src/main/java/gravit/code/learning/facade/LearningFacade.java
+++ b/src/main/java/gravit/code/learning/facade/LearningFacade.java
@@ -2,9 +2,11 @@ package gravit.code.learning.facade;
 
 import gravit.code.global.event.LessonCompletedEvent;
 import gravit.code.global.event.badge.QualifiedSolvedEvent;
+import gravit.code.learning.dto.LearningIds;
 import gravit.code.learning.dto.event.UpdateLearningEvent;
 import gravit.code.learning.dto.request.LearningResultSaveRequest;
 import gravit.code.learning.dto.response.LessonResponse;
+import gravit.code.learning.service.LessonService;
 import gravit.code.learning.service.ProblemService;
 import gravit.code.mission.dto.event.LessonMissionEvent;
 import gravit.code.progress.domain.ChapterProgress;
@@ -33,6 +35,7 @@ public class LearningFacade {
     private final ApplicationEventPublisher publisher;
 
     private final UserService userService;
+    private final LessonService lessonService;
     private final ProblemService problemService;
 
     private final ChapterProgressService chapterProgressService;
@@ -68,8 +71,10 @@ public class LearningFacade {
     @Transactional
     public UserLevelResponse saveLearningResult(long userId, LearningResultSaveRequest request){
 
-        ChapterProgress chapterProgress = chapterProgressService.ensureChapterProgress(request.chapterId(), userId);
-        UnitProgress unitProgress = unitProgressService.ensureUnitProgress(request.unitId(), userId);
+        LearningIds learningIds = lessonService.findLearningIdsByLessonId(request.lessonId());
+
+        ChapterProgress chapterProgress = chapterProgressService.ensureChapterProgress(learningIds.chapterId(), userId);
+        UnitProgress unitProgress = unitProgressService.ensureUnitProgress(learningIds.unitId(), userId);
 
         // 문제 풀이 결과 저장
         problemProgressService.saveProblemResults(userId, request.problemResults());
@@ -80,7 +85,7 @@ public class LearningFacade {
         if(unitProgressService.updateUnitProgress(unitProgress))
             chapterProgressService.updateChapterProgress(chapterProgress);
 
-        publisher.publishEvent(new UpdateLearningEvent(userId, request.chapterId()));
+        publisher.publishEvent(new UpdateLearningEvent(userId, learningIds.chapterId()));
         publisher.publishEvent(new LessonCompletedEvent(userId, 20, request.accuracy()));
         publisher.publishEvent(new LessonMissionEvent(userId, request.lessonId(), request.learningTime(), request.accuracy()));
         publisher.publishEvent(new QualifiedSolvedEvent(userId, request.learningTime(), request.accuracy()));

--- a/src/main/java/gravit/code/learning/infrastructure/LessonJpaRepository.java
+++ b/src/main/java/gravit/code/learning/infrastructure/LessonJpaRepository.java
@@ -6,6 +6,8 @@ import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.data.jpa.repository.Query;
 import org.springframework.data.repository.query.Param;
 
+import java.util.Optional;
+
 public interface LessonJpaRepository extends JpaRepository<Lesson, Long> {
     @Query("""
         SELECT new gravit.code.learning.dto.LearningIds(c.id, u.id, l.id)
@@ -15,4 +17,6 @@ public interface LessonJpaRepository extends JpaRepository<Lesson, Long> {
         WHERE l.id = :lessonId
     """)
     LearningIds findLearningIdsByLessonId(@Param("lessonId")long lessonId);
+
+    Optional<String> findLessonNameById(Long id);
 }

--- a/src/main/java/gravit/code/learning/infrastructure/LessonJpaRepository.java
+++ b/src/main/java/gravit/code/learning/infrastructure/LessonJpaRepository.java
@@ -1,7 +1,18 @@
 package gravit.code.learning.infrastructure;
 
 import gravit.code.learning.domain.Lesson;
+import gravit.code.learning.dto.LearningIds;
 import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Query;
+import org.springframework.data.repository.query.Param;
 
 public interface LessonJpaRepository extends JpaRepository<Lesson, Long> {
+    @Query("""
+        SELECT new gravit.code.learning.dto.LearningIds(c.id, u.id, l.id)
+        FROM Lesson l
+        INNER JOIN Unit u ON u.id = l.unitId
+        INNER JOIN Chapter c ON c.id = u.chapterId
+        WHERE l.id = :lessonId
+    """)
+    LearningIds findLearningIdsByLessonId(@Param("lessonId")long lessonId);
 }

--- a/src/main/java/gravit/code/learning/infrastructure/LessonRepositoryImpl.java
+++ b/src/main/java/gravit/code/learning/infrastructure/LessonRepositoryImpl.java
@@ -38,4 +38,9 @@ public class LessonRepositoryImpl implements LessonRepository {
     public LearningIds findLearningIdsByLessonId(long lessonId){
         return lessonJpaRepository.findLearningIdsByLessonId(lessonId);
     }
+
+    @Override
+    public Optional<String> findLessonNameById(long lessonId){
+        return lessonJpaRepository.findLessonNameById(lessonId);
+    }
 }

--- a/src/main/java/gravit/code/learning/infrastructure/LessonRepositoryImpl.java
+++ b/src/main/java/gravit/code/learning/infrastructure/LessonRepositoryImpl.java
@@ -2,6 +2,7 @@ package gravit.code.learning.infrastructure;
 
 import gravit.code.learning.domain.Lesson;
 import gravit.code.learning.domain.LessonRepository;
+import gravit.code.learning.dto.LearningIds;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Repository;
 
@@ -26,5 +27,15 @@ public class LessonRepositoryImpl implements LessonRepository {
     @Override
     public long count(){
         return lessonJpaRepository.count();
+    }
+
+    @Override
+    public boolean existsById(Long lessonId){
+        return lessonJpaRepository.existsById(lessonId);
+    }
+
+    @Override
+    public LearningIds findLearningIdsByLessonId(long lessonId){
+        return lessonJpaRepository.findLearningIdsByLessonId(lessonId);
     }
 }

--- a/src/main/java/gravit/code/learning/service/LessonService.java
+++ b/src/main/java/gravit/code/learning/service/LessonService.java
@@ -1,0 +1,23 @@
+package gravit.code.learning.service;
+
+import gravit.code.global.exception.domain.CustomErrorCode;
+import gravit.code.global.exception.domain.RestApiException;
+import gravit.code.learning.domain.LessonRepository;
+import gravit.code.learning.dto.LearningIds;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+@Service
+@RequiredArgsConstructor
+public class LessonService {
+    private final LessonRepository lessonRepository;
+
+    @Transactional(readOnly = true)
+    public LearningIds findLearningIdsByLessonId(long lessonId){
+        if(!lessonRepository.existsById(lessonId))
+            throw new RestApiException(CustomErrorCode.LESSON_NOT_FOUND);
+
+        return lessonRepository.findLearningIdsByLessonId(lessonId);
+    }
+}

--- a/src/main/java/gravit/code/learning/service/LessonService.java
+++ b/src/main/java/gravit/code/learning/service/LessonService.java
@@ -6,18 +6,22 @@ import gravit.code.learning.domain.LessonRepository;
 import gravit.code.learning.dto.LearningIds;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
-import org.springframework.transaction.annotation.Transactional;
 
 @Service
 @RequiredArgsConstructor
 public class LessonService {
     private final LessonRepository lessonRepository;
 
-    @Transactional(readOnly = true)
     public LearningIds findLearningIdsByLessonId(long lessonId){
         if(!lessonRepository.existsById(lessonId))
             throw new RestApiException(CustomErrorCode.LESSON_NOT_FOUND);
 
         return lessonRepository.findLearningIdsByLessonId(lessonId);
     }
+
+    public String findLessonName(long lessonId){
+        return lessonRepository.findLessonNameById(lessonId)
+                .orElseThrow(() -> new RestApiException(CustomErrorCode.LESSON_NOT_FOUND));
+    }
+
 }

--- a/src/test/java/gravit/code/GravitApplicationTests.java
+++ b/src/test/java/gravit/code/GravitApplicationTests.java
@@ -4,7 +4,7 @@ import org.junit.jupiter.api.Test;
 import org.springframework.boot.test.context.SpringBootTest;
 import org.springframework.test.context.ActiveProfiles;
 
-@SpringBootTest
+@SpringBootTest(classes = GravitApplication.class)
 @ActiveProfiles("test")
 class GravitApplicationTests {
 

--- a/src/test/java/gravit/code/auth/oauth/service/OAuthLoginUrlServiceTest.java
+++ b/src/test/java/gravit/code/auth/oauth/service/OAuthLoginUrlServiceTest.java
@@ -1,5 +1,6 @@
 package gravit.code.auth.oauth.service;
 
+import gravit.code.GravitApplication;
 import gravit.code.auth.service.oauth.OAuthLoginUrlService;
 import gravit.code.global.exception.domain.RestApiException;
 import org.junit.jupiter.api.Test;
@@ -10,7 +11,7 @@ import org.springframework.test.context.ActiveProfiles;
 import static org.assertj.core.api.SoftAssertions.assertSoftly;
 import static org.junit.jupiter.api.Assertions.assertThrows;
 
-@SpringBootTest
+@SpringBootTest(classes = GravitApplication.class)
 @ActiveProfiles("test")
 class OAuthLoginUrlServiceTest {
 

--- a/src/test/java/gravit/code/friend/controller/FriendControllerTest.java
+++ b/src/test/java/gravit/code/friend/controller/FriendControllerTest.java
@@ -1,6 +1,7 @@
 package gravit.code.friend.controller;
 
 import com.fasterxml.jackson.databind.ObjectMapper;
+import gravit.code.GravitApplication;
 import gravit.code.common.auth.WithMockLoginUser;
 import gravit.code.friend.domain.Friend;
 import gravit.code.friend.domain.FriendRepository;
@@ -17,13 +18,12 @@ import org.springframework.test.context.ActiveProfiles;
 import org.springframework.test.context.jdbc.Sql;
 import org.springframework.test.web.servlet.MockMvc;
 
-import java.time.LocalDateTime;
-
 import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
 import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.post;
-import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.*;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.jsonPath;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
 
-@SpringBootTest
+@SpringBootTest(classes = GravitApplication.class)
 @ActiveProfiles("test")
 @AutoConfigureMockMvc
 @AutoConfigureTestDatabase

--- a/src/test/java/gravit/code/learning/controller/LearningControllerTest.java
+++ b/src/test/java/gravit/code/learning/controller/LearningControllerTest.java
@@ -246,7 +246,7 @@ class LearningControllerTest {
                     ProblemResponse.builder().problemId(8L).problemType(ProblemType.OBJECTIVE).question("힙 자료구조의 특징이 아닌 것은?").content("1. 완전 이진 트리, 2. 부모가 자식보다 크거나 작음, 3. 중위 순회시 정렬됨, 4. 우선순위 큐 구현").answer("3").options(List.of()).build()
             );
 
-            LessonResponse lessonResponse = LessonResponse.create(problemResponses);
+            LessonResponse lessonResponse = LessonResponse.create("스택 기본 개념", problemResponses);
 
             when(learningFacade.getLesson(lessonId)).thenReturn(lessonResponse);
 
@@ -259,6 +259,7 @@ class LearningControllerTest {
             resultActions
                     .andDo(print())
                     .andExpect(status().is2xxSuccessful())
+                    .andExpect(jsonPath("$.lessonName").value("스택 기본 개념"))
                     .andExpect(jsonPath("$.problems[0].problemId").value(1L))
                     .andExpect(jsonPath("$.problems[0].problemType").value("SUBJECTIVE"))
                     .andExpect(jsonPath("$.problems[0].question").value("스택에서 마지막에 삽입된 데이터가 가장 먼저 삭제되는 원리를 ( )라고 합니다."))

--- a/src/test/java/gravit/code/learning/controller/LearningControllerTest.java
+++ b/src/test/java/gravit/code/learning/controller/LearningControllerTest.java
@@ -274,8 +274,6 @@ class LearningControllerTest {
 
         private final LearningResultSaveRequest invalidRequest = new LearningResultSaveRequest(
                 null,
-                2L,
-                null,
                 null,
                 null,
                 List.of(
@@ -287,8 +285,6 @@ class LearningControllerTest {
 
         private final LearningResultSaveRequest validRequest = new LearningResultSaveRequest(
                 1L,
-                2L,
-                3L,
                 120,
                 85,
                 List.of(
@@ -304,9 +300,6 @@ class LearningControllerTest {
         @WithMockLoginUser
         @DisplayName("RequestBody가 유효하지 않으면 예외를 반환한다.")
         void withInvalidRequestBody() throws Exception {
-            //given
-            long userId = 1L;
-
             //when
             ResultActions resultActions = mockMvc.perform(post("/api/v1/learning/results")
                     .contentType(MediaType.APPLICATION_JSON)

--- a/src/test/java/gravit/code/learning/facade/LearningFacadeTest.java
+++ b/src/test/java/gravit/code/learning/facade/LearningFacadeTest.java
@@ -1,7 +1,9 @@
 package gravit.code.learning.facade;
 
 import gravit.code.learning.domain.Problem;
+import gravit.code.learning.dto.LearningIds;
 import gravit.code.learning.dto.event.UpdateLearningEvent;
+import gravit.code.learning.service.LessonService;
 import gravit.code.progress.domain.ChapterProgress;
 import gravit.code.progress.dto.response.ChapterProgressDetailResponse;
 import gravit.code.progress.service.ChapterProgressService;
@@ -46,6 +48,9 @@ class LearningFacadeTest {
 
     @Mock
     private UserService userService;
+
+    @Mock
+    private LessonService lessonService;
 
     @Mock
     private ProblemService problemService;
@@ -291,7 +296,7 @@ class LearningFacadeTest {
 
         private final Long userId = 1L;
         private final LearningResultSaveRequest validRequest = new LearningResultSaveRequest(
-                1L, 2L, 3L, 150, 80,
+                1L, 150, 80,
                 List.of(
                         new ProblemResultRequest(1L, true, 0L),
                         new ProblemResultRequest(2L, false, 2L),
@@ -301,17 +306,34 @@ class LearningFacadeTest {
                 )
         );
 
+        private final LearningIds learningIds = new LearningIds(3L, 2L, 1L);
+
         @Nested
         @DisplayName("특정 학습 조회에 실패하면 예외를 반환한다.")
         class FailedAtFind{
 
             @Test
+            @DisplayName("레슨 조회에 실패한 경우")
+            void returnLesson404Exception(){
+                //given
+                when(lessonService.findLearningIdsByLessonId(validRequest.lessonId()))
+                        .thenThrow(new RestApiException(CustomErrorCode.LESSON_NOT_FOUND));
+
+                //when&then
+                assertThatThrownBy(() -> learningFacade.saveLearningResult(userId, validRequest))
+                        .isInstanceOf(RestApiException.class)
+                        .hasFieldOrPropertyWithValue("errorCode", CustomErrorCode.LESSON_NOT_FOUND);
+            }
+
+            @Test
             @DisplayName("유닛 조회에 실패한 경우")
             void returnUnit404Exception(){
                 //given
-                when(chapterProgressService.ensureChapterProgress(validRequest.chapterId(), userId))
+                when(lessonService.findLearningIdsByLessonId(validRequest.lessonId()))
+                        .thenReturn(learningIds);
+                when(chapterProgressService.ensureChapterProgress(learningIds.chapterId(), userId))
                         .thenReturn(mock(ChapterProgress.class));
-                when(unitProgressService.ensureUnitProgress(validRequest.unitId(), userId))
+                when(unitProgressService.ensureUnitProgress(learningIds.unitId(), userId))
                         .thenThrow(new RestApiException(CustomErrorCode.UNIT_NOT_FOUND));
 
                 //when&then
@@ -324,7 +346,9 @@ class LearningFacadeTest {
             @DisplayName("챕터 조회에 실패한 경우")
             void returnChapter404Exception(){
                 //given
-                when(chapterProgressService.ensureChapterProgress(validRequest.chapterId(), userId))
+                when(lessonService.findLearningIdsByLessonId(validRequest.lessonId()))
+                        .thenReturn(learningIds);
+                when(chapterProgressService.ensureChapterProgress(learningIds.chapterId(), userId))
                         .thenThrow(new RestApiException(CustomErrorCode.CHAPTER_NOT_FOUND));
 
                 //when&then
@@ -345,9 +369,11 @@ class LearningFacadeTest {
                 ChapterProgress chapterProgress = mock(ChapterProgress.class);
                 UnitProgress unitProgress = mock(UnitProgress.class);
 
-                when(chapterProgressService.ensureChapterProgress(validRequest.chapterId(), userId))
+                when(lessonService.findLearningIdsByLessonId(validRequest.lessonId()))
+                        .thenReturn(learningIds);
+                when(chapterProgressService.ensureChapterProgress(learningIds.chapterId(), userId))
                         .thenReturn(chapterProgress);
-                when(unitProgressService.ensureUnitProgress(validRequest.unitId(), userId))
+                when(unitProgressService.ensureUnitProgress(learningIds.unitId(), userId))
                         .thenReturn(unitProgress);
                 doNothing().when(problemProgressService).saveProblemResults(userId, validRequest.problemResults());
                 doNothing().when(lessonProgressService).updateLessonProgress(validRequest.lessonId(), userId, validRequest.learningTime());
@@ -358,7 +384,7 @@ class LearningFacadeTest {
 
                 //then
                 verify(chapterProgressService, times(1)).updateChapterProgress(chapterProgress);
-                verify(publisher, times(1)).publishEvent(new UpdateLearningEvent(userId, validRequest.chapterId()));
+                verify(publisher, times(1)).publishEvent(new UpdateLearningEvent(userId, learningIds.chapterId()));
                 verify(userService, times(1)).updateUserLevelAndXp(userId, 20, validRequest.accuracy());
             }
 
@@ -369,9 +395,11 @@ class LearningFacadeTest {
                 ChapterProgress chapterProgress = mock(ChapterProgress.class);
                 UnitProgress unitProgress = mock(UnitProgress.class);
 
-                when(chapterProgressService.ensureChapterProgress(validRequest.chapterId(), userId))
+                when(lessonService.findLearningIdsByLessonId(validRequest.lessonId()))
+                        .thenReturn(learningIds);
+                when(chapterProgressService.ensureChapterProgress(learningIds.chapterId(), userId))
                         .thenReturn(chapterProgress);
-                when(unitProgressService.ensureUnitProgress(validRequest.unitId(), userId))
+                when(unitProgressService.ensureUnitProgress(learningIds.unitId(), userId))
                         .thenReturn(unitProgress);
                 doNothing().when(problemProgressService).saveProblemResults(userId, validRequest.problemResults());
                 doNothing().when(lessonProgressService).updateLessonProgress(validRequest.lessonId(), userId, validRequest.learningTime());
@@ -382,7 +410,7 @@ class LearningFacadeTest {
 
                 //then
                 verify(chapterProgressService, never()).updateChapterProgress(any());
-                verify(publisher, times(1)).publishEvent(new UpdateLearningEvent(userId, validRequest.chapterId()));
+                verify(publisher, times(1)).publishEvent(new UpdateLearningEvent(userId, learningIds.chapterId()));
                 verify(userService, times(1)).updateUserLevelAndXp(userId, 20, validRequest.accuracy());
             }
         }

--- a/src/test/java/gravit/code/learning/facade/LearningFacadeTest.java
+++ b/src/test/java/gravit/code/learning/facade/LearningFacadeTest.java
@@ -243,7 +243,7 @@ class LearningFacadeTest {
             );
         }
 
-        private final LessonResponse lessonResponse = LessonResponse.create(problemResponses);
+        private final LessonResponse lessonResponse = LessonResponse.create("스택 기본 개념", problemResponses);
 
         @Test
         @DisplayName("Problem의 리스트가 비어있으면 예외를 반환한다.")
@@ -279,6 +279,7 @@ class LearningFacadeTest {
             //given
             Long lessonId = 1L;
 
+            when(lessonService.findLessonName(lessonId)).thenReturn("스택 기본 개념");
             when(problemService.getAllProblemInLesson(lessonId)).thenReturn(problemResponses);
 
             //when
@@ -286,6 +287,7 @@ class LearningFacadeTest {
 
             //then
             assertThat(returnValue).isEqualTo(lessonResponse);
+            verify(lessonService, times(1)).findLessonName(lessonId);
             verify(problemService, times(1)).getAllProblemInLesson(lessonId);
         }
     }

--- a/src/test/java/gravit/code/user/controller/UserControllerTest.java
+++ b/src/test/java/gravit/code/user/controller/UserControllerTest.java
@@ -1,6 +1,7 @@
 package gravit.code.user.controller;
 
 import com.fasterxml.jackson.databind.ObjectMapper;
+import gravit.code.GravitApplication;
 import gravit.code.common.auth.WithMockLoginUser;
 import gravit.code.friend.domain.Friend;
 import gravit.code.friend.domain.FriendRepository;
@@ -23,12 +24,10 @@ import org.springframework.test.context.ActiveProfiles;
 import org.springframework.test.context.jdbc.Sql;
 import org.springframework.test.web.servlet.MockMvc;
 
-import java.time.LocalDateTime;
-
 import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.*;
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.*;
 
-@SpringBootTest
+@SpringBootTest(classes = GravitApplication.class)
 @ActiveProfiles("test")
 @AutoConfigureMockMvc
 @AutoConfigureTestDatabase


### PR DESCRIPTION
## 📋 이슈 번호
- close #166 

## 🛠 구현 사항
- 문제 조회 API 응답에 lessonName을 추가하였습니다. 
- 문제 풀이 결과 제출 API 요청에 기존 chapterId, unitId를 제거하고 lessonId로만 저장할 수 있게 수정하였습니다.

## 🤔 추가 고려 사항