### PR TITLE
cicd: Java 버전 17에서 21로 업그레이드

### DIFF
--- a/.github/workflows/cd-dev.yml
+++ b/.github/workflows/cd-dev.yml
@@ -19,7 +19,7 @@ jobs:
       - name: JDK 버전 설정
         uses: actions/setup-java@v4
         with:
-          java-version: '17'
+          java-version: '21'
           distribution: 'adopt'
 
       - name: application-dev.yml 환경변수 주입

--- a/.github/workflows/cd-prod.yml
+++ b/.github/workflows/cd-prod.yml
@@ -19,7 +19,7 @@ jobs:
       - name: JDK 버전 설정
         uses: actions/setup-java@v4
         with:
-          java-version: '17'
+          java-version: '21'
           distribution: 'adopt'
 
       - name: application-prod.yml 환경변수 주입

--- a/.github/workflows/ci-common.yml
+++ b/.github/workflows/ci-common.yml
@@ -16,7 +16,7 @@ jobs:
       - name: JDK 버전 설정
         uses: actions/setup-java@v4
         with:
-          java-version: '17'
+          java-version: '21'
           distribution: 'adopt'
 
       - name: 테스트 실행

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM eclipse-temurin:17-jre
+FROM eclipse-temurin:21-jre
 
 ARG JAR_NAME=code-0.0.1-SNAPSHOT.jar
 ARG JAR_PATH=./build/libs/${JAR_NAME}


### PR DESCRIPTION
## Summary
- `Dockerfile`: `eclipse-temurin:17-jre` → `eclipse-temurin:21-jre`
- `ci-common.yml`: JDK `java-version: '17'` → `'21'`
- `cd-dev.yml`: JDK `java-version: '17'` → `'21'`
- `cd-prod.yml`: JDK `java-version: '17'` → `'21'`

## Test plan
- [ ] CI 워크플로우에서 JDK 21로 빌드 및 테스트 통과 확인
- [ ] Docker 이미지가 `eclipse-temurin:21-jre` 기반으로 정상 빌드되는지 확인

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## 릴리스 노트

* **Chores**
  * Java 런타임 버전을 17에서 21로 업그레이드했습니다. 모든 CI/CD 파이프라인 및 Docker 컨테이너 이미지가 Java 21을 기반으로 구동됩니다. 이 인프라 업데이트는 애플리케이션의 안정성과 성능을 향상시킵니다.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->