### PR TITLE
refactor: swagger 에서 dev 서버 동적 주입 및 prod 에서 QueryMetric 실행x

### DIFF
--- a/src/main/java/gravit/code/global/config/DatasourceConfig.java
+++ b/src/main/java/gravit/code/global/config/DatasourceConfig.java
@@ -14,7 +14,7 @@ import org.springframework.context.annotation.Profile;
 
 import javax.sql.DataSource;
 
-@Profile("!test")
+@Profile("!test & !prod")
 @RequiredArgsConstructor
 @Configuration
 public class DatasourceConfig {

--- a/src/main/java/gravit/code/global/listener/QueryMetricsListener.java
+++ b/src/main/java/gravit/code/global/listener/QueryMetricsListener.java
@@ -10,8 +10,10 @@ import lombok.extern.slf4j.Slf4j;
 import net.ttddyy.dsproxy.ExecutionInfo;
 import net.ttddyy.dsproxy.QueryInfo;
 import net.ttddyy.dsproxy.listener.QueryExecutionListener;
+import org.springframework.context.annotation.Profile;
 import org.springframework.stereotype.Component;
 
+@Profile("!prod")
 @RequiredArgsConstructor
 @Component
 @Slf4j

--- a/src/main/resources/application-dev.yml
+++ b/src/main/resources/application-dev.yml
@@ -121,7 +121,7 @@ admin:
     emails: ${ADMIN_BOOTSTRAP_EMAILS}
 
 springdoc:
-  server-url: http://localhost:8080
+  server-url: https://grav-it-dev.inuappcenter.kr
 
 management:
   endpoints:


### PR DESCRIPTION
### 1. 연관 이슈
- closed #323 

### 2. 구현 사항
1. swagger에서 서버 리스트가 dev profile 에 맞게 동적으로 주입하도록 수정.

2. prod에서 DataSourceProxy와 QueryMetric 클래스가 실행되지 않도록 수정.

### 추가
DataSourceConfig가 실행되지 않아서 Flyway 설정도 실행되지 않는 문제 존재. 하지만 yml 설정 기반으로 채워지므로 구동 시 한번 flyway 실행하고 커넥션을 회수하기  때문에 성능 문제는 발생하지 않습니다.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## 릴리즈 노트

* **Chores**
  * 개발 환경의 서버 URL이 로컬 주소에서 배포된 HTTPS 호스트로 변경되었습니다.
  * 애플리케이션 환경별 설정 조건이 조정되었습니다.
  * 애플리케이션 동작 환경에 따른 기능 로드 조건이 업데이트되었습니다.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->