### PR TITLE
merge: main <- dev

### DIFF
--- a/src/main/java/gravit/code/csnote/controller/CSNoteController.java
+++ b/src/main/java/gravit/code/csnote/controller/CSNoteController.java
@@ -1,6 +1,18 @@
 package gravit.code.csnote.controller;
 
+import static gravit.code.global.exception.domain.CustomErrorCode.CHAPTER_NOT_FOUND;
+import static gravit.code.global.exception.domain.CustomErrorCode.UNIT_NOT_FOUND;
+
+import gravit.code.chapter.domain.Chapter;
+import gravit.code.chapter.domain.ChapterRepository;
 import gravit.code.csnote.controller.docs.CSNoteControllerDocs;
+import gravit.code.global.exception.domain.RestApiException;
+import gravit.code.unit.domain.Unit;
+import gravit.code.unit.domain.UnitRepository;
+import java.nio.charset.StandardCharsets;
+import java.util.List;
+import java.util.Map;
+import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.core.io.ClassPathResource;
 import org.springframework.core.io.Resource;
@@ -13,22 +25,44 @@ import org.springframework.web.bind.annotation.PathVariable;
 import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RestController;
 
-import java.nio.charset.StandardCharsets;
-
 @RestController
-@RequestMapping("/api/v1/cs-notes")
 @Slf4j
+@RequiredArgsConstructor
+@RequestMapping("/api/v1/cs-notes")
 public class CSNoteController implements CSNoteControllerDocs {
 
-    private static final String BASE_PATH = "static/notes";
+    private final UnitRepository unitRepository;
+    private final ChapterRepository chapterRepository;
 
-    @GetMapping("/{chapter}/{unit}")
+    private static final String BASE_PATH = "static/notes";
+    private static final String UNIT_PREFIX = "unit";
+    private static final Map<String, String> chapterMap = Map.of(
+            "자료구조", "data-structure",
+            "알고리즘", "algorithm",
+            "네트워크", "network"
+    );
+
+    @GetMapping("/{unitId}")
     public ResponseEntity<Resource> getNote(
-            @PathVariable("chapter") String chapter,
-            @PathVariable("unit") String unit
+            @PathVariable("unitId") Long unitId
     ){
+        Unit unit = unitRepository.findById(unitId)
+                .orElseThrow(() -> new RestApiException(UNIT_NOT_FOUND));
+
+        Chapter chapter = chapterRepository.findById(unit.getChapterId())
+                .orElseThrow(() -> new RestApiException(CHAPTER_NOT_FOUND));
+
+        List<Long> unitIdsInChapter = unitRepository.findIdsByChapterIdOrderById(chapter.getId());
+        int orderInChapter = calculateOrderInChapter(unitIdsInChapter, unitId);
+
+        String chapterName = chapterMap.get(chapter.getTitle());
+        if(chapterName == null){
+            throw new RestApiException(CHAPTER_NOT_FOUND);
+        }
+        String unitKey = makeUnitKey(orderInChapter);
+
         try{
-            String filePath = String.format("%s/%s/%s.md", BASE_PATH, chapter, unit);
+            String filePath = String.format("%s/%s/%s.md", BASE_PATH, chapterName, unitKey);
             ClassPathResource resource = new ClassPathResource(filePath);
 
             if(!resource.exists()){
@@ -48,5 +82,22 @@ public class CSNoteController implements CSNoteControllerDocs {
         }catch (Exception e){
             return ResponseEntity.internalServerError().build();
         }
+    }
+
+    private int calculateOrderInChapter(List<Long> unitIdsInChapter, long targetUnitId) {
+        int index = unitIdsInChapter.indexOf(targetUnitId);
+        if(index == -1){
+            throw new RestApiException(UNIT_NOT_FOUND);
+        }
+        return index + 1;
+    }
+
+    private String makeUnitKey(long unitId) {
+        if(unitId < 10){
+            String numStr = String.format("0%d", unitId);
+            return String.format("%s%s", UNIT_PREFIX, numStr);
+        }
+
+        return String.format("%s%d", UNIT_PREFIX, unitId);
     }
 }

--- a/src/main/java/gravit/code/csnote/controller/docs/CSNoteControllerDocs.java
+++ b/src/main/java/gravit/code/csnote/controller/docs/CSNoteControllerDocs.java
@@ -21,12 +21,7 @@ public interface CSNoteControllerDocs {
             summary = "개념 노트 조회",
             description = "챕터와 유닛 정보로 Markdown 형식의 개념 노트를 조회합니다. <br>" +
                     "응답 본문은 Markdown 텍스트 데이터입니다. <br><br>" +
-                    "**파일 구조**: static/notes/{chapter}/{unit}.md <br>" +
-                    "**예시**: /api/v1/notes/algorithm/unit01 → static/notes/algorithm/unit01.md <br>" +
-                    "**챕터 리스트** : [algorithm, data-structure, network] <br>" +
-                    "**알고리즘 유닛 리스트** : unit01 ~ unit17 <br>" +
-                    "**자료구조 유닛 리스트** : unit01 ~ unit10 <br>" +
-                    "**네트워크 유닛 리스트** : unit01 ~ unit14"
+                    "unitId 를 입력하면 unit에 해당하는 개념노트를 응답합니다."
     )
     @ApiResponses({
             @ApiResponse(
@@ -43,13 +38,23 @@ public interface CSNoteControllerDocs {
             ),
             @ApiResponse(
                     responseCode = "404",
-                    description = "요청한 개념 노트를 찾을 수 없습니다.",
+                    description = "유닛을 찾을 수 없거나 해당 개념 노트 파일이 존재하지 않습니다.",
                     content = @Content(
                             mediaType = MediaType.APPLICATION_JSON_VALUE,
-                            examples = @ExampleObject(
-                                    name = "파일 없음",
-                                    value = "{\"error\": \"NOT_FOUND\", \"message\": \"요청한 노트를 찾을 수 없습니다.\"}"
-                            ),
+                            examples = {
+                                    @ExampleObject(
+                                            name = "유닛 없음",
+                                            value = "{\"errorCode\": \"UNIT_NOT_FOUND\", \"message\": \"존재하지 않는 유닛입니다.\"}"
+                                    ),
+                                    @ExampleObject(
+                                            name = "챕터 없음",
+                                            value = "{\"errorCode\": \"CHAPTER_NOT_FOUND\", \"message\": \"존재하지 않는 챕터입니다.\"}"
+                                    ),
+                                    @ExampleObject(
+                                            name = "노트 파일 없음",
+                                            value = "{\"errorCode\": \"NOT_FOUND\", \"message\": \"요청한 개념 노트 파일을 찾을 수 없습니다.\"}"
+                                    )
+                            },
                             schema = @Schema(implementation = ErrorResponse.class)
                     )
             ),
@@ -66,10 +71,9 @@ public interface CSNoteControllerDocs {
                     )
             )
     })
-    @GetMapping("/{chapter}/{unit}")
+    @GetMapping("/{unitId}")
     ResponseEntity<Resource> getNote(
-            @PathVariable("chapter") String chapter,
-            @PathVariable("unit") String unit
+            @PathVariable("unitId") Long unitId
     );
 
 }

--- a/src/main/java/gravit/code/global/exception/domain/CustomErrorCode.java
+++ b/src/main/java/gravit/code/global/exception/domain/CustomErrorCode.java
@@ -130,6 +130,9 @@ public enum CustomErrorCode implements ErrorCode {
     // Admin
     ADMIN_ONLY_FEATURE(HttpStatus.UNAUTHORIZED, "ADMIN_4011", "admin 전용 기능입니다."),
 
+    // CS-NOTE
+    CHAPTER_NAME_NOT_MATCHING(HttpStatus.BAD_REQUEST, "CS_NOTE_4001", "CS 노트 경로와 챕터 이름이 매칭되지 않습니다."),
+
     // Global
     INVALID_PARAMS(HttpStatus.BAD_REQUEST, "GLOBAL_4001", "유효성 검사 실패"),
     DATABASE_EXCEPTION(HttpStatus.BAD_REQUEST, "DB_4001", "데이터베이스 작업 중 예외 발생"),

--- a/src/main/java/gravit/code/unit/domain/UnitRepository.java
+++ b/src/main/java/gravit/code/unit/domain/UnitRepository.java
@@ -12,4 +12,5 @@ public interface UnitRepository {
     Optional<UnitSummary> findUnitSummaryByLessonId(long lessonId);
     Unit save(Unit unit);
     void saveAll(List<Unit> units);
+    List<Long> findIdsByChapterIdOrderById(long chapterId);
 }

--- a/src/main/java/gravit/code/unit/infrastructure/UnitJpaRepository.java
+++ b/src/main/java/gravit/code/unit/infrastructure/UnitJpaRepository.java
@@ -32,4 +32,7 @@ public interface UnitJpaRepository extends JpaRepository<Unit, Long> {
         WHERE u.id = :unitId
     """)
     Optional<UnitSummary> findUnitSummaryById(@Param("unitId")long unitId);
+
+    @Query("SELECT u.id FROM Unit u WHERE u.chapterId = :chapterId ORDER BY u.id ASC")
+    List<Long> findIdsByChapterIdOrderById(@Param("chapterId") long chapterId);
 }

--- a/src/main/java/gravit/code/unit/infrastructure/UnitRepositoryImpl.java
+++ b/src/main/java/gravit/code/unit/infrastructure/UnitRepositoryImpl.java
@@ -44,4 +44,9 @@ public class UnitRepositoryImpl implements UnitRepository {
     public void saveAll(List<Unit> units){
         unitJpaRepository.saveAll(units);
     }
+
+    @Override
+    public List<Long> findIdsByChapterIdOrderById(long chapterId) {
+        return unitJpaRepository.findIdsByChapterIdOrderById(chapterId);
+    }
 }


### PR DESCRIPTION
## 📋 이슈 번호
- close #이슈 번호

## 🛠 구현 사항
### unitId를 기반으로 알맞은 개념 노트를 응답하도록 수정

<img width="390" height="514" alt="image" src="https://github.com/user-attachments/assets/57cba670-acf1-48d6-bceb-0781fade6b08" />

### url 변경
/api/v1/cs-notes/{chapter}/{unit} 에서
**/api/v1/cs-notes/{unitId}** 로 변경



## 🤔 추가 고려 사항