### PR TITLE
fix: leagueName 을 한글로 저장, 응답 합니다

### DIFF
--- a/src/main/resources/db/migration/seed/V19__seed_korean_leagues.sql
+++ b/src/main/resources/db/migration/seed/V19__seed_korean_leagues.sql
@@ -1,0 +1,20 @@
+-- 리그 이름 한글화 (기존 데이터 수정)
+UPDATE league
+SET name = CASE id
+               WHEN 1 THEN '브론즈 1'
+               WHEN 2 THEN '브론즈 2'
+               WHEN 3 THEN '브론즈 3'
+               WHEN 4 THEN '실버 1'
+               WHEN 5 THEN '실버 2'
+               WHEN 6 THEN '실버 3'
+               WHEN 7 THEN '골드 1'
+               WHEN 8 THEN '골드 2'
+               WHEN 9 THEN '골드 3'
+               WHEN 10 THEN '플래티넘 1'
+               WHEN 11 THEN '플래티넘 2'
+               WHEN 12 THEN '플래티넘 3'
+               WHEN 13 THEN '다이아몬드 1'
+               WHEN 14 THEN '다이아몬드 2'
+               WHEN 15 THEN '다이아몬드 3'
+    END
+WHERE id IN (1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15);


### PR DESCRIPTION
## 📋 이슈 번호
- close #176 

## 🛠 구현 사항
영어로 리턴한 리그 이름을 한글로 리턴합니다.

## 🤔 추가 고려 사항

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* 신기능
  * 리그 이름이 한국어로 현지화되어 UI에 한국어 명칭이 표시됩니다(브론즈 1–3, 실버 1–3, 골드 1–3, 플래티넘 1–3, 다이아몬드 1–3).
  * 기존 리그(1–15)에 일괄 적용되어 목록과 상세 화면 등에서 더 직관적인 식별이 가능합니다.
  * 앱 전반에서 리그 명 표기가 일관된 한국어로 노출되어 사용성이 향상됩니다.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->