### PR TITLE
fix: 학습 결과 저장 로직 수정

### DIFF
--- a/src/main/java/gravit/code/progress/service/LessonProgressService.java
+++ b/src/main/java/gravit/code/progress/service/LessonProgressService.java
@@ -1,12 +1,9 @@
 package gravit.code.progress.service;
 
-import gravit.code.learning.domain.Lesson;
 import gravit.code.learning.domain.LessonRepository;
 import gravit.code.progress.domain.LessonProgress;
 import gravit.code.progress.domain.LessonProgressRepository;
 import gravit.code.progress.dto.response.LessonProgressSummaryResponse;
-import gravit.code.global.exception.domain.CustomErrorCode;
-import gravit.code.global.exception.domain.RestApiException;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
@@ -17,25 +14,22 @@ import java.util.List;
 @RequiredArgsConstructor
 public class LessonProgressService {
 
-    private final LessonRepository lessonRepository;
     private final LessonProgressRepository lessonProgressRepository;
 
     @Transactional
-    public void updateLessonProgress(
+    public LessonProgress getLessonProgressAndUpdateStatus(
             long lessonId,
             long userId,
             int learningTime
-    ){
+    ) {
+        return lessonProgressRepository.findByLessonIdAndUserId(lessonId, userId)
+                .orElseGet(() -> {
+                    LessonProgress newLessonProgress = LessonProgress.create(userId, lessonId);
 
-        Lesson targetLesson = lessonRepository.findById(lessonId)
-                .orElseThrow(() -> new RestApiException(CustomErrorCode.LESSON_NOT_FOUND));
+                    newLessonProgress.updateStatus(learningTime);
 
-        LessonProgress lessonProgress = lessonProgressRepository.findByLessonIdAndUserId(lessonId, userId)
-                .orElseGet(() -> LessonProgress.create(userId, targetLesson.getId()));
-
-        lessonProgress.updateStatus(learningTime);
-
-        lessonProgressRepository.save(lessonProgress);
+                    return lessonProgressRepository.save(newLessonProgress);
+                });
     }
 
     @Transactional(readOnly = true)
@@ -45,4 +39,5 @@ public class LessonProgressService {
     ){
         return lessonProgressRepository.findLessonProgressSummaryByUnitIdAndUserId(unitId, userId);
     }
+
 }

--- a/src/main/java/gravit/code/progress/service/LessonProgressService.java
+++ b/src/main/java/gravit/code/progress/service/LessonProgressService.java
@@ -22,14 +22,12 @@ public class LessonProgressService {
             long userId,
             int learningTime
     ) {
-        return lessonProgressRepository.findByLessonIdAndUserId(lessonId, userId)
-                .orElseGet(() -> {
-                    LessonProgress newLessonProgress = LessonProgress.create(userId, lessonId);
+        LessonProgress lessonProgress = lessonProgressRepository.findByLessonIdAndUserId(lessonId, userId)
+                .orElseGet(() -> LessonProgress.create(userId, lessonId));
 
-                    newLessonProgress.updateStatus(learningTime);
+        lessonProgress.updateStatus(learningTime);
 
-                    return lessonProgressRepository.save(newLessonProgress);
-                });
+        return lessonProgressRepository.save(lessonProgress);
     }
 
     @Transactional(readOnly = true)

--- a/src/main/java/gravit/code/user/domain/UserLevel.java
+++ b/src/main/java/gravit/code/user/domain/UserLevel.java
@@ -25,7 +25,7 @@ public class UserLevel {
     }
 
     public void updateXp(int xp){
-        this.xp = xp;
+        this.xp += xp;
         updateLevel(this.xp);
     }
 


### PR DESCRIPTION
## 📋 이슈 번호
- close #200 

## 🛠 구현 사항
- 중복된 레슨 풀이를 저장하는 로직을 업데이트하였습니다.

## 🤔 추가 고려 사항

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- 신기능
  - 학습 결과 저장이 첫 시도/재시도에 따라 분기되어 처리됩니다.
  - 첫 시도 시 진도가 자동 생성·갱신되고, 학습 완료 관련 이벤트가 발행됩니다.
  - 첫 시도에 레벨 경험치 20이 부여됩니다; 재시도에는 경험치가 부여되지 않습니다.
- 버그 수정
  - 레벨 경험치가 덮어쓰기 대신 누적되도록 수정했습니다.
- 테스트
  - 첫 시도, 재시도 및 예외 상황을 포괄하는 통합 테스트를 강화했습니다.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->