### PR TITLE
fix: docker-compose-dev Spring 프로파일 환경변수 및 로그 볼륨 설정 수정

### DIFF
--- a/docker-compose-dev.yml
+++ b/docker-compose-dev.yml
@@ -6,9 +6,11 @@ services:
       - "8521:8080"
     environment:
       - TZ=Asia/Seoul
-      - SPRING_PROFILE=dev
+      - SPRING_PROFILES_ACTIVE=dev
     networks:
       - gravit-dev
+    volumes:
+      - ./logs:/var/log/spring
     depends_on:
       gravit-redis-dev:
         condition: service_started


### PR DESCRIPTION
### 1. 연관 이슈

---
- 없음

<br>

### 2. 구현 사항

---
**구현 사항 1: SPRING_PROFILE → SPRING_PROFILES_ACTIVE 환경변수 수정**

`docker-compose-dev.yml`의 Spring 프로파일 환경변수가 `SPRING_PROFILE=dev`로 잘못 설정되어 있었습니다. Spring Boot의 표준 환경변수는 `SPRING_PROFILES_ACTIVE`이므로, 기존 설정으로는 `dev` 프로파일이 실제로 활성화되지 않는 문제가 있었습니다. 올바른 환경변수명으로 수정하여 dev 환경에서 `application-dev.yml` 설정이 정상 적용되도록 합니다.

**구현 사항 2: 로그 볼륨 마운트 추가**

Loki 기반 로그 수집을 위해 `./logs:/var/log/spring` 볼륨 마운트를 추가했습니다. 컨테이너 내부의 Spring 애플리케이션 로그를 호스트의 `./logs` 디렉토리로 내보내어 Grafana Loki가 수집할 수 있도록 합니다.

**구현 사항 3: 파일 끝 개행 추가**

`docker-compose-dev.yml` 마지막 줄에 누락된 개행 문자를 추가하여 POSIX 표준을 준수합니다.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## 릴리스 노트

* **Chores**
  * 개발 환경 설정을 업데이트했습니다. Spring 런타임 구성을 최신화하고 로그 저장소 처리를 개선했습니다.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->