### PR TITLE
feat: 개념노트 api 추가 및 서브모듈로 정적 md 파일 관리

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -1,0 +1,3 @@
+[submodule "src/main/resources/static/notes"]
+	path = src/main/resources/static/notes
+	url = https://github.com/Team-Gravit/gravit-cs-notes.git

--- a/src/main/java/gravit/code/note/controller/NoteController.java
+++ b/src/main/java/gravit/code/note/controller/NoteController.java
@@ -1,0 +1,51 @@
+package gravit.code.note.controller;
+
+import gravit.code.note.controller.docs.NoteControllerDocs;
+import java.nio.charset.StandardCharsets;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.core.io.ClassPathResource;
+import org.springframework.core.io.Resource;
+import org.springframework.http.ContentDisposition;
+import org.springframework.http.HttpHeaders;
+import org.springframework.http.MediaType;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.PathVariable;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+@RestController
+@RequestMapping("/api/v1/notes")
+@Slf4j
+public class NoteController implements NoteControllerDocs {
+
+    private static final String BASE_PATH = "static/notes";
+
+    @GetMapping("/{chapter}/{unit}")
+    public ResponseEntity<Resource> getNote(
+            @PathVariable("chapter") String chapter,
+            @PathVariable("unit") String unit
+    ){
+        try{
+            String filePath = String.format("%s/%s/%s.md", BASE_PATH, chapter, unit);
+            ClassPathResource resource = new ClassPathResource(filePath);
+
+            if(!resource.exists()){
+                return ResponseEntity.notFound().build();
+            }
+
+            HttpHeaders headers = new HttpHeaders();
+            headers.setContentType(MediaType.TEXT_MARKDOWN);
+            headers.setContentDisposition(
+                    ContentDisposition.inline()
+                            .filename(unit + ".md", StandardCharsets.UTF_8)
+                            .build()
+            );
+
+            return ResponseEntity.ok().headers(headers).body(resource);
+
+        }catch (Exception e){
+            return ResponseEntity.internalServerError().build();
+        }
+    }
+}

--- a/src/main/java/gravit/code/note/controller/docs/NoteControllerDocs.java
+++ b/src/main/java/gravit/code/note/controller/docs/NoteControllerDocs.java
@@ -1,0 +1,75 @@
+package gravit.code.note.controller.docs;
+
+import gravit.code.global.exception.domain.ErrorResponse;
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.media.Content;
+import io.swagger.v3.oas.annotations.media.ExampleObject;
+import io.swagger.v3.oas.annotations.media.Schema;
+import io.swagger.v3.oas.annotations.responses.ApiResponse;
+import io.swagger.v3.oas.annotations.responses.ApiResponses;
+import io.swagger.v3.oas.annotations.tags.Tag;
+import org.springframework.core.io.Resource;
+import org.springframework.http.MediaType;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.PathVariable;
+
+@Tag(name = "Note API", description = "개념 노트 관련 API")
+public interface NoteControllerDocs {
+
+    @Operation(
+            summary = "개념 노트 조회",
+            description = "챕터와 유닛 정보로 Markdown 형식의 개념 노트를 조회합니다. <br>" +
+                    "응답 본문은 Markdown 텍스트 데이터입니다. <br><br>" +
+                    "**파일 구조**: static/notes/{chapter}/{unit}.md <br>" +
+                    "**예시**: /api/v1/notes/algorithm/unit01 → static/notes/algorithm/unit01.md <br>" +
+                    "**챕터 리스트** : [algorithm, data-structure, network] <br>" +
+                    "**알고리즘 유닛 리스트** : unit01 ~ unit17 <br>" +
+                    "**자료구조 유닛 리스트** : unit01 ~ unit10 <br>" +
+                    "**네트워크 유닛 리스트** : unit01 ~ unit14"
+    )
+    @ApiResponses({
+            @ApiResponse(
+                    responseCode = "200",
+                    description = "개념 노트 조회 성공",
+                    content = @Content(
+                            mediaType = "text/markdown",
+                            schema = @Schema(type = "string", format = "binary"),
+                            examples = @ExampleObject(
+                                    name = "Markdown 응답 예시",
+                                    value = "# 제목\n\n## 소제목\n\n본문 내용..."
+                            )
+                    )
+            ),
+            @ApiResponse(
+                    responseCode = "404",
+                    description = "요청한 개념 노트를 찾을 수 없습니다.",
+                    content = @Content(
+                            mediaType = MediaType.APPLICATION_JSON_VALUE,
+                            examples = @ExampleObject(
+                                    name = "파일 없음",
+                                    value = "{\"error\": \"NOT_FOUND\", \"message\": \"요청한 노트를 찾을 수 없습니다.\"}"
+                            ),
+                            schema = @Schema(implementation = ErrorResponse.class)
+                    )
+            ),
+            @ApiResponse(
+                    responseCode = "500",
+                    description = "서버 내부 오류가 발생했습니다.",
+                    content = @Content(
+                            mediaType = MediaType.APPLICATION_JSON_VALUE,
+                            examples = @ExampleObject(
+                                    name = "서버 오류",
+                                    value = "{\"error\": \"INTERNAL_SERVER_ERROR\", \"message\": \"서버 오류가 발생했습니다.\"}"
+                            ),
+                            schema = @Schema(implementation = ErrorResponse.class)
+                    )
+            )
+    })
+    @GetMapping("/{chapter}/{unit}")
+    ResponseEntity<Resource> getNote(
+            @PathVariable("chapter") String chapter,
+            @PathVariable("unit") String unit
+    );
+
+}

--- a/src/main/java/gravit/code/security/config/SecurityConfig.java
+++ b/src/main/java/gravit/code/security/config/SecurityConfig.java
@@ -54,6 +54,7 @@ public class SecurityConfig {
                 .requestMatchers("/api/v1/users/restore").permitAll()
                 .requestMatchers("/api/v1/test/**").permitAll() // 테스트 할때만
                 .requestMatchers("/api/v1/admin/**").hasRole("ADMIN")
+                .requestMatchers("/api/v1/notes/**").permitAll()
                 .anyRequest().authenticated());
 
         // JwtFilter 추가

--- a/src/main/java/gravit/code/security/filter/JwtAuthFilter.java
+++ b/src/main/java/gravit/code/security/filter/JwtAuthFilter.java
@@ -43,7 +43,10 @@ public class JwtAuthFilter extends OncePerRequestFilter {
             HttpEndpoint.exact("/api/v1/users/restore", HttpMethod.POST),
 
             /* metrics monitoring */
-            HttpEndpoint.prefix("/actuator", HttpMethod.GET)
+            HttpEndpoint.prefix("/actuator", HttpMethod.GET),
+
+            /* note */
+            HttpEndpoint.prefix("/api/v1/notes", HttpMethod.GET)
 
     );
 


### PR DESCRIPTION
## 📋 이슈 번호
- close #241 

## 🛠 구현 사항
1. resources 파일에 있는 개념노트 md 파일을 'text/markdown' 로 읽어 응답하는 api 추가
- 챕터명, 유닛명 을 입력 받아서 해당하는 개념노트 md 파일을 리턴합니다.

2. 서브모듈을 통해 깃허브의 개념노트 변경사항을 가져오는 기능 추가

### 서브 모듈 초기 설정
```bash
# 저장소 클론 시 서브모듈 포함
git clone --recurse-submodules https://github.com/Team-Gravit/gravit-cs-notes.git**

# 또는 이미 클론 한 경우
git submodule update --init --recursive
```
### 최신 서브모듈 데이터 가져오는 방법
```bash
git submodule update --remote
```



## 🤔 추가 고려 사항

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## 릴리스 노트

* **새로운 기능**
  * 학습 노트 조회 API 추가: 장(chapter)과 단원(unit)별로 마크다운 형식의 노트 콘텐츠를 조회할 수 있습니다. 별도의 인증 없이 공개적으로 접근 가능한 엔드포인트입니다.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->