### PR TITLE
fix: 미션 도메인 로직 일부 수정 (#244)

### DIFF
--- a/src/main/java/gravit/code/learning/facade/LearningFacade.java
+++ b/src/main/java/gravit/code/learning/facade/LearningFacade.java
@@ -128,6 +128,9 @@ public class LearningFacade {
         publisher.publishEvent(new UpdateLearningEvent(userId, learningIds.chapterId()));
 
         if(isFirstTry){
+            /**
+             * 아래 두 이벤트 발행이 로직적으로 중복되는 것은 아니지만 발행하는 이벤트의 이름을 봤을 때, 어 왜 두번 반복되지? 싶을 것 같아서 적절하게 수정이 필요해보임.
+             */
             publisher.publishEvent(new LessonCompletedEvent(userId, 20, request.lessonSubmissionSaveRequest().accuracy()));
             publisher.publishEvent(new LessonMissionEvent(userId, request.lessonSubmissionSaveRequest().lessonId(), request.lessonSubmissionSaveRequest().learningTime(), request.lessonSubmissionSaveRequest().accuracy()));
             publisher.publishEvent(new QualifiedSolvedEvent(userId, request.lessonSubmissionSaveRequest().learningTime(), request.lessonSubmissionSaveRequest().accuracy()));

--- a/src/main/java/gravit/code/mission/domain/Mission.java
+++ b/src/main/java/gravit/code/mission/domain/Mission.java
@@ -18,19 +18,19 @@ public class Mission {
     @Column(name = "mission_type",  nullable = false)
     private MissionType missionType;
 
-    @Column(name = "progress_rate", columnDefinition = "double precision", nullable = false)
+    @Column(name = "progress_rate", nullable = false)
     private double progressRate;
 
-    @Column(name = "is_completed", columnDefinition = "boolean", nullable = false)
+    @Column(name = "is_completed", nullable = false)
     private boolean isCompleted;
 
-    @Column(name = "user_id", columnDefinition = "bigint", nullable = false, unique = true)
+    @Column(name = "user_id", nullable = false, unique = true)
     private long userId;
 
     @Version
     private long version;
 
-    @Builder
+    @Builder(access = AccessLevel.PRIVATE)
     private Mission(
             MissionType missionType,
             long userId
@@ -91,8 +91,8 @@ public class Mission {
 
     // 학습 x분 완료하기 관련
     public void updateLearningMinutesProgress(int learningTime) {
-        // 학습 시간 상한 7분으로 설정
-        learningTime = Math.min(learningTime, 420);
+        // 학습 시간 상한 5분으로 설정
+        learningTime = Math.min(learningTime, 300);
 
         double targetMinutes = getTargetLearningMinutes();
         double studyTimeMinutes = learningTime / 60.0;
@@ -104,16 +104,15 @@ public class Mission {
     private double getTargetLearningMinutes() {
         return switch (this.missionType.name()) {
             case "LEARNING_MINUTES_FIVE" -> 5.0;
-            case "LEARNING_MINUTES_FIFTEEN" -> 15.0;
-            case "LEARNING_MINUTES_TWENTY" -> 20.0;
+            case "LEARNING_MINUTES_TEN" -> 10.0;
+            case "LEARNING_MINUTES_FIFTEEN" -> 14.0;
             default -> 1.0;
         };
     }
 
     // 유저 팔로우하기 관련
     public void updateFollowProgress(){
-        this.progressRate += 100.0;
-        this.isCompleted = true;
+        this.progressRate = 100.0;
     }
 
     public void reassignMission(){

--- a/src/main/java/gravit/code/mission/domain/MissionType.java
+++ b/src/main/java/gravit/code/mission/domain/MissionType.java
@@ -18,9 +18,9 @@ public enum MissionType {
     PERFECT_LESSONS_THREE(6, "정답율 100%로 레슨 3개 완료하기", 40, 6),
 
     // 학습 x분 완료하기
-    LEARNING_MINUTES_TEN(7, "학습 10분 완료하기", 25, 15),
-    LEARNING_MINUTES_FIFTEEN(8, "학습 15분 완료하기", 35, 10),
-    LEARNING_MINUTES_TWENTY(9, "학습 20분 완료하기", 40, 5),
+    LEARNING_MINUTES_FIVE(7, "학습 5분 완료하기", 25, 15),
+    LEARNING_MINUTES_TEN(8, "학습 10분 완료하기", 35, 10),
+    LEARNING_MINUTES_FIFTEEN(9, "학습 15분 완료하기", 40, 5),
 
     // 새로운 친구 팔로우하기
     FOLLOW_NEW_FRIEND(10, "새로운 친구 팔로우하기", 40, 5);

--- a/src/main/java/gravit/code/mission/service/MissionService.java
+++ b/src/main/java/gravit/code/mission/service/MissionService.java
@@ -120,15 +120,17 @@ public class MissionService {
 
         mission.updateFollowProgress();
 
+        mission.checkAndUpdateCompletionStatus();
+
         awardMissionXp(followMissionDto.userId(), mission.getMissionType().getAwardXp());
     }
 
     @Transactional(propagation = Propagation.REQUIRES_NEW)
     public void createMission(CreateMissionEvent createMissionDto) {
-        Mission mission = Mission.builder()
-                .missionType(RandomMissionGenerator.getRandomMissionType())
-                .userId(createMissionDto.userId())
-                .build();
+        Mission mission = Mission.create(
+                RandomMissionGenerator.getRandomMissionType(),
+                createMissionDto.userId()
+        );
 
         missionRepository.save(mission);
     }

--- a/src/main/java/gravit/code/user/service/UserService.java
+++ b/src/main/java/gravit/code/user/service/UserService.java
@@ -122,7 +122,7 @@ public class UserService {
         String newHandle = handleGenerator.generateUniqueHandle();
         user.restoreUser(newHandle);
     }
-
+    
     private UserLevelDetail getUserLevelDetail(long userId){
         UserLevel userLevel = userRepository.findUserLevelById(userId)
                 .orElseThrow(() -> new RestApiException(CustomErrorCode.USER_NOT_FOUND));

--- a/src/main/java/gravit/code/userLeague/service/UserLeagueService.java
+++ b/src/main/java/gravit/code/userLeague/service/UserLeagueService.java
@@ -25,6 +25,7 @@ public class UserLeagueService {
     private final LeagueRepository leagueRepository;
     private final SeasonService seasonService;
 
+    @Transactional(readOnly = true)
     public String getUserLeagueName(Long userId){
         return userLeagueRepository.findUserLeagueNameByUserId(userId)
                 .orElseThrow(() -> new RestApiException(CustomErrorCode.USER_LEAGUE_NOT_FOUND));


### PR DESCRIPTION
## 📋 이슈 번호
- close #244

## 🛠 구현 사항
미션 도메인의 세부 로직을 일부 업데이트하였습니다. 또한, 한 레슨당 문제수가 줄어듬을 고려하여 미션타입 중 '5, 15, 20분 학습 시, 경험치 지급'을 '5, 10, 15분 학습 시, 경험치 지급'으로 수정하였습니다.

## 🤔 추가 고려 사항

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

# 릴리스 노트

* **New Features**
  * 5분 학습 미션 추가
  * 레슨 완료 시 이벤트 알림 시스템 강화

* **Changes**
  * 10분 및 15분 학습 미션의 보상(경험치, 티켓) 업데이트
  * 20분 학습 미션 제거
  * 미션 진행 로직 개선

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->