### PR TITLE
hotfix: 미션 이름 조회 쿼리 JPQL로 변경 (#171)

### DIFF
--- a/src/main/java/gravit/code/global/exception/handler/GlobalExceptionHandler.java
+++ b/src/main/java/gravit/code/global/exception/handler/GlobalExceptionHandler.java
@@ -55,6 +55,8 @@ public class GlobalExceptionHandler {
     public ResponseEntity<ErrorResponse<String>> handleDatabaseException(DataAccessException e){
         ErrorCode errorCode = CustomErrorCode.DATABASE_EXCEPTION;
 
+        log.error("DataAccessException occur with: {}", e.getMessage());
+
         return handleExceptionInternal(errorCode);
     }
 

--- a/src/main/java/gravit/code/learning/domain/LessonRepository.java
+++ b/src/main/java/gravit/code/learning/domain/LessonRepository.java
@@ -10,5 +10,5 @@ public interface LessonRepository {
     long count();
     boolean existsById(Long lessonId);
     LearningIds findLearningIdsByLessonId(long lessonId);
-    Optional<String> findLessonNameById(long lessonId);
+    Optional<String> findLessonNameByLessonId(long lessonId);
 }

--- a/src/main/java/gravit/code/learning/infrastructure/LessonJpaRepository.java
+++ b/src/main/java/gravit/code/learning/infrastructure/LessonJpaRepository.java
@@ -18,5 +18,10 @@ public interface LessonJpaRepository extends JpaRepository<Lesson, Long> {
     """)
     LearningIds findLearningIdsByLessonId(@Param("lessonId")long lessonId);
 
-    Optional<String> findLessonNameById(Long id);
+    @Query("""
+        SELECT l.name
+        FROM Lesson l
+        WHERE l.id = :lessonId
+    """)
+    Optional<String> findLessonNameByLessonId(@Param("lessonId") long lessonId);
 }

--- a/src/main/java/gravit/code/learning/infrastructure/LessonRepositoryImpl.java
+++ b/src/main/java/gravit/code/learning/infrastructure/LessonRepositoryImpl.java
@@ -40,7 +40,7 @@ public class LessonRepositoryImpl implements LessonRepository {
     }
 
     @Override
-    public Optional<String> findLessonNameById(long lessonId){
-        return lessonJpaRepository.findLessonNameById(lessonId);
+    public Optional<String> findLessonNameByLessonId(long lessonId){
+        return lessonJpaRepository.findLessonNameByLessonId(lessonId);
     }
 }

--- a/src/main/java/gravit/code/learning/service/LessonService.java
+++ b/src/main/java/gravit/code/learning/service/LessonService.java
@@ -20,7 +20,7 @@ public class LessonService {
     }
 
     public String findLessonName(long lessonId){
-        return lessonRepository.findLessonNameById(lessonId)
+        return lessonRepository.findLessonNameByLessonId(lessonId)
                 .orElseThrow(() -> new RestApiException(CustomErrorCode.LESSON_NOT_FOUND));
     }
 


### PR DESCRIPTION
## 📋 이슈 번호
- close #171 

## 🛠 구현 사항
- 잘못된 작성된 네이밍 메서드를 JPQL로 변경합니다.

## 🤔 추가 고려 사항