### PR TITLE
hotfix: Flyway DataSource 충돌 해결 및 전용 커넥션 풀 설정

### DIFF
--- a/src/main/java/gravit/code/global/config/DatasourceConfig.java
+++ b/src/main/java/gravit/code/global/config/DatasourceConfig.java
@@ -1,9 +1,12 @@
 package gravit.code.global.config;
 
+import com.zaxxer.hikari.HikariDataSource;
 import gravit.code.global.listener.QueryMetricsListener;
 import javax.sql.DataSource;
 import lombok.RequiredArgsConstructor;
 import net.ttddyy.dsproxy.support.ProxyDataSourceBuilder;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.boot.autoconfigure.flyway.FlywayDataSource;
 import org.springframework.boot.autoconfigure.jdbc.DataSourceProperties;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
@@ -12,7 +15,43 @@ import org.springframework.context.annotation.Primary;
 @RequiredArgsConstructor
 @Configuration
 public class DatasourceConfig {
+
     private final QueryMetricsListener queryMetricsListener;
+
+    // Pool Name
+    public static final String FLYWAY_POOL_NAME = "FlywayPool";
+
+    // Connection Pool Settings
+    public static final int FLYWAY_MINIMUM_IDLE = 0;             // 유휴 커넥션을 0으로 설정하면 사용하지 않을 때 커넥션을 즉시 반납
+    public static final int FLYWAY_MAXIMUM_POOL_SIZE = 2;        // 마이그레이션은 순차 실행이므로 2개로 충분
+    public static final long FLYWAY_CONNECTION_TIMEOUT = 10000L;
+    public static final long FLYWAY_IDLE_TIMEOUT = 60000L;       // 1분 후 유휴 커넥션 반환
+    public static final long FLYWAY_MAX_LIFETIME = 300000L;      // 최대 5분
+
+    // Flyway 전용 DataSource (Proxy 미적용, 커넥션 최소화)
+    @Bean
+    @FlywayDataSource
+    public DataSource flywayDataSource(
+            @Value("${spring.datasource.url}") String url,
+            @Value("${spring.flyway.user}") String username,
+            @Value("${spring.flyway.password}") String password,
+            @Value("${spring.datasource.driver-class-name}") String driverClassName
+    ) {
+        HikariDataSource dataSource = new HikariDataSource();
+        dataSource.setJdbcUrl(url);
+        dataSource.setUsername(username);
+        dataSource.setPassword(password);
+        dataSource.setDriverClassName(driverClassName);
+        dataSource.setPoolName(FLYWAY_POOL_NAME);
+
+        dataSource.setMinimumIdle(FLYWAY_MINIMUM_IDLE);
+        dataSource.setMaximumPoolSize(FLYWAY_MAXIMUM_POOL_SIZE);
+        dataSource.setConnectionTimeout(FLYWAY_CONNECTION_TIMEOUT);
+        dataSource.setIdleTimeout(FLYWAY_IDLE_TIMEOUT);
+        dataSource.setMaxLifetime(FLYWAY_MAX_LIFETIME);
+
+        return dataSource;
+    }
 
     @Bean
     @Primary


### PR DESCRIPTION
## 📋 이슈 번호
- close #이슈 번호

## 🛠 구현 사항
- @FlywayDataSource로 Flyway 전용 DataSource 분리하여 proxyDataSource와 충돌 해결
- FlywayPool에 최소 커넥션 설정 적용 (minimumIdle=0, maxPoolSize=2)
- 마이그레이션 완료 후 유휴 커넥션 즉시 반환 (idleTimeout=60s, maxLifetime=300s)

## 🤔 추가 고려 사항

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## 릴리스 노트

* **Chores**
  * 데이터베이스 마이그레이션 도구의 연결 설정을 개선했습니다. 이제 마이그레이션 작업이 전용 데이터베이스 연결 풀을 사용하여 더 안정적으로 작동합니다.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->