### PR TITLE
feat: 오답노트 도메인 추가 및 관련 API 작성

### DIFF
--- a/src/main/java/gravit/code/bookmark/domain/BookmarkRepository.java
+++ b/src/main/java/gravit/code/bookmark/domain/BookmarkRepository.java
@@ -1,6 +1,14 @@
 package gravit.code.bookmark.domain;
 
+import gravit.code.problem.dto.response.ProblemDetail;
+
+import java.util.List;
+
 public interface BookmarkRepository {
+    List<ProblemDetail> findBookmarkedProblemDetailByUnitIdAndUserId(
+            long unitId,
+            long userId
+    );
     void save(Bookmark bookmark);
     void deleteByProblemIdAndUserId(
             long problemId,

--- a/src/main/java/gravit/code/bookmark/dto/request/BookmarkSaveRequest.java
+++ b/src/main/java/gravit/code/bookmark/dto/request/BookmarkSaveRequest.java
@@ -10,6 +10,6 @@ public record BookmarkSaveRequest(
                 example = "1"
         )
         @NotNull(message = "문제 아이디가 비어있습니다.")
-        long problemId
+        Long problemId
 ) {
 }

--- a/src/main/java/gravit/code/bookmark/infrastructure/BookmarkJpaRepository.java
+++ b/src/main/java/gravit/code/bookmark/infrastructure/BookmarkJpaRepository.java
@@ -1,10 +1,13 @@
 package gravit.code.bookmark.infrastructure;
 
 import gravit.code.bookmark.domain.Bookmark;
+import gravit.code.problem.dto.response.ProblemDetail;
 import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.data.jpa.repository.Modifying;
 import org.springframework.data.jpa.repository.Query;
 import org.springframework.data.repository.query.Param;
+
+import java.util.List;
 
 public interface BookmarkJpaRepository extends JpaRepository<Bookmark, Long> {
 
@@ -20,4 +23,24 @@ public interface BookmarkJpaRepository extends JpaRepository<Bookmark, Long> {
     );
 
     boolean existsByProblemIdAndUserId(long problemId, long userId);
+
+    @Query("""
+        SELECT new gravit.code.problem.dto.response.ProblemDetail(
+            p.id,
+            p.problemType,
+            p.instruction,
+            p.content,
+            true
+        )
+        FROM Bookmark b
+        JOIN Problem p ON p.id = b.problemId
+        JOIN Lesson l ON l.id = p.lessonId
+        JOIN Unit u ON u.id = l.unitId
+        WHERE u.id = :unitId AND b.userId = :userId
+        ORDER BY b.createdAt ASC
+    """)
+    List<ProblemDetail> findBookmarkedProblemDetailByUnitIdAndUserId(
+            @Param("unitId")long unitId,
+            @Param("userId")long userId
+    );
 }

--- a/src/main/java/gravit/code/bookmark/infrastructure/BookmarkRepositoryImpl.java
+++ b/src/main/java/gravit/code/bookmark/infrastructure/BookmarkRepositoryImpl.java
@@ -2,8 +2,11 @@ package gravit.code.bookmark.infrastructure;
 
 import gravit.code.bookmark.domain.Bookmark;
 import gravit.code.bookmark.domain.BookmarkRepository;
+import gravit.code.problem.dto.response.ProblemDetail;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Repository;
+
+import java.util.List;
 
 @Repository
 @RequiredArgsConstructor
@@ -11,6 +14,13 @@ public class BookmarkRepositoryImpl implements BookmarkRepository {
 
     private final BookmarkJpaRepository bookmarkJpaRepository;
 
+    @Override
+    public List<ProblemDetail> findBookmarkedProblemDetailByUnitIdAndUserId(
+            long unitId,
+            long userId
+    ) {
+        return bookmarkJpaRepository.findBookmarkedProblemDetailByUnitIdAndUserId(unitId, userId);
+    }
 
     @Override
     public void save(Bookmark bookmark) {

--- a/src/main/java/gravit/code/bookmark/service/BookmarkService.java
+++ b/src/main/java/gravit/code/bookmark/service/BookmarkService.java
@@ -6,15 +6,26 @@ import gravit.code.bookmark.dto.request.BookmarkDeleteRequest;
 import gravit.code.bookmark.dto.request.BookmarkSaveRequest;
 import gravit.code.global.exception.domain.CustomErrorCode;
 import gravit.code.global.exception.domain.RestApiException;
+import gravit.code.problem.dto.response.ProblemDetail;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
+
+import java.util.List;
 
 @Service
 @RequiredArgsConstructor
 public class BookmarkService {
 
     private final BookmarkRepository bookmarkRepository;
+
+    @Transactional(readOnly = true)
+    public List<ProblemDetail> findBookmarkedProblemDetailByUnitIdAndUserId(
+            long unitId,
+            long userId
+    ){
+        return bookmarkRepository.findBookmarkedProblemDetailByUnitIdAndUserId(unitId, userId);
+    }
 
     @Transactional
     public void saveBookmark(

--- a/src/main/java/gravit/code/learning/controller/LearningController.java
+++ b/src/main/java/gravit/code/learning/controller/LearningController.java
@@ -17,6 +17,8 @@ import gravit.code.problem.dto.response.WrongAnsweredProblemsResponse;
 import gravit.code.report.dto.request.ProblemReportSubmitRequest;
 import gravit.code.report.service.ReportService;
 import gravit.code.unit.dto.response.UnitDetailResponse;
+import gravit.code.wrongAnsweredNote.dto.response.WrongAnsweredNoteDeleteRequest;
+import gravit.code.wrongAnsweredNote.service.WrongAnsweredNoteService;
 import jakarta.validation.Valid;
 import lombok.RequiredArgsConstructor;
 import org.springframework.http.HttpStatus;
@@ -34,6 +36,7 @@ public class LearningController implements LearningControllerDocs {
     private final LearningFacade learningFacade;
     private final ReportService reportService;
     private final BookmarkService bookmarkService;
+    private final WrongAnsweredNoteService wrongAnsweredNoteService;
 
     @GetMapping("/chapters")
     public ResponseEntity<List<ChapterDetailResponse>> getAllChapters(@AuthenticationPrincipal LoginUser loginUser) {
@@ -89,12 +92,21 @@ public class LearningController implements LearningControllerDocs {
         return ResponseEntity.status(HttpStatus.OK).body(learningFacade.getBookmarkedProblemsInUnit(loginUser.getId(), unitId));
     }
 
-    @GetMapping("/{unitId}/wrong-answered-problems")
+    @GetMapping("/{unitId}/wrong-answered-notes")
     public ResponseEntity<WrongAnsweredProblemsResponse> getWrongAnsweredProblemsInUnit(
             @AuthenticationPrincipal LoginUser loginUser,
             @PathVariable("unitId") Long unitId
     ){
         return ResponseEntity.status(HttpStatus.OK).body(learningFacade.getWrongAnsweredProblemsInUnit(loginUser.getId(), unitId));
+    }
+
+    @DeleteMapping("/wrong-answered-notes")
+    public ResponseEntity<Void> deleteWrongAnsweredNote(
+            @AuthenticationPrincipal LoginUser loginUser,
+            @Valid@RequestBody WrongAnsweredNoteDeleteRequest request
+    ){
+        wrongAnsweredNoteService.deleteWrongAnsweredNote(loginUser.getId(), request.problemId());
+        return ResponseEntity.noContent().build();
     }
 
     @PostMapping("/bookmarks")

--- a/src/main/java/gravit/code/learning/controller/docs/LearningControllerDocs.java
+++ b/src/main/java/gravit/code/learning/controller/docs/LearningControllerDocs.java
@@ -7,10 +7,14 @@ import gravit.code.global.exception.domain.ErrorResponse;
 import gravit.code.learning.dto.request.LearningSubmissionSaveRequest;
 import gravit.code.chapter.dto.response.ChapterDetailResponse;
 import gravit.code.learning.dto.response.LearningSubmissionSaveResponse;
+import gravit.code.lesson.dto.response.LessonDetailResponse;
 import gravit.code.lesson.dto.response.LessonResponse;
+import gravit.code.problem.dto.request.ProblemSubmissionRequest;
 import gravit.code.problem.dto.response.BookmarkedProblemResponse;
+import gravit.code.problem.dto.response.WrongAnsweredProblemsResponse;
 import gravit.code.unit.dto.response.UnitDetailResponse;
 import gravit.code.report.dto.request.ProblemReportSubmitRequest;
+import gravit.code.wrongAnsweredNote.dto.response.WrongAnsweredNoteDeleteRequest;
 import io.swagger.v3.oas.annotations.Operation;
 import io.swagger.v3.oas.annotations.media.Content;
 import io.swagger.v3.oas.annotations.media.ExampleObject;
@@ -75,6 +79,35 @@ public interface LearningControllerDocs {
     @GetMapping("/{chapterId}/units")
     ResponseEntity<UnitDetailResponse> getAllUnitsInChapter(@AuthenticationPrincipal LoginUser loginUser,
                                                             @PathVariable("chapterId") Long chapterId);
+
+    @Operation(summary = "레슨 목록 조회", description = "특정 유닛의 레슨 목록을 조회합니다.<br>" +
+            "🔐 <strong>Jwt 필요</strong><br>")
+    @ApiResponses({
+            @ApiResponse(responseCode = "200", description = "✅ 레슨 목록 조회 성공"),
+            @ApiResponse(responseCode = "UNIT_4041", description = "🚨 유닛 조회 실패",
+                    content = @Content(mediaType = MediaType.APPLICATION_JSON_VALUE,
+                            examples = {
+                                    @ExampleObject(
+                                            name = "유닛 조회 실패",
+                                            value = "{\"error\" : \"UNIT_4041\", \"message\" : \"유닛 조회에 실패하였습니다.\"}"
+                                    )
+                            },
+                            schema = @Schema(implementation = ErrorResponse.class))
+            ),
+            @ApiResponse(responseCode = "USER_4041", description = "🚨 유저 조회 실패",
+                    content = @Content(mediaType = MediaType.APPLICATION_JSON_VALUE,
+                            examples = {
+                                    @ExampleObject(
+                                            name = "유저 조회 실패",
+                                            value = "{\"error\" : \"USER_4041\", \"message\" : \"존재하지 않는 유저입니다.\"}"
+                                    )
+                            },
+                            schema = @Schema(implementation = ErrorResponse.class))
+            )
+    })
+    @GetMapping("/{unitId}/lessons")
+    ResponseEntity<LessonDetailResponse> getAllLessonsInUnit(@AuthenticationPrincipal LoginUser loginUser,
+                                                              @PathVariable("unitId") Long unitId);
 
     @Operation(summary = "레슨 문제 조회", description = "특정 레슨을 구성하는 문제 목록을 조회합니다.<br>" +
             "🔐 <strong>Jwt 필요</strong><br>")
@@ -162,9 +195,38 @@ public interface LearningControllerDocs {
                             schema = @Schema(implementation = ErrorResponse.class))
             )
     })
-    @PostMapping("/lesson/results")
+    @PostMapping("/lessons/results")
     ResponseEntity<LearningSubmissionSaveResponse> saveLearningSubmission(@AuthenticationPrincipal LoginUser loginUser,
                                                                       @Valid @RequestBody LearningSubmissionSaveRequest request);
+
+    @Operation(summary = "문제 결과 저장", description = "문제 풀이 결과를 저장합니다<br>" +
+            "🔐 <strong>Jwt 필요</strong><br>")
+    @ApiResponses({
+            @ApiResponse(responseCode = "200", description = "✅ 문제 결과 저장 성공"),
+            @ApiResponse(responseCode = "PROBLEM_4041", description = "🚨 문제 조회 실패",
+                    content = @Content(mediaType = MediaType.APPLICATION_JSON_VALUE,
+                            examples = {
+                                    @ExampleObject(
+                                            name = "문제 조회 실패",
+                                            value = "{\"error\" : \"PROBLEM_4041\", \"message\" : \"문제 조회에 실패하였습니다.\"}"
+                                    )
+                            },
+                            schema = @Schema(implementation = ErrorResponse.class))
+            ),
+            @ApiResponse(responseCode = "USER_4041", description = "🚨 유저 조회 실패",
+                    content = @Content(mediaType = MediaType.APPLICATION_JSON_VALUE,
+                            examples = {
+                                    @ExampleObject(
+                                            name = "유저 조회 실패",
+                                            value = "{\"error\" : \"USER_4041\", \"message\" : \"존재하지 않는 유저입니다.\"}"
+                                    )
+                            },
+                            schema = @Schema(implementation = ErrorResponse.class))
+            )
+    })
+    @PostMapping("/problems/results")
+    ResponseEntity<Void> saveProblemSubmission(@AuthenticationPrincipal LoginUser loginUser,
+                                               @Valid @RequestBody ProblemSubmissionRequest request);
 
     @Operation(summary = "문제 신고 제출", description = "특정 문제에 대한 오류를 신고합니다<br>" +
             "🔐 <strong>Jwt 필요</strong><br>")
@@ -223,6 +285,64 @@ public interface LearningControllerDocs {
     @GetMapping("/{unitId}/bookmarks")
     ResponseEntity<BookmarkedProblemResponse> getBookmarkedProblemsInUnit(@AuthenticationPrincipal LoginUser loginUser,
                                                                            @PathVariable("unitId") Long unitId);
+
+    @Operation(summary = "유닛 내 오답 문제 조회", description = "특정 유닛에서 사용자가 틀린 문제 목록을 조회합니다<br>" +
+            "🔐 <strong>Jwt 필요</strong><br>")
+    @ApiResponses({
+            @ApiResponse(responseCode = "200", description = "✅ 오답 문제 목록 조회 성공"),
+            @ApiResponse(responseCode = "UNIT_4041", description = "🚨 유닛 조회 실패",
+                    content = @Content(mediaType = MediaType.APPLICATION_JSON_VALUE,
+                            examples = {
+                                    @ExampleObject(
+                                            name = "유닛 조회 실패",
+                                            value = "{\"error\" : \"UNIT_4041\", \"message\" : \"유닛 조회에 실패하였습니다.\"}"
+                                    )
+                            },
+                            schema = @Schema(implementation = ErrorResponse.class))
+            ),
+            @ApiResponse(responseCode = "ANSWER_4041", description = "🚨 정답 조회 실패",
+                    content = @Content(mediaType = MediaType.APPLICATION_JSON_VALUE,
+                            examples = {
+                                    @ExampleObject(
+                                            name = "정답 조회 실패",
+                                            value = "{\"error\" : \"ANSWER_4041\", \"message\" : \"정답 조회에 실패하였습니다.\"}"
+                                    )
+                            },
+                            schema = @Schema(implementation = ErrorResponse.class))
+            ),
+            @ApiResponse(responseCode = "OPTION_4041", description = "🚨 옵션 조회 실패",
+                    content = @Content(mediaType = MediaType.APPLICATION_JSON_VALUE,
+                            examples = {
+                                    @ExampleObject(
+                                            name = "옵션 조회 실패",
+                                            value = "{\"error\" : \"OPTION_4041\", \"message\" : \"옵션 조회에 실패하였습니다.\"}"
+                                    )
+                            },
+                            schema = @Schema(implementation = ErrorResponse.class))
+            )
+    })
+    @GetMapping("/{unitId}/wrong-answered-notes")
+    ResponseEntity<WrongAnsweredProblemsResponse> getWrongAnsweredProblemsInUnit(@AuthenticationPrincipal LoginUser loginUser,
+                                                                                   @PathVariable("unitId") Long unitId);
+
+    @Operation(summary = "오답노트 삭제", description = "특정 문제의 오답노트를 삭제합니다<br>" +
+            "🔐 <strong>Jwt 필요</strong><br>")
+    @ApiResponses({
+            @ApiResponse(responseCode = "204", description = "✅ 오답노트 삭제 성공"),
+            @ApiResponse(responseCode = "WRONG_ANSWERED_NOTE_4041", description = "🚨 오답노트 조회 실패",
+                    content = @Content(mediaType = MediaType.APPLICATION_JSON_VALUE,
+                            examples = {
+                                    @ExampleObject(
+                                            name = "오답노트 조회 실패",
+                                            value = "{\"error\" : \"WRONG_ANSWERED_NOTE_4041\", \"message\" : \"오답노트 조회에 실패하였습니다.\"}"
+                                    )
+                            },
+                            schema = @Schema(implementation = ErrorResponse.class))
+            )
+    })
+    @DeleteMapping("/wrong-answered-notes")
+    ResponseEntity<Void> deleteWrongAnsweredNote(@AuthenticationPrincipal LoginUser loginUser,
+                                                  @Valid @RequestBody WrongAnsweredNoteDeleteRequest request);
 
     @Operation(summary = "북마크 저장", description = "특정 문제를 북마크에 추가합니다<br>" +
             "🔐 <strong>Jwt 필요</strong><br>")

--- a/src/main/java/gravit/code/lesson/service/LessonSubmissionService.java
+++ b/src/main/java/gravit/code/lesson/service/LessonSubmissionService.java
@@ -51,6 +51,6 @@ public class LessonSubmissionService {
 
     @Transactional(readOnly = true)
     public boolean checkUserSubmitted(long lessonId, long userId) {
-        return lessonSubmissionRepository.existsByLessonIdAndUserId(lessonId, userId);
+        return !lessonSubmissionRepository.existsByLessonIdAndUserId(lessonId, userId);
     }
 }

--- a/src/main/java/gravit/code/problem/domain/ProblemRepository.java
+++ b/src/main/java/gravit/code/problem/domain/ProblemRepository.java
@@ -10,14 +10,6 @@ public interface ProblemRepository {
             long lessonId,
             long userId
     );
-    List<ProblemDetail> findBookmarkedProblemDetailByUnitIdAndUserId(
-            long unitId,
-            long userId
-    );
-    List<ProblemDetail> findWrongAnsweredProblemsByUnitIdAndUserId(
-            long unitId,
-            long userId
-    );
     Optional<Problem> findById(long problemId);
     boolean existsProblemById(long problemId);
     Problem save(Problem problem);

--- a/src/main/java/gravit/code/problem/domain/ProblemSubmissionRepository.java
+++ b/src/main/java/gravit/code/problem/domain/ProblemSubmissionRepository.java
@@ -13,4 +13,5 @@ public interface ProblemSubmissionRepository {
             long userId
     );
     List<ProblemSubmission> saveAll(List<ProblemSubmission> problemSubmissions);
+    void save(ProblemSubmission problemSubmission);
 }

--- a/src/main/java/gravit/code/problem/infrastructure/ProblemJpaRepository.java
+++ b/src/main/java/gravit/code/problem/infrastructure/ProblemJpaRepository.java
@@ -24,50 +24,10 @@ public interface ProblemJpaRepository extends JpaRepository<Problem, Long> {
         ORDER BY p.id
     """)
     List<ProblemDetail> findAllProblemDetailByLessonIdAndUserId(
-            @Param("lessonId")long lessonId,
-            @Param("userId")long userId
+            @Param("lessonId") long lessonId,
+            @Param("userId") long userId
     );
 
     boolean existsProblemById(long id);
 
-    @Query("""
-        SELECT new gravit.code.problem.dto.response.ProblemDetail(
-            p.id,
-            p.problemType,
-            p.instruction,
-            p.content,
-            true
-        )
-        FROM Problem p
-        JOIN Lesson l ON l.id = p.lessonId
-        JOIN Unit u ON u.id = l.unitId AND u.id = :unitId
-        JOIN Bookmark b ON b.problemId = p.id AND b.userId = :userId
-        ORDER BY b.createdAt ASC
-    """)
-    List<ProblemDetail> findBookmarkedProblemDetailByUnitIdAndUserId(
-            @Param("unitId")long unitId,
-            @Param("userId")long userId
-    );
-
-    @Query("""
-        SELECT new gravit.code.problem.dto.response.ProblemDetail(
-            p.id,
-            p.problemType,
-            p.instruction,
-            p.content,
-            CASE WHEN b.id IS NOT NULL THEN true ELSE false END
-        )
-        FROM Problem p
-        JOIN Lesson l ON l.id = p.lessonId
-        JOIN Unit u ON u.id = l.unitId
-        JOIN ProblemSubmission ps ON ps.problemId = p.id AND ps.userId = :userId AND ps.isCorrect = false
-        LEFT JOIN Bookmark b ON b.problemId = p.id AND b.userId = :userId
-        WHERE u.id = :unitId
-        ORDER BY ps.id
-  
-    """)
-    List<ProblemDetail> findWrongAnsweredProblemsByUnitIdAndUserId(
-            @Param("unitId")long unitId,
-            @Param("userId")long userId
-    );
 }

--- a/src/main/java/gravit/code/problem/infrastructure/ProblemRepositoryImpl.java
+++ b/src/main/java/gravit/code/problem/infrastructure/ProblemRepositoryImpl.java
@@ -24,22 +24,6 @@ public class ProblemRepositoryImpl implements ProblemRepository {
     }
 
     @Override
-    public List<ProblemDetail> findBookmarkedProblemDetailByUnitIdAndUserId(
-            long unitId,
-            long userId
-    ) {
-        return problemJpaRepository.findBookmarkedProblemDetailByUnitIdAndUserId(unitId, userId);
-    }
-
-    @Override
-    public List<ProblemDetail> findWrongAnsweredProblemsByUnitIdAndUserId(
-            long unitId,
-            long userId
-    ) {
-        return problemJpaRepository.findWrongAnsweredProblemsByUnitIdAndUserId(unitId, userId);
-    }
-
-    @Override
     public Optional<Problem> findById(long problemId){
         return problemJpaRepository.findById(problemId);
     }

--- a/src/main/java/gravit/code/problem/infrastructure/ProblemSubmissionRepositoryImpl.java
+++ b/src/main/java/gravit/code/problem/infrastructure/ProblemSubmissionRepositoryImpl.java
@@ -34,4 +34,9 @@ public class ProblemSubmissionRepositoryImpl implements ProblemSubmissionReposit
     public List<ProblemSubmission> saveAll(List<ProblemSubmission> problemSubmissions){
         return problemSubmissionJpaRepository.saveAll(problemSubmissions);
     }
+
+    @Override
+    public void save(ProblemSubmission problemSubmission) {
+        problemSubmissionJpaRepository.save(problemSubmission);
+    }
 }

--- a/src/main/java/gravit/code/problem/service/ProblemService.java
+++ b/src/main/java/gravit/code/problem/service/ProblemService.java
@@ -2,6 +2,7 @@ package gravit.code.problem.service;
 
 import gravit.code.answer.domain.AnswerRepository;
 import gravit.code.answer.dto.response.AnswerResponse;
+import gravit.code.bookmark.service.BookmarkService;
 import gravit.code.global.exception.domain.CustomErrorCode;
 import gravit.code.global.exception.domain.RestApiException;
 import gravit.code.option.domain.OptionRepository;
@@ -10,6 +11,7 @@ import gravit.code.problem.domain.ProblemRepository;
 import gravit.code.problem.domain.ProblemType;
 import gravit.code.problem.dto.response.ProblemDetail;
 import gravit.code.problem.dto.response.ProblemResponse;
+import gravit.code.wrongAnsweredNote.service.WrongAnsweredNoteService;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
@@ -19,6 +21,9 @@ import java.util.List;
 @Service
 @RequiredArgsConstructor
 public class ProblemService {
+
+    private final WrongAnsweredNoteService wrongAnsweredNoteService;
+    private final BookmarkService bookmarkService;
 
     private final ProblemRepository problemRepository;
     private final AnswerRepository answerRepository;
@@ -39,7 +44,7 @@ public class ProblemService {
             long unitId,
             long userId
     ){
-        List<ProblemDetail> problemDetails = problemRepository.findBookmarkedProblemDetailByUnitIdAndUserId(unitId, userId);
+        List<ProblemDetail> problemDetails = bookmarkService.findBookmarkedProblemDetailByUnitIdAndUserId(unitId, userId);
 
         return getAnswerOrOptionInProblems(problemDetails);
     }
@@ -49,7 +54,7 @@ public class ProblemService {
             long unitId,
             long userId
     ) {
-        List<ProblemDetail> problemDetails = problemRepository.findWrongAnsweredProblemsByUnitIdAndUserId(unitId, userId);
+        List<ProblemDetail> problemDetails = wrongAnsweredNoteService.findWrongAnsweredProblemDetailByUnitIdAndUserId(unitId, userId);
 
         return getAnswerOrOptionInProblems(problemDetails);
     }
@@ -72,6 +77,4 @@ public class ProblemService {
                     }
                 }).toList();
     }
-
-
 }

--- a/src/main/java/gravit/code/progress/dto/ChapterCompletedDto.java
+++ b/src/main/java/gravit/code/progress/dto/ChapterCompletedDto.java
@@ -1,8 +1,0 @@
-package gravit.code.progress.dto;
-
-public record ChapterCompletedDto(
-        long before,
-        long after,
-        long totalUnits
-) {
-}

--- a/src/main/java/gravit/code/wrongAnsweredNote/domain/WrongAnsweredNote.java
+++ b/src/main/java/gravit/code/wrongAnsweredNote/domain/WrongAnsweredNote.java
@@ -1,0 +1,39 @@
+package gravit.code.wrongAnsweredNote.domain;
+
+import jakarta.persistence.*;
+import lombok.AccessLevel;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Entity
+@Getter
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+public class WrongAnsweredNote {
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    Long id;
+
+    private long problemId;
+
+    private long userId;
+
+    @Builder(access = AccessLevel.PRIVATE)
+    private WrongAnsweredNote(
+            long problemId,
+            long userId
+    ) {
+        this.problemId = problemId;
+        this.userId = userId;
+    }
+
+    public static WrongAnsweredNote create(
+            long problemId,
+            long userId
+    ) {
+        return WrongAnsweredNote.builder()
+                .problemId(problemId)
+                .userId(userId)
+                .build();
+    }
+}

--- a/src/main/java/gravit/code/wrongAnsweredNote/domain/WrongAnsweredProblemRepository.java
+++ b/src/main/java/gravit/code/wrongAnsweredNote/domain/WrongAnsweredProblemRepository.java
@@ -1,0 +1,22 @@
+package gravit.code.wrongAnsweredNote.domain;
+
+import gravit.code.problem.dto.response.ProblemDetail;
+
+import java.util.List;
+import java.util.Optional;
+
+public interface WrongAnsweredProblemRepository {
+    Optional<WrongAnsweredNote> findByProblemIdAndUserId(
+            long problemId,
+            long userId
+    );
+    List<ProblemDetail> findWrongAnsweredProblemDetailByUnitIdAndUserId(
+            long unitId,
+            long userId
+    );
+    void save(WrongAnsweredNote wrongAnsweredNote);
+    void deleteByProblemIdAndUserId(
+            long problemId,
+            long userId
+    );
+}

--- a/src/main/java/gravit/code/wrongAnsweredNote/dto/response/WrongAnsweredNoteDeleteRequest.java
+++ b/src/main/java/gravit/code/wrongAnsweredNote/dto/response/WrongAnsweredNoteDeleteRequest.java
@@ -1,14 +1,15 @@
-package gravit.code.bookmark.dto.request;
+package gravit.code.wrongAnsweredNote.dto.response;
 
 import io.swagger.v3.oas.annotations.media.Schema;
 import jakarta.validation.constraints.NotNull;
 
-@Schema(description = "북마크 삭제 request")
-public record BookmarkDeleteRequest(
+@Schema(description = "오답노트 삭제 request")
+public record WrongAnsweredNoteDeleteRequest(
         @Schema(
                 description = "문제 아이디",
                 example = "1"
         )
         @NotNull(message = "문제 아이디가 비어있습니다.")
         Long problemId
-) { }
+) {
+}

--- a/src/main/java/gravit/code/wrongAnsweredNote/infrastructure/WrongAnsweredProblemJpaRepository.java
+++ b/src/main/java/gravit/code/wrongAnsweredNote/infrastructure/WrongAnsweredProblemJpaRepository.java
@@ -1,0 +1,44 @@
+package gravit.code.wrongAnsweredNote.infrastructure;
+
+import gravit.code.problem.dto.response.ProblemDetail;
+import gravit.code.wrongAnsweredNote.domain.WrongAnsweredNote;
+import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Modifying;
+import org.springframework.data.jpa.repository.Query;
+import org.springframework.data.repository.query.Param;
+
+import java.util.List;
+import java.util.Optional;
+
+public interface WrongAnsweredProblemJpaRepository extends JpaRepository<WrongAnsweredNote, Long> {
+    Optional<WrongAnsweredNote> findByProblemIdAndUserId(
+            long problemId,
+            long userId
+    );
+
+    @Query("""
+        SELECT new gravit.code.problem.dto.response.ProblemDetail(
+            p.id,
+            p.problemType,
+            p.instruction,
+            p.content,
+            CASE WHEN b.id IS NOT NULL THEN true ELSE false END
+        )
+        FROM WrongAnsweredNote wan
+        JOIN Problem p ON p.id = wan.problemId
+        JOIN Lesson l ON l.id = p.lessonId
+        JOIN Unit u ON u.id = l.unitId
+        LEFT JOIN Bookmark b on b.problemId = p.id AND b.userId = :userId
+        WHERE wan.userId = :userId AND u.id = :unitId
+    """)
+    List<ProblemDetail> findWrongAnsweredProblemDetailByUnitIdAndUserId(
+            @Param("unitId")long unitId,
+            @Param("userId")long userId
+    );
+
+    @Modifying
+    void deleteByProblemIdAndUserId(
+            long problemId,
+            long userId
+    );
+}

--- a/src/main/java/gravit/code/wrongAnsweredNote/infrastructure/WrongAnsweredProblemRepositoryImpl.java
+++ b/src/main/java/gravit/code/wrongAnsweredNote/infrastructure/WrongAnsweredProblemRepositoryImpl.java
@@ -1,0 +1,46 @@
+package gravit.code.wrongAnsweredNote.infrastructure;
+
+import gravit.code.problem.dto.response.ProblemDetail;
+import gravit.code.wrongAnsweredNote.domain.WrongAnsweredNote;
+import gravit.code.wrongAnsweredNote.domain.WrongAnsweredProblemRepository;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Repository;
+
+import java.util.List;
+import java.util.Optional;
+
+@Repository
+@RequiredArgsConstructor
+public class WrongAnsweredProblemRepositoryImpl implements WrongAnsweredProblemRepository {
+
+    private final WrongAnsweredProblemJpaRepository wrongAnsweredProblemJpaRepository;
+
+    @Override
+    public List<ProblemDetail> findWrongAnsweredProblemDetailByUnitIdAndUserId(
+            long unitId,
+            long userId
+    ) {
+        return wrongAnsweredProblemJpaRepository.findWrongAnsweredProblemDetailByUnitIdAndUserId(unitId, userId);
+    }
+
+    @Override
+    public Optional<WrongAnsweredNote> findByProblemIdAndUserId(
+            long problemId,
+            long userId
+    ) {
+        return wrongAnsweredProblemJpaRepository.findByProblemIdAndUserId(problemId, userId);
+    }
+
+    @Override
+    public void save(WrongAnsweredNote wrongAnsweredNote) {
+        wrongAnsweredProblemJpaRepository.save(wrongAnsweredNote);
+    }
+
+    @Override
+    public void deleteByProblemIdAndUserId(
+            long problemId,
+            long userId
+    ) {
+        wrongAnsweredProblemJpaRepository.deleteByProblemIdAndUserId(problemId, userId);
+    }
+}

--- a/src/main/java/gravit/code/wrongAnsweredNote/service/WrongAnsweredNoteService.java
+++ b/src/main/java/gravit/code/wrongAnsweredNote/service/WrongAnsweredNoteService.java
@@ -1,0 +1,44 @@
+package gravit.code.wrongAnsweredNote.service;
+
+import gravit.code.problem.dto.response.ProblemDetail;
+import gravit.code.wrongAnsweredNote.domain.WrongAnsweredNote;
+import gravit.code.wrongAnsweredNote.domain.WrongAnsweredProblemRepository;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+import java.util.List;
+
+@Service
+@RequiredArgsConstructor
+public class WrongAnsweredNoteService {
+
+    private final WrongAnsweredProblemRepository wrongAnsweredProblemRepository;
+
+    @Transactional
+    public void saveWrongAnsweredNoteIfNotExists(
+            long problemId,
+            long userId
+    ) {
+        WrongAnsweredNote wrongAnsweredNote = wrongAnsweredProblemRepository.findByProblemIdAndUserId(problemId, userId)
+                .orElseGet(() -> WrongAnsweredNote.create(problemId, userId));
+
+        wrongAnsweredProblemRepository.save(wrongAnsweredNote);
+    }
+
+    @Transactional(readOnly = true)
+    public List<ProblemDetail> findWrongAnsweredProblemDetailByUnitIdAndUserId(
+            long unitId,
+            long userId
+    ){
+        return wrongAnsweredProblemRepository.findWrongAnsweredProblemDetailByUnitIdAndUserId(unitId, userId);
+    }
+
+    @Transactional
+    public void deleteWrongAnsweredNote(
+            long userId,
+            long problemId
+    ) {
+        wrongAnsweredProblemRepository.deleteByProblemIdAndUserId(problemId, userId);
+    }
+}


### PR DESCRIPTION
## 📋 이슈 번호
- close #247 

## 🛠 구현 사항
**오답노트 생성 조건**
레슨 또는 북마크, 오답노트에서 문제를 풀이하여 제출했을 때, 다음 경우에 오답노트 엔티티를 생성합니다.
- 최초 풀이에서 오답인 경우
- 이전 풀이는 정답이었으나, 재풀이에서 오답인 경우

<br>

**ProblemSubmission 업데이트**
ProblemSubmission은 항상 해당 문제에 대한 최신 풀이 결과를 저장합니다.
- 특정 문제를 처음 풀이한 경우 → ProblemSubmission 생성
- 특정 문제를 재풀이한 경우 → ProblemSubmission 조회 + ProblemSubmission 업데이트

**예시**
문제(problemId = 1) 1회 풀이 시, 오답 → ProblemSubmission.isCorrect == false
문제(problemId = 1) 2회 풀이 시, 정답 → ProblemSubmission.isCorrect == true

<br>

**문제 풀이 제출 시, 처리 플로우**
1. 문제 아이디와 유저 아이디로 ProblemSubmission 조회
- 존재하지 않으면 생성, 존재하면 조회 후 isCorrect 필드 업데이트

2. 제출 결과가 오답인 경우
- WrongAnswerNote 조회, 존재하지 않으면 생성 후 저장

<br>

**오답노트에 등록된 문제를 다시 풀어서 정답을 맞춘 경우**
프론트엔드에서 명시적으로 오답노트 삭제 API를 호출해야 삭제.

**북마크, 오답노트 문제 조회 로직 수정**
의존 방향을 북마크, 오답노트 → 문제로 수정


## 🤔 추가 고려 사항

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## 릴리스 노트

* **새로운 기능**
  * 오답노트 삭제 기능 추가
  * 단원 내 오답 문제 관리 기능 강화

* **개선사항**
  * API 엔드포인트명 변경 (`wrong-answered-problems` → `wrong-answered-notes`)
  * 북마크 및 오답 데이터 조회 성능 최적화
  * 문제 풀이 시 오답 자동 기록

* **버그 수정**
  * 제출 여부 확인 로직 수정

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->