### PR TITLE
merge: dev -> main

### DIFF
--- a/src/main/java/gravit/code/admin/controller/docs/AdminOptionControllerDocs.java
+++ b/src/main/java/gravit/code/admin/controller/docs/AdminOptionControllerDocs.java
@@ -22,32 +22,12 @@ public interface AdminOptionControllerDocs {
             "🔐 <strong>관리자 권한 필요</strong><br>")
     @ApiResponses({
             @ApiResponse(responseCode = "204", description = "✅ 옵션 생성 성공"),
-            @ApiResponse(responseCode = "GLOBAL_4001", description = "🚨 유효성 검사 실패",
-                    content = @Content(mediaType = MediaType.APPLICATION_JSON_VALUE,
-                            examples = {
-                                    @ExampleObject(
-                                            name = "유효성 검사 실패",
-                                            value = "{\"error\" : \"GLOBAL_4001\", \"message\" : \"유효성 검사 실패\"}"
-                                    )
-                            },
-                            schema = @Schema(implementation = ErrorResponse.class))
-            ),
             @ApiResponse(responseCode = "PROBLEM_4041", description = "🚨 문제 조회 실패",
                     content = @Content(mediaType = MediaType.APPLICATION_JSON_VALUE,
                             examples = {
                                     @ExampleObject(
                                             name = "문제 조회 실패",
                                             value = "{\"error\" : \"PROBLEM_4041\", \"message\" : \"문제 조회에 실패하였습니다.\"}"
-                                    )
-                            },
-                            schema = @Schema(implementation = ErrorResponse.class))
-            ),
-            @ApiResponse(responseCode = "GLOBAL_5001", description = "🚨 예기치 못한 예외 발생",
-                    content = @Content(mediaType = MediaType.APPLICATION_JSON_VALUE,
-                            examples = {
-                                    @ExampleObject(
-                                            name = "예기치 못한 예외 발생",
-                                            value = "{\"error\" : \"GLOBAL_5001\", \"message\" : \"예기치 못한 예외 발생\"}"
                                     )
                             },
                             schema = @Schema(implementation = ErrorResponse.class))
@@ -66,26 +46,6 @@ public interface AdminOptionControllerDocs {
                                     @ExampleObject(
                                             name = "옵션 조회 실패",
                                             value = "{\"error\" : \"OPTION_4041\", \"message\" : \"옵션 조회에 실패하였습니다.\"}"
-                                    )
-                            },
-                            schema = @Schema(implementation = ErrorResponse.class))
-            ),
-            @ApiResponse(responseCode = "GLOBAL_4001", description = "🚨 유효성 검사 실패",
-                    content = @Content(mediaType = MediaType.APPLICATION_JSON_VALUE,
-                            examples = {
-                                    @ExampleObject(
-                                            name = "유효성 검사 실패",
-                                            value = "{\"error\" : \"GLOBAL_4001\", \"message\" : \"유효성 검사 실패\"}"
-                                    )
-                            },
-                            schema = @Schema(implementation = ErrorResponse.class))
-            ),
-            @ApiResponse(responseCode = "GLOBAL_5001", description = "🚨 예기치 못한 예외 발생",
-                    content = @Content(mediaType = MediaType.APPLICATION_JSON_VALUE,
-                            examples = {
-                                    @ExampleObject(
-                                            name = "예기치 못한 예외 발생",
-                                            value = "{\"error\" : \"GLOBAL_5001\", \"message\" : \"예기치 못한 예외 발생\"}"
                                     )
                             },
                             schema = @Schema(implementation = ErrorResponse.class))
@@ -108,16 +68,6 @@ public interface AdminOptionControllerDocs {
                             },
                             schema = @Schema(implementation = ErrorResponse.class))
             ),
-            @ApiResponse(responseCode = "GLOBAL_5001", description = "🚨 예기치 못한 예외 발생",
-                    content = @Content(mediaType = MediaType.APPLICATION_JSON_VALUE,
-                            examples = {
-                                    @ExampleObject(
-                                            name = "예기치 못한 예외 발생",
-                                            value = "{\"error\" : \"GLOBAL_5001\", \"message\" : \"예기치 못한 예외 발생\"}"
-                                    )
-                            },
-                            schema = @Schema(implementation = ErrorResponse.class))
-            )
     })
     @DeleteMapping("/{optionId}")
     ResponseEntity<Void> deleteOption(@PathVariable("optionId") Long optionId);

--- a/src/main/java/gravit/code/admin/controller/docs/AdminProblemControllerDocs.java
+++ b/src/main/java/gravit/code/admin/controller/docs/AdminProblemControllerDocs.java
@@ -32,16 +32,6 @@ public interface AdminProblemControllerDocs {
                                     )
                             },
                             schema = @Schema(implementation = ErrorResponse.class))
-            ),
-            @ApiResponse(responseCode = "GLOBAL_5001", description = "🚨 예기치 못한 예외 발생",
-                    content = @Content(mediaType = MediaType.APPLICATION_JSON_VALUE,
-                            examples = {
-                                    @ExampleObject(
-                                            name = "예기치 못한 예외 발생",
-                                            value = "{\"error\" : \"GLOBAL_5001\", \"message\" : \"예기치 못한 예외 발생\"}"
-                                    )
-                            },
-                            schema = @Schema(implementation = ErrorResponse.class))
             )
     })
     @GetMapping("/{problemId}")
@@ -50,27 +40,7 @@ public interface AdminProblemControllerDocs {
     @Operation(summary = "문제 생성", description = "새로운 문제를 생성합니다<br>" +
             "🔐 <strong>관리자 권한 필요</strong><br>")
     @ApiResponses({
-            @ApiResponse(responseCode = "201", description = "✅ 문제 생성 성공"),
-            @ApiResponse(responseCode = "GLOBAL_4001", description = "🚨 유효성 검사 실패",
-                    content = @Content(mediaType = MediaType.APPLICATION_JSON_VALUE,
-                            examples = {
-                                    @ExampleObject(
-                                            name = "유효성 검사 실패",
-                                            value = "{\"error\" : \"GLOBAL_4001\", \"message\" : \"유효성 검사 실패\"}"
-                                    )
-                            },
-                            schema = @Schema(implementation = ErrorResponse.class))
-            ),
-            @ApiResponse(responseCode = "GLOBAL_5001", description = "🚨 예기치 못한 예외 발생",
-                    content = @Content(mediaType = MediaType.APPLICATION_JSON_VALUE,
-                            examples = {
-                                    @ExampleObject(
-                                            name = "예기치 못한 예외 발생",
-                                            value = "{\"error\" : \"GLOBAL_5001\", \"message\" : \"예기치 못한 예외 발생\"}"
-                                    )
-                            },
-                            schema = @Schema(implementation = ErrorResponse.class))
-            )
+            @ApiResponse(responseCode = "201", description = "✅ 문제 생성 성공")
     })
     @PostMapping
     ResponseEntity<Void> createProblem(@Valid @RequestBody ProblemCreateRequest request);
@@ -85,26 +55,6 @@ public interface AdminProblemControllerDocs {
                                     @ExampleObject(
                                             name = "문제 조회 실패",
                                             value = "{\"error\" : \"PROBLEM_4041\", \"message\" : \"문제 조회에 실패하였습니다.\"}"
-                                    )
-                            },
-                            schema = @Schema(implementation = ErrorResponse.class))
-            ),
-            @ApiResponse(responseCode = "GLOBAL_4001", description = "🚨 유효성 검사 실패",
-                    content = @Content(mediaType = MediaType.APPLICATION_JSON_VALUE,
-                            examples = {
-                                    @ExampleObject(
-                                            name = "유효성 검사 실패",
-                                            value = "{\"error\" : \"GLOBAL_4001\", \"message\" : \"유효성 검사 실패\"}"
-                                    )
-                            },
-                            schema = @Schema(implementation = ErrorResponse.class))
-            ),
-            @ApiResponse(responseCode = "GLOBAL_5001", description = "🚨 예기치 못한 예외 발생",
-                    content = @Content(mediaType = MediaType.APPLICATION_JSON_VALUE,
-                            examples = {
-                                    @ExampleObject(
-                                            name = "예기치 못한 예외 발생",
-                                            value = "{\"error\" : \"GLOBAL_5001\", \"message\" : \"예기치 못한 예외 발생\"}"
                                     )
                             },
                             schema = @Schema(implementation = ErrorResponse.class))
@@ -123,16 +73,6 @@ public interface AdminProblemControllerDocs {
                                     @ExampleObject(
                                             name = "문제 조회 실패",
                                             value = "{\"error\" : \"PROBLEM_4041\", \"message\" : \"문제 조회에 실패하였습니다.\"}"
-                                    )
-                            },
-                            schema = @Schema(implementation = ErrorResponse.class))
-            ),
-            @ApiResponse(responseCode = "GLOBAL_5001", description = "🚨 예기치 못한 예외 발생",
-                    content = @Content(mediaType = MediaType.APPLICATION_JSON_VALUE,
-                            examples = {
-                                    @ExampleObject(
-                                            name = "예기치 못한 예외 발생",
-                                            value = "{\"error\" : \"GLOBAL_5001\", \"message\" : \"예기치 못한 예외 발생\"}"
                                     )
                             },
                             schema = @Schema(implementation = ErrorResponse.class))

--- a/src/main/java/gravit/code/admin/controller/docs/AdminReportControllerDocs.java
+++ b/src/main/java/gravit/code/admin/controller/docs/AdminReportControllerDocs.java
@@ -25,17 +25,7 @@ public interface AdminReportControllerDocs {
     @Operation(summary = "신고 목록 조회", description = "페이징된 신고 목록을 조회합니다<br>" +
             "🔐 <strong>관리자 권한 필요</strong><br>")
     @ApiResponses({
-            @ApiResponse(responseCode = "200", description = "✅ 신고 목록 조회 성공"),
-            @ApiResponse(responseCode = "GLOBAL_5001", description = "🚨 예기치 못한 예외 발생",
-                    content = @Content(mediaType = MediaType.APPLICATION_JSON_VALUE,
-                            examples = {
-                                    @ExampleObject(
-                                            name = "예기치 못한 예외 발생",
-                                            value = "{\"error\" : \"GLOBAL_5001\", \"message\" : \"예기치 못한 예외 발생\"}"
-                                    )
-                            },
-                            schema = @Schema(implementation = ErrorResponse.class))
-            )
+            @ApiResponse(responseCode = "200", description = "✅ 신고 목록 조회 성공")
     })
     @GetMapping
     ResponseEntity<List<ReportSummaryResponse>> getAllReports(@RequestParam(defaultValue = "0") int page);
@@ -50,16 +40,6 @@ public interface AdminReportControllerDocs {
                                     @ExampleObject(
                                             name = "신고 조회 실패",
                                             value = "{\"error\" : \"REPORT_4041\", \"message\" : \"신고 조회에 실패하였습니다.\"}"
-                                    )
-                            },
-                            schema = @Schema(implementation = ErrorResponse.class))
-            ),
-            @ApiResponse(responseCode = "GLOBAL_5001", description = "🚨 예기치 못한 예외 발생",
-                    content = @Content(mediaType = MediaType.APPLICATION_JSON_VALUE,
-                            examples = {
-                                    @ExampleObject(
-                                            name = "예기치 못한 예외 발생",
-                                            value = "{\"error\" : \"GLOBAL_5001\", \"message\" : \"예기치 못한 예외 발생\"}"
                                     )
                             },
                             schema = @Schema(implementation = ErrorResponse.class))
@@ -78,16 +58,6 @@ public interface AdminReportControllerDocs {
                                     @ExampleObject(
                                             name = "신고 조회 실패",
                                             value = "{\"error\" : \"REPORT_4041\", \"message\" : \"신고 조회에 실패하였습니다.\"}"
-                                    )
-                            },
-                            schema = @Schema(implementation = ErrorResponse.class))
-            ),
-            @ApiResponse(responseCode = "GLOBAL_5001", description = "🚨 예기치 못한 예외 발생",
-                    content = @Content(mediaType = MediaType.APPLICATION_JSON_VALUE,
-                            examples = {
-                                    @ExampleObject(
-                                            name = "예기치 못한 예외 발생",
-                                            value = "{\"error\" : \"GLOBAL_5001\", \"message\" : \"예기치 못한 예외 발생\"}"
                                     )
                             },
                             schema = @Schema(implementation = ErrorResponse.class))

--- a/src/main/java/gravit/code/admin/service/AdminOptionService.java
+++ b/src/main/java/gravit/code/admin/service/AdminOptionService.java
@@ -37,6 +37,9 @@ public class AdminOptionService {
 
     @Transactional
     public void deleteOption(Long optionId){
+        if(!optionRepository.existsById(optionId))
+            throw new RestApiException(CustomErrorCode.OPTION_NOT_FOUND);
+
         optionRepository.deleteById(optionId);
     }
 }

--- a/src/main/java/gravit/code/admin/service/AdminProblemService.java
+++ b/src/main/java/gravit/code/admin/service/AdminProblemService.java
@@ -55,6 +55,10 @@ public class AdminProblemService {
 
     @Transactional
     public void deleteProblem(Long problemId){
+
+        if(!problemRepository.existsProblemById(problemId))
+            throw new RestApiException(CustomErrorCode.PROBLEM_NOT_FOUND);
+
         problemRepository.deleteById(problemId);
         optionRepository.deleteAllByProblemId(problemId);
     }

--- a/src/main/java/gravit/code/admin/service/AdminReportService.java
+++ b/src/main/java/gravit/code/admin/service/AdminReportService.java
@@ -33,7 +33,7 @@ public class AdminReportService {
     }
 
     @Transactional
-    public Boolean updateResolvedStatus(Long reportId){
+    public void updateResolvedStatus(Long reportId){
         Report report = reportRepository.findById(reportId)
                 .orElseThrow(() -> new RestApiException(CustomErrorCode.REPORT_NOT_FOUND));
 
@@ -41,6 +41,5 @@ public class AdminReportService {
 
         reportRepository.save(report);
 
-        return report.isResolved();
     }
 }

--- a/src/main/java/gravit/code/global/exception/domain/CustomErrorCode.java
+++ b/src/main/java/gravit/code/global/exception/domain/CustomErrorCode.java
@@ -62,7 +62,6 @@ public enum CustomErrorCode implements ErrorCode {
     // Report
     REPORT_NOT_FOUND(HttpStatus.NOT_FOUND, "REPORT_4041", "신고 조회에 실패하였습니다."),
     REPORT_TYPE_NOT_AVAILABLE(HttpStatus.BAD_REQUEST, "REPORT_4001", "지원하지 않는 신고 유형입니다."),
-    ALREADY_SUBMITTED_REPORT(HttpStatus.BAD_REQUEST, "REPORT_4002", "이미 제출된 신고입니다."),
 
     // Mission
     MISSION_NOT_FOUND(HttpStatus.NOT_FOUND, "MISSION_4041", "사용자의 미션 조회에 실패하였습니다."),

--- a/src/main/java/gravit/code/learning/controller/docs/LearningControllerDocs.java
+++ b/src/main/java/gravit/code/learning/controller/docs/LearningControllerDocs.java
@@ -29,7 +29,7 @@ import java.util.List;
 @Tag(name = "Learning API", description = "학습 관련 API")
 public interface LearningControllerDocs {
 
-    @Operation(summary = "챕터 목록 조회", description = "사용자의 챕터 진행 상황과 함께 전체 챕터 목록을 조회합니다<br>" +
+    @Operation(summary = "챕터 조회", description = "유저의 챕터 진행도를 포함한 챕터 목록을 조회합니다.<br>" +
             "🔐 <strong>Jwt 필요</strong><br>")
     @ApiResponses({
             @ApiResponse(responseCode = "200", description = "✅ 챕터 목록 조회 성공"),
@@ -42,25 +42,25 @@ public interface LearningControllerDocs {
                                     )
                             },
                             schema = @Schema(implementation = ErrorResponse.class))
-            ),
-            @ApiResponse(responseCode = "GLOBAL_5001", description = "🚨 예기치 못한 예외 발생",
-                    content = @Content(mediaType = MediaType.APPLICATION_JSON_VALUE,
-                            examples = {
-                                    @ExampleObject(
-                                            name = "예기치 못한 예외 발생",
-                                            value = "{\"error\" : \"GLOBAL_5001\", \"message\" : \"예기치 못한 예외 발생\"}"
-                                    )
-                            },
-                            schema = @Schema(implementation = ErrorResponse.class))
             )
     })
     @GetMapping("/chapters")
     ResponseEntity<List<ChapterProgressDetailResponse>> getAllChapters(@AuthenticationPrincipal LoginUser loginUser);
 
-    @Operation(summary = "유닛 목록 조회", description = "특정 챕터의 유닛 목록과 레슨 진행 상황을 조회합니다<br>" +
+    @Operation(summary = "유닛 조회", description = "유저의 유닛 진행도를 포함한 유닛 목록을 조회합니다.<br>" +
             "🔐 <strong>Jwt 필요</strong><br>")
     @ApiResponses({
             @ApiResponse(responseCode = "200", description = "✅ 유닛 목록 조회 성공"),
+            @ApiResponse(responseCode = "CHAPTER_4041", description = "🚨 챕터 조회 실패",
+                    content = @Content(mediaType = MediaType.APPLICATION_JSON_VALUE,
+                            examples = {
+                                    @ExampleObject(
+                                            name = "챕터 조회 실패",
+                                            value = "{\"error\" : \"CHAPTER_4041\", \"message\" : \"챕터 조회에 실패하였습니다.\"}"
+                                    )
+                            },
+                            schema = @Schema(implementation = ErrorResponse.class))
+            ),
             @ApiResponse(responseCode = "USER_4041", description = "🚨 유저 조회 실패",
                     content = @Content(mediaType = MediaType.APPLICATION_JSON_VALUE,
                             examples = {
@@ -70,26 +70,36 @@ public interface LearningControllerDocs {
                                     )
                             },
                             schema = @Schema(implementation = ErrorResponse.class))
-            ),
-            @ApiResponse(responseCode = "GLOBAL_5001", description = "🚨 예기치 못한 예외 발생",
-                    content = @Content(mediaType = MediaType.APPLICATION_JSON_VALUE,
-                            examples = {
-                                    @ExampleObject(
-                                            name = "예기치 못한 예외 발생",
-                                            value = "{\"error\" : \"GLOBAL_5001\", \"message\" : \"예기치 못한 예외 발생\"}"
-                                    )
-                            },
-                            schema = @Schema(implementation = ErrorResponse.class))
             )
     })
     @GetMapping("/{chapterId}/units")
     ResponseEntity<UnitPageResponse> getAllUnitsInChapter(@AuthenticationPrincipal LoginUser loginUser,
                                                           @PathVariable("chapterId") Long chapterId);
 
-    @Operation(summary = "레슨 문제 목록 조회", description = "특정 레슨에 포함된 문제 목록을 조회합니다<br>" +
+    @Operation(summary = "레슨 문제 조회", description = "특정 레슨을 구성하는 문제 목록을 조회합니다.<br>" +
             "🔐 <strong>Jwt 필요</strong><br>")
     @ApiResponses({
             @ApiResponse(responseCode = "200", description = "✅ 레슨 문제 목록 조회 성공"),
+            @ApiResponse(responseCode = "CHAPTER_4041", description = "🚨 챕터 조회 실패",
+                    content = @Content(mediaType = MediaType.APPLICATION_JSON_VALUE,
+                            examples = {
+                                    @ExampleObject(
+                                            name = "챕터 조회 실패",
+                                            value = "{\"error\" : \"CHAPTER_4041\", \"message\" : \"챕터 조회에 실패하였습니다.\"}"
+                                    )
+                            },
+                            schema = @Schema(implementation = ErrorResponse.class))
+            ),
+            @ApiResponse(responseCode = "LESSON_4041", description = "🚨 레슨 조회 실패",
+                    content = @Content(mediaType = MediaType.APPLICATION_JSON_VALUE,
+                            examples = {
+                                    @ExampleObject(
+                                            name = "레슨 조회 실패",
+                                            value = "{\"error\" : \"LESSON_4041\", \"message\" : \"레슨 조회에 실패하였습니다.\"}"
+                                    )
+                            },
+                            schema = @Schema(implementation = ErrorResponse.class))
+            ),
             @ApiResponse(responseCode = "PROBLEM_4041", description = "🚨 문제 조회 실패",
                     content = @Content(mediaType = MediaType.APPLICATION_JSON_VALUE,
                             examples = {
@@ -100,12 +110,12 @@ public interface LearningControllerDocs {
                             },
                             schema = @Schema(implementation = ErrorResponse.class))
             ),
-            @ApiResponse(responseCode = "GLOBAL_5001", description = "🚨 예기치 못한 예외 발생",
+            @ApiResponse(responseCode = "OPTION_4041", description = "🚨 옵션 조회 실패",
                     content = @Content(mediaType = MediaType.APPLICATION_JSON_VALUE,
                             examples = {
                                     @ExampleObject(
-                                            name = "예기치 못한 예외 발생",
-                                            value = "{\"error\" : \"GLOBAL_5001\", \"message\" : \"예기치 못한 예외 발생\"}"
+                                            name = "옵션 조회 실패",
+                                            value = "{\"error\" : \"OPTION_4041\", \"message\" : \"옵션 조회에 실패하였습니다.\"}"
                                     )
                             },
                             schema = @Schema(implementation = ErrorResponse.class))
@@ -128,16 +138,6 @@ public interface LearningControllerDocs {
                             },
                             schema = @Schema(implementation = ErrorResponse.class))
             ),
-            @ApiResponse(responseCode = "LESSON_4041", description = "🚨 레슨 조회 실패",
-                    content = @Content(mediaType = MediaType.APPLICATION_JSON_VALUE,
-                            examples = {
-                                    @ExampleObject(
-                                            name = "레슨 조회 실패",
-                                            value = "{\"error\" : \"LESSON_4041\", \"message\" : \"레슨 조회에 실패하였습니다.\"}"
-                                    )
-                            },
-                            schema = @Schema(implementation = ErrorResponse.class))
-            ),
             @ApiResponse(responseCode = "UNIT_4041", description = "🚨 유닛 조회 실패",
                     content = @Content(mediaType = MediaType.APPLICATION_JSON_VALUE,
                             examples = {
@@ -148,32 +148,12 @@ public interface LearningControllerDocs {
                             },
                             schema = @Schema(implementation = ErrorResponse.class))
             ),
-            @ApiResponse(responseCode = "CHAPTER_4041", description = "🚨 챕터 조회 실패",
+            @ApiResponse(responseCode = "LESSON_4041", description = "🚨 레슨 조회 실패",
                     content = @Content(mediaType = MediaType.APPLICATION_JSON_VALUE,
                             examples = {
                                     @ExampleObject(
-                                            name = "챕터 조회 실패",
-                                            value = "{\"error\" : \"CHAPTER_4041\", \"message\" : \"챕터 조회에 실패하였습니다.\"}"
-                                    )
-                            },
-                            schema = @Schema(implementation = ErrorResponse.class))
-            ),
-            @ApiResponse(responseCode = "GLOBAL_4001", description = "🚨 유효성 검사 실패",
-                    content = @Content(mediaType = MediaType.APPLICATION_JSON_VALUE,
-                            examples = {
-                                    @ExampleObject(
-                                            name = "유효성 검사 실패",
-                                            value = "{\"error\" : \"GLOBAL_4001\", \"message\" : \"유효성 검사 실패\"}"
-                                    )
-                            },
-                            schema = @Schema(implementation = ErrorResponse.class))
-            ),
-            @ApiResponse(responseCode = "GLOBAL_5001", description = "🚨 예기치 못한 예외 발생",
-                    content = @Content(mediaType = MediaType.APPLICATION_JSON_VALUE,
-                            examples = {
-                                    @ExampleObject(
-                                            name = "예기치 못한 예외 발생",
-                                            value = "{\"error\" : \"GLOBAL_5001\", \"message\" : \"예기치 못한 예외 발생\"}"
+                                            name = "레슨 조회 실패",
+                                            value = "{\"error\" : \"LESSON_4041\", \"message\" : \"레슨 조회에 실패하였습니다.\"}"
                                     )
                             },
                             schema = @Schema(implementation = ErrorResponse.class))
@@ -187,52 +167,12 @@ public interface LearningControllerDocs {
             "🔐 <strong>Jwt 필요</strong><br>")
     @ApiResponses({
             @ApiResponse(responseCode = "200", description = "✅ 문제 신고 제출 성공"),
-            @ApiResponse(responseCode = "USER_4041", description = "🚨 유저 조회 실패",
-                    content = @Content(mediaType = MediaType.APPLICATION_JSON_VALUE,
-                            examples = {
-                                    @ExampleObject(
-                                            name = "유저 조회 실패",
-                                            value = "{\"error\" : \"USER_4041\", \"message\" : \"존재하지 않는 유저입니다.\"}"
-                                    )
-                            },
-                            schema = @Schema(implementation = ErrorResponse.class))
-            ),
             @ApiResponse(responseCode = "PROBLEM_4041", description = "🚨 문제 조회 실패",
                     content = @Content(mediaType = MediaType.APPLICATION_JSON_VALUE,
                             examples = {
                                     @ExampleObject(
                                             name = "문제 조회 실패",
                                             value = "{\"error\" : \"PROBLEM_4041\", \"message\" : \"문제 조회에 실패하였습니다.\"}"
-                                    )
-                            },
-                            schema = @Schema(implementation = ErrorResponse.class))
-            ),
-            @ApiResponse(responseCode = "REPORT_DUPLICATE", description = "🚨 중복 신고",
-                    content = @Content(mediaType = MediaType.APPLICATION_JSON_VALUE,
-                            examples = {
-                                    @ExampleObject(
-                                            name = "중복 신고",
-                                            value = "{\"error\" : \"REPORT_DUPLICATE\", \"message\" : \"이미 신고한 문제입니다.\"}"
-                                    )
-                            },
-                            schema = @Schema(implementation = ErrorResponse.class))
-            ),
-            @ApiResponse(responseCode = "GLOBAL_4001", description = "🚨 유효성 검사 실패",
-                    content = @Content(mediaType = MediaType.APPLICATION_JSON_VALUE,
-                            examples = {
-                                    @ExampleObject(
-                                            name = "유효성 검사 실패",
-                                            value = "{\"error\" : \"GLOBAL_4001\", \"message\" : \"유효성 검사 실패\"}"
-                                    )
-                            },
-                            schema = @Schema(implementation = ErrorResponse.class))
-            ),
-            @ApiResponse(responseCode = "GLOBAL_5001", description = "🚨 예기치 못한 예외 발생",
-                    content = @Content(mediaType = MediaType.APPLICATION_JSON_VALUE,
-                            examples = {
-                                    @ExampleObject(
-                                            name = "예기치 못한 예외 발생",
-                                            value = "{\"error\" : \"GLOBAL_5001\", \"message\" : \"예기치 못한 예외 발생\"}"
                                     )
                             },
                             schema = @Schema(implementation = ErrorResponse.class))

--- a/src/main/java/gravit/code/learning/domain/OptionRepository.java
+++ b/src/main/java/gravit/code/learning/domain/OptionRepository.java
@@ -13,4 +13,5 @@ public interface OptionRepository {
     Optional<Option> findById(Long optionId);
     void deleteById(Long optionId);
     void deleteAllByProblemId(Long problemId);
+    boolean existsById(Long optionId);
 }

--- a/src/main/java/gravit/code/learning/infrastructure/OptionRepositoryImpl.java
+++ b/src/main/java/gravit/code/learning/infrastructure/OptionRepositoryImpl.java
@@ -49,4 +49,9 @@ public class OptionRepositoryImpl implements OptionRepository {
     public void deleteAllByProblemId(Long problemId){
         optionJpaRepository.deleteAllByProblemId(problemId);
     }
+
+    @Override
+    public boolean existsById(Long optionId){
+        return optionJpaRepository.existsById(optionId);
+    }
 }

--- a/src/main/java/gravit/code/mainPage/controller/docs/MainPageControllerDocs.java
+++ b/src/main/java/gravit/code/mainPage/controller/docs/MainPageControllerDocs.java
@@ -22,16 +22,6 @@ public interface MainPageControllerDocs {
             "🔐 <strong>Jwt 필요</strong><br>")
     @ApiResponses({
             @ApiResponse(responseCode = "200", description = "✅ 메인 페이지 정보 조회 성공"),
-            @ApiResponse(responseCode = "USER_4041", description = "🚨 유저 조회 실패",
-                    content = @Content(mediaType = MediaType.APPLICATION_JSON_VALUE,
-                            examples = {
-                                    @ExampleObject(
-                                            name = "유저 조회 실패",
-                                            value = "{\"error\" : \"USER_4041\", \"message\" : \"존재하지 않는 유저입니다.\"}"
-                                    )
-                            },
-                            schema = @Schema(implementation = ErrorResponse.class))
-            ),
             @ApiResponse(responseCode = "RECENT_LEARNING_4041", description = "🚨 최근 학습 정보 조회 실패",
                     content = @Content(mediaType = MediaType.APPLICATION_JSON_VALUE,
                             examples = {
@@ -42,16 +32,6 @@ public interface MainPageControllerDocs {
                             },
                             schema = @Schema(implementation = ErrorResponse.class))
             ),
-            @ApiResponse(responseCode = "GLOBAL_5001", description = "🚨 예기치 못한 예외 발생",
-                    content = @Content(mediaType = MediaType.APPLICATION_JSON_VALUE,
-                            examples = {
-                                    @ExampleObject(
-                                            name = "예기치 못한 예외 발생",
-                                            value = "{\"error\" : \"GLOBAL_5001\", \"message\" : \"예기치 못한 예외 발생\"}"
-                                    )
-                            },
-                            schema = @Schema(implementation = ErrorResponse.class))
-            )
     })
     @GetMapping
     ResponseEntity<MainPageResponse> getMainPage(@AuthenticationPrincipal LoginUser loginUser);

--- a/src/test/java/gravit/code/learning/controller/LearningControllerTest.java
+++ b/src/test/java/gravit/code/learning/controller/LearningControllerTest.java
@@ -448,26 +448,26 @@ class LearningControllerTest {
                     .andExpect(status().is4xxClientError());
         }
 
-        @Test
-        @WithMockLoginUser
-        @DisplayName("이미 제출된 신고라면 예외를 반환한다.")
-        void withAlreadySubmittedReport() throws Exception{
-            //given
-            long userId = 1L;
-
-            doThrow(new RestApiException(CustomErrorCode.ALREADY_SUBMITTED_REPORT)).when(reportService).submitProblemReport(userId, validRequest);
-
-            //when
-            ResultActions resultActions = mockMvc.perform(post("/api/v1/learning/reports")
-                    .contentType(MediaType.APPLICATION_JSON)
-                    .content(objectMapper.writeValueAsString(validRequest))
-                    .with(csrf()));
-
-            //then
-            resultActions
-                    .andDo(print())
-                    .andExpect(status().is4xxClientError());
-        }
+//        @Test
+//        @WithMockLoginUser
+//        @DisplayName("이미 제출된 신고라면 예외를 반환한다.")
+//        void withAlreadySubmittedReport() throws Exception{
+//            //given
+//            long userId = 1L;
+//
+//            doThrow(new RestApiException(CustomErrorCode.ALREADY_SUBMITTED_REPORT)).when(reportService).submitProblemReport(userId, validRequest);
+//
+//            //when
+//            ResultActions resultActions = mockMvc.perform(post("/api/v1/learning/reports")
+//                    .contentType(MediaType.APPLICATION_JSON)
+//                    .content(objectMapper.writeValueAsString(validRequest))
+//                    .with(csrf()));
+//
+//            //then
+//            resultActions
+//                    .andDo(print())
+//                    .andExpect(status().is4xxClientError());
+//        }
 
         @Test
         @WithMockLoginUser


### PR DESCRIPTION
## 📋 이슈 번호

## 🛠 구현 사항

## 🤔 추가 고려 사항

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- 문서
  - API 문서에서 중복/전역 에러 응답(GLOBAL_4001, GLOBAL_5001 등) 정리 및 삭제.
  - 챕터/유닛/레슨/문제/옵션 조회 실패에 대한 404 에러 코드와 예시 추가 및 설명 업데이트.
  - 메인 페이지, 어드민 문제/옵션/리포트 문서의 불필요한 에러 케이스 제거.
- 버그 수정
  - 문제/옵션 삭제 시 존재하지 않는 항목에 대해 명확히 404 에러를 반환하도록 보완.
- 테스트
  - 중복 신고(ALREADY_SUBMITTED_REPORT) 관련 테스트 비활성화.
- 작업
  - REPORT_4002(ALREADY_SUBMITTED_REPORT) 오류 코드 제거.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->