### PR TITLE
hotfix: 학습 저장 완료시, 챕터 아이디와 레슨 이름 함께 반환하도록 수정 (#225)

### DIFF
--- a/src/main/java/gravit/code/learning/dto/response/LearningResultSaveResponse.java
+++ b/src/main/java/gravit/code/learning/dto/response/LearningResultSaveResponse.java
@@ -7,6 +7,19 @@ import lombok.Builder;
 @Builder
 @Schema(description = "풀이 결과 저장 Response")
 public record LearningResultSaveResponse(
+
+        @Schema(
+                description = "챕터 아이디",
+                example = "1"
+        )
+        long chapterId,
+
+        @Schema(
+                description = "레슨 이름",
+                example = "배열 기초"
+        )
+        String lessonName,
+
         @Schema(
                 description = "리그 이름",
                 example = "브론즈 1"
@@ -27,9 +40,13 @@ public record LearningResultSaveResponse(
 ) {
     public static  LearningResultSaveResponse create(
             UserLevelResponse userLevelResponse,
-            String leagueName
+            String leagueName,
+            long chapterId,
+            String lessonName
     ){
         return LearningResultSaveResponse.builder()
+                .chapterId(chapterId)
+                .lessonName(lessonName)
                 .leagueName(leagueName)
                 .currentLevel(userLevelResponse.currentLevel())
                 .xp(userLevelResponse.xp())

--- a/src/main/java/gravit/code/learning/facade/LearningFacade.java
+++ b/src/main/java/gravit/code/learning/facade/LearningFacade.java
@@ -99,17 +99,19 @@ public class LearningFacade {
 
         checkAndUpdateLearningProgress(learningIds.chapterId(), learningIds.unitId(), userId);
 
+        String lessonName = lessonService.getLessonNameByLessonId(request.lessonId());
+
         LearningResultSaveResponse response;
         if(lessonProgress.getAttemptCount() == 1){ // 레슨 첫번째 풀이라면,
 
-            response = saveLearningResultForFirstAttemptUser(userId, request);
+            response = saveLearningResultForFirstAttemptUser(userId, request, learningIds.chapterId(), lessonName);
 
             publisher.publishEvent(new UpdateLearningEvent(userId, learningIds.chapterId()));
             publisher.publishEvent(new LessonCompletedEvent(userId, 20, request.accuracy()));
             publisher.publishEvent(new LessonMissionEvent(userId, request.lessonId(), request.learningTime(), request.accuracy()));
             publisher.publishEvent(new QualifiedSolvedEvent(userId, request.learningTime(), request.accuracy()));
         }else{ // 레슨 첫번째 풀이가 아니라면,
-            response = saveLearningResultForRetryUser(userId, request);
+            response = saveLearningResultForRetryUser(userId, request, learningIds.chapterId(), lessonName);
 
             publisher.publishEvent(new UpdateLearningEvent(userId, learningIds.chapterId()));
         }
@@ -128,21 +130,21 @@ public class LearningFacade {
         }
     }
 
-    private LearningResultSaveResponse saveLearningResultForFirstAttemptUser(long userId, LearningResultSaveRequest request){
+    private LearningResultSaveResponse saveLearningResultForFirstAttemptUser(long userId, LearningResultSaveRequest request, Long chapterId, String lessonName){
 
         problemProgressService.saveProblemResults(userId, request.problemResults());
 
         String leagueName = userLeagueService.getUserLeagueName(userId);
         UserLevelResponse userLevelResponse = userService.updateUserLevelAndXp(userId, 20, request.accuracy());
 
-        return LearningResultSaveResponse.create(userLevelResponse, leagueName);
+        return LearningResultSaveResponse.create(userLevelResponse, leagueName, chapterId, lessonName);
     }
 
-    private LearningResultSaveResponse saveLearningResultForRetryUser(long userId, LearningResultSaveRequest request){
+    private LearningResultSaveResponse saveLearningResultForRetryUser(long userId, LearningResultSaveRequest request, Long chapterId, String lessonName){
 
         String leagueName = userLeagueService.getUserLeagueName(userId);
         UserLevelResponse userLevelResponse = userService.updateUserLevelAndXp(userId, 0, request.accuracy());
 
-        return LearningResultSaveResponse.create(userLevelResponse, leagueName);
+        return LearningResultSaveResponse.create(userLevelResponse, leagueName, chapterId, lessonName);
     }
 }

--- a/src/test/java/gravit/code/learning/controller/LearningControllerTest.java
+++ b/src/test/java/gravit/code/learning/controller/LearningControllerTest.java
@@ -357,7 +357,7 @@ class LearningControllerTest {
             //given
             long userId = 1L;
             UserLevelResponse userLevelResponse = UserLevelResponse.create(3, 150);
-            LearningResultSaveResponse learningResultSaveResponse = LearningResultSaveResponse.create(userLevelResponse, "브론즈 1");
+            LearningResultSaveResponse learningResultSaveResponse = LearningResultSaveResponse.create(userLevelResponse, "브론즈 1", 1L, "배열 기초");
 
             when(learningFacade.saveLearningResult(userId, validRequest)).thenReturn(learningResultSaveResponse);
 


### PR DESCRIPTION
## 📋 이슈 번호
- close #225 

## 🛠 구현 사항

## 🤔 추가 고려 사항

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- 신기능
  - 학습 결과 저장 응답에 챕터 ID와 레슨 이름이 포함됩니다.
  - 첫 시도 및 재도전 흐름 모두에서 챕터/레슨 정보가 반환되어 클라이언트에서 진행 상황 표시와 추적이 용이합니다.

- 테스트
  - 공개 응답 형식 변경에 맞춰 테스트를 업데이트했습니다.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->