### PR TITLE
feat: 레슨 첫 풀이 시 일일 학습 기록 처리 로직 추가(#334)

### DIFF
--- a/.claude/skills/write-test/SKILL.md
+++ b/.claude/skills/write-test/SKILL.md
@@ -55,6 +55,8 @@ allowed-tools: Read, Grep, Glob, Edit, Write, Bash
 4. Phase 1에서 파악한 각 메서드에 대해 다음 테스트 케이스를 작성하라:
    - 정상 동작 (성공 케이스)
    - 예외 발생 (실패 케이스: 존재하지 않음, 권한 없음, 중복 등)
+     - **`RestApiException`을 던지는 케이스는 반드시 `errorCode`까지 검증**한다 (예: `.extracting(e -> ((RestApiException) e).getErrorCode()).isEqualTo({CODE})`). 타입만 검증(`.isInstanceOf(RestApiException.class)` 단독)하면 다른 errorCode로 회귀해도 통과하므로 회귀 감지가 불가능하다.
+     - `CustomErrorCode`는 static import로 식별자만 노출한다 (`CustomErrorCode.X` 표기 금지).
    - 엣지 케이스 (경계값, 빈 리스트, null 등 — 해당하는 경우만)
 
 > 다음 Phase 조건: 테스트 파일 작성이 완료되었을 때

--- a/.claude/skills/write-test/references/test-code-convention.md
+++ b/.claude/skills/write-test/references/test-code-convention.md
@@ -35,6 +35,32 @@
 | 그룹화 | `@Nested` + `@DisplayName` | `@DisplayName("북마크를 추가할 때")` |
 | 구간 구분 | `// given` / `// when` / `// then` 주석 필수 | — |
 
+## 예외 검증 규칙
+
+`RestApiException`을 던지는 메서드의 예외 케이스는 **반드시 `errorCode`까지 검증**한다. 타입만 검증하면 다른 errorCode로 회귀해도 테스트가 통과해 회귀 감지가 불가능하다.
+
+| 항목 | 규칙 |
+|---|---|
+| 예외 타입 검증 | `.isInstanceOf(RestApiException.class)` (필수) |
+| errorCode 검증 | `.extracting(e -> ((RestApiException) e).getErrorCode()).isEqualTo({CODE})` (필수) |
+| `CustomErrorCode` import | static import로만 사용 (`CustomErrorCode.X` 표기 금지) |
+
+**올바른 예시**
+```java
+import static gravit.code.global.exception.domain.CustomErrorCode.CHAPTER_NOT_FOUND;
+
+assertThatThrownBy(() -> chapterQueryService.getChapterSummary(chapterId))
+        .isInstanceOf(RestApiException.class)
+        .extracting(e -> ((RestApiException) e).getErrorCode())
+        .isEqualTo(CHAPTER_NOT_FOUND);
+```
+
+**잘못된 예시** (사용 금지)
+```java
+assertThatThrownBy(() -> chapterQueryService.getChapterSummary(chapterId))
+        .isInstanceOf(RestApiException.class);  // ❌ errorCode 미검증으로 회귀 감지 불가
+```
+
 ## Fixture
 
 | 항목 | 규칙 |

--- a/.claude/skills/write-test/references/test-code-template.md
+++ b/.claude/skills/write-test/references/test-code-template.md
@@ -87,6 +87,7 @@ class {Target}UnitTest {
 ```java
 package gravit.code.{domain}.service;
 
+import gravit.code.global.exception.domain.RestApiException;
 import gravit.code.support.TCSpringBootTest;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Nested;
@@ -95,7 +96,9 @@ import org.junit.jupiter.api.BeforeEach;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.test.context.jdbc.Sql;
 
+import static gravit.code.global.exception.domain.CustomErrorCode.{ERROR_CODE};
 import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
 
 @TCSpringBootTest
 @Sql(scripts = "classpath:sql/truncate_all.sql", executionPhase = Sql.ExecutionPhase.BEFORE_TEST_METHOD)

--- a/.claude/skills/write-test/references/test-code-template.md
+++ b/.claude/skills/write-test/references/test-code-template.md
@@ -5,7 +5,6 @@
 ```java
 package gravit.code.{domain}.service;
 
-import gravit.code.global.exception.domain.CustomErrorCode;
 import gravit.code.global.exception.domain.RestApiException;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Nested;
@@ -15,6 +14,7 @@ import org.mockito.InjectMocks;
 import org.mockito.Mock;
 import org.mockito.junit.jupiter.MockitoExtension;
 
+import static gravit.code.global.exception.domain.CustomErrorCode.{ERROR_CODE};
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
 import static org.assertj.core.api.SoftAssertions.assertSoftly;
@@ -53,12 +53,34 @@ class {Target}UnitTest {
             when(dependency.method(any())).thenReturn(Optional.empty());
 
             // when & then
+            // 예외 타입과 errorCode를 함께 검증한다 (errorCode 누락 시 회귀 발생 시 감지 불가)
             assertThatThrownBy(() -> target.method(param))
-                    .isInstanceOf(RestApiException.class);
+                    .isInstanceOf(RestApiException.class)
+                    .extracting(e -> ((RestApiException) e).getErrorCode())
+                    .isEqualTo({ERROR_CODE});
         }
     }
 }
 ```
+
+> **예외 검증 규칙**
+> - `RestApiException`을 던지는 메서드의 예외 케이스는 반드시 `errorCode`까지 검증하라.
+> - `.isInstanceOf(RestApiException.class)`만 단언하면 다른 errorCode로 회귀해도 테스트가 통과한다.
+> - `CustomErrorCode`는 static import로 가져와 식별자만 노출한다 (`CustomErrorCode.X` 사용 금지).
+>
+> **올바른 예시**
+> ```java
+> assertThatThrownBy(() -> chapterQueryService.getChapterSummary(chapterId))
+>         .isInstanceOf(RestApiException.class)
+>         .extracting(e -> ((RestApiException) e).getErrorCode())
+>         .isEqualTo(CHAPTER_NOT_FOUND);
+> ```
+>
+> **잘못된 예시** (사용 금지)
+> ```java
+> assertThatThrownBy(() -> chapterQueryService.getChapterSummary(chapterId))
+>         .isInstanceOf(RestApiException.class);  // ❌ errorCode 미검증
+> ```
 
 ## 통합 테스트
 
@@ -102,6 +124,18 @@ class {Target}IntegrationTest {
             ...
             // then
             assertThat(...).isEqualTo(...);
+        }
+
+        @Test
+        void 존재하지_않으면_예외를_던진다() {
+            // given
+            ...
+            // when & then
+            // 통합 테스트에서도 errorCode까지 검증한다
+            assertThatThrownBy(() -> target.method(param))
+                    .isInstanceOf(RestApiException.class)
+                    .extracting(e -> ((RestApiException) e).getErrorCode())
+                    .isEqualTo({ERROR_CODE});
         }
     }
 }

--- a/src/main/java/gravit/code/badge/listener/BadgeEventListener.java
+++ b/src/main/java/gravit/code/badge/listener/BadgeEventListener.java
@@ -64,7 +64,7 @@ public class BadgeEventListener {
 
             log.info("레슨 완료 뱃지 평가 완료");
         }catch(Exception e){
-            log.error("레슨 완료 뱃지 평가 에러: {}", e.getMessage());
+            log.error("레슨 완료 뱃지 평가 에러", e);
         }
     }
 
@@ -82,7 +82,7 @@ public class BadgeEventListener {
             );
 
         }catch(Exception e){
-            log.error("handleMissionCompleted 에러 : {}", e.getMessage());
+            log.error("handleMissionCompleted 에러", e);
         }
     }
 }

--- a/src/main/java/gravit/code/dailyLearningRecord/domain/DailyLearningRecord.java
+++ b/src/main/java/gravit/code/dailyLearningRecord/domain/DailyLearningRecord.java
@@ -46,7 +46,7 @@ public class DailyLearningRecord {
     ) {
         this.userId = userId;
         this.solvedDate = solvedDate;
-        this.solvedLessonCount = 1;
+        this.solvedLessonCount = 0;
     }
 
     public static DailyLearningRecord create(
@@ -57,5 +57,9 @@ public class DailyLearningRecord {
                 .userId(userId)
                 .solvedDate(solvedDate)
                 .build();
+    }
+
+    public void increaseSolvedLessonCount() {
+        this.solvedLessonCount++;
     }
 }

--- a/src/main/java/gravit/code/dailyLearningRecord/listener/DailyLearningRecordListener.java
+++ b/src/main/java/gravit/code/dailyLearningRecord/listener/DailyLearningRecordListener.java
@@ -26,7 +26,7 @@ public class DailyLearningRecordListener {
         try{
             dailyLearningRecordService.handleDailyLearningRecord(event.userId());
         } catch (Exception e) {
-            log.error("Exception occurred while handling Daily Learning Record event with {}", e.getMessage());
+            log.error("Exception occurred while handling Daily Learning Record event", e);
         }
     }
 }

--- a/src/main/java/gravit/code/dailyLearningRecord/listener/DailyLearningRecordListener.java
+++ b/src/main/java/gravit/code/dailyLearningRecord/listener/DailyLearningRecordListener.java
@@ -1,0 +1,32 @@
+package gravit.code.dailyLearningRecord.listener;
+
+import gravit.code.dailyLearningRecord.service.DailyLearningRecordService;
+import gravit.code.global.event.LessonCompletedEvent;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.log4j.Log4j2;
+import org.springframework.scheduling.annotation.Async;
+import org.springframework.stereotype.Component;
+import org.springframework.transaction.annotation.Transactional;
+import org.springframework.transaction.event.TransactionalEventListener;
+
+import static org.springframework.transaction.annotation.Propagation.REQUIRES_NEW;
+import static org.springframework.transaction.event.TransactionPhase.AFTER_COMMIT;
+
+@Async("dailyLearningRecordAsync")
+@Log4j2
+@Component
+@RequiredArgsConstructor
+public class DailyLearningRecordListener {
+
+    private final DailyLearningRecordService dailyLearningRecordService;
+
+    @Transactional(propagation = REQUIRES_NEW)
+    @TransactionalEventListener(phase = AFTER_COMMIT)
+    public void handleDailyLearningRecord(LessonCompletedEvent event) {
+        try{
+            dailyLearningRecordService.handleDailyLearningRecord(event.userId());
+        } catch (Exception e) {
+            log.error("Exception occurred while handling Daily Learning Record event with {}", e.getMessage());
+        }
+    }
+}

--- a/src/main/java/gravit/code/dailyLearningRecord/repository/DailyLearningRecordRepository.java
+++ b/src/main/java/gravit/code/dailyLearningRecord/repository/DailyLearningRecordRepository.java
@@ -7,6 +7,7 @@ import org.springframework.data.repository.query.Param;
 
 import java.time.LocalDate;
 import java.util.List;
+import java.util.Optional;
 
 public interface DailyLearningRecordRepository extends JpaRepository<DailyLearningRecord, Long> {
 
@@ -19,5 +20,16 @@ public interface DailyLearningRecordRepository extends JpaRepository<DailyLearni
             @Param("userId") long userId,
             @Param("startDate") LocalDate startDate,
             @Param("endDate") LocalDate endDate
+    );
+
+    @Query("""
+        SELECT dlr
+        FROM DailyLearningRecord dlr
+        WHERE dlr.userId = :userId
+          AND dlr.solvedDate = :solvedDate
+    """)
+    Optional<DailyLearningRecord> findByUserIdAndSolvedDate(
+            @Param("userId") long userId,
+            @Param("solvedDate") LocalDate solvedDate
     );
 }

--- a/src/main/java/gravit/code/dailyLearningRecord/service/DailyLearningRecordService.java
+++ b/src/main/java/gravit/code/dailyLearningRecord/service/DailyLearningRecordService.java
@@ -1,5 +1,6 @@
 package gravit.code.dailyLearningRecord.service;
 
+import gravit.code.dailyLearningRecord.domain.DailyLearningRecord;
 import gravit.code.dailyLearningRecord.dto.response.WeeklyLearningRecordResponse;
 import gravit.code.dailyLearningRecord.repository.DailyLearningRecordRepository;
 import lombok.RequiredArgsConstructor;
@@ -26,9 +27,7 @@ public class DailyLearningRecordService {
         LocalDate monday = today.with(DayOfWeek.MONDAY);
         LocalDate sunday = today.with(DayOfWeek.SUNDAY);
 
-        Set<DayOfWeek> solvedDays = dailyLearningRecordRepository
-                .findSolvedDatesByUserIdAndDateRange(userId, monday, sunday)
-                .stream()
+        Set<DayOfWeek> solvedDays = dailyLearningRecordRepository.findSolvedDatesByUserIdAndDateRange(userId, monday, sunday).stream()
                 .map(LocalDate::getDayOfWeek)
                 .collect(Collectors.toUnmodifiableSet());
 
@@ -41,5 +40,17 @@ public class DailyLearningRecordService {
                 solvedDays.contains(DayOfWeek.SATURDAY),
                 solvedDays.contains(DayOfWeek.SUNDAY)
         );
+    }
+
+    @Transactional
+    public void handleDailyLearningRecord(long userId) {
+        LocalDate today = LocalDate.now(KST);
+
+        DailyLearningRecord dailyLearningRecord = dailyLearningRecordRepository.findByUserIdAndSolvedDate(userId, today)
+                .orElseGet(() -> DailyLearningRecord.create(userId, today));
+
+        dailyLearningRecord.increaseSolvedLessonCount();
+
+        dailyLearningRecordRepository.save(dailyLearningRecord);
     }
 }

--- a/src/main/java/gravit/code/global/config/AsyncConfig.java
+++ b/src/main/java/gravit/code/global/config/AsyncConfig.java
@@ -55,4 +55,19 @@ public class AsyncConfig {
 
         return executor;
     }
+
+    @Bean(name = "dailyLearningRecordAsync")
+    public Executor dailyLearningRecordAsyncExecutor() {
+        ThreadPoolTaskExecutor executor = new ThreadPoolTaskExecutor();
+
+        executor.setCorePoolSize(2);
+        executor.setMaxPoolSize(4);
+        executor.setQueueCapacity(20);
+        executor.setKeepAliveSeconds(60);
+        executor.setAllowCoreThreadTimeOut(true);
+        executor.setThreadNamePrefix("DailyLearningRecordAsync - ");
+        executor.initialize();
+
+        return executor;
+    }
 }

--- a/src/main/java/gravit/code/learning/listener/LearningEventListener.java
+++ b/src/main/java/gravit/code/learning/listener/LearningEventListener.java
@@ -20,7 +20,7 @@ public class LearningEventListener {
         try{
             learningService.createLearning(event.userId());
         }catch (Exception e){
-            log.error("Exception occurred while creating Learning with {}", e.getMessage());
+            log.error("Exception occurred while creating Learning", e);
         }
     }
 }

--- a/src/main/java/gravit/code/mission/listener/MissionEventListener.java
+++ b/src/main/java/gravit/code/mission/listener/MissionEventListener.java
@@ -27,7 +27,7 @@ public class MissionEventListener {
                     event.accuracy()
             );
         }catch(Exception e){
-            log.error("Exception occurred while handling complete lesson mission event with {}", e.getMessage());
+            log.error("Exception occurred while handling complete lesson mission event", e);
         }
     }
 
@@ -36,7 +36,7 @@ public class MissionEventListener {
         try{
             missionService.handleFollowMission(followMissionDto);
         }catch(Exception e){
-            log.error("Exception occurred while handling follow mission event with {}", e.getMessage());
+            log.error("Exception occurred while handling follow mission event", e);
         }
     }
 
@@ -45,7 +45,7 @@ public class MissionEventListener {
         try{
             missionService.createMission(event.userId());
         }catch(Exception e){
-            log.error("Exception occurred while creating mission for new User with {}", e.getMessage());
+            log.error("Exception occurred while creating mission for new User", e);
         }
     }
 }

--- a/src/test/java/gravit/code/dailyLearningRecord/listener/DailyLearningRecordListenerIntegrationTest.java
+++ b/src/test/java/gravit/code/dailyLearningRecord/listener/DailyLearningRecordListenerIntegrationTest.java
@@ -1,0 +1,65 @@
+package gravit.code.dailyLearningRecord.listener;
+
+import gravit.code.dailyLearningRecord.service.DailyLearningRecordService;
+import gravit.code.global.event.LessonCompletedEvent;
+import gravit.code.mission.service.MissionService;
+import gravit.code.support.TCSpringBootTest;
+import gravit.code.userLeague.service.UserLeaguePointService;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Nested;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.context.ApplicationEventPublisher;
+import org.springframework.test.context.bean.override.mockito.MockitoBean;
+import org.springframework.test.context.bean.override.mockito.MockitoSpyBean;
+import org.springframework.test.context.jdbc.Sql;
+import org.springframework.test.context.transaction.TestTransaction;
+import org.springframework.transaction.annotation.Transactional;
+
+import java.util.concurrent.TimeUnit;
+
+import static org.awaitility.Awaitility.await;
+import static org.mockito.Mockito.verify;
+
+@TCSpringBootTest
+@Sql(scripts = "classpath:sql/truncate_all.sql", executionPhase = Sql.ExecutionPhase.BEFORE_TEST_METHOD)
+class DailyLearningRecordListenerIntegrationTest {
+
+    @Autowired
+    private ApplicationEventPublisher publisher;
+
+    @MockitoSpyBean
+    private DailyLearningRecordService dailyLearningRecordService;
+
+    // 같은 LessonCompletedEvent를 BEFORE_COMMIT으로 구독하는 다른 리스너의 의존성을 격리한다.
+    // - UserLeagueEventListener: try-catch 없음 → 예외 전파로 트랜잭션 롤백
+    // - MissionEventListener: try-catch 있지만 내부 @Transactional이 본 트랜잭션을 rollback-only로 마크
+    @MockitoBean
+    private UserLeaguePointService userLeaguePointService;
+
+    @MockitoBean
+    private MissionService missionService;
+
+    @Nested
+    @DisplayName("레슨 완료 이벤트가 발행되면")
+    class HandleDailyLearningRecord {
+
+        @Test
+        @Transactional
+        void 트랜잭션_커밋_후_비동기로_서비스의_일일_학습_기록_처리_메서드가_호출된다() {
+            // given
+            long userId = 1L;
+            LessonCompletedEvent event = new LessonCompletedEvent(userId, 10L, 100L, 20, 80, 120, 0, 1);
+
+            // when
+            publisher.publishEvent(event);
+            TestTransaction.flagForCommit();
+            TestTransaction.end();
+
+            // then
+            await().atMost(2, TimeUnit.SECONDS).untilAsserted(() ->
+                    verify(dailyLearningRecordService).handleDailyLearningRecord(userId)
+            );
+        }
+    }
+}

--- a/src/test/java/gravit/code/dailyLearningRecord/listener/DailyLearningRecordListenerUnitTest.java
+++ b/src/test/java/gravit/code/dailyLearningRecord/listener/DailyLearningRecordListenerUnitTest.java
@@ -1,0 +1,57 @@
+package gravit.code.dailyLearningRecord.listener;
+
+import gravit.code.dailyLearningRecord.service.DailyLearningRecordService;
+import gravit.code.global.event.LessonCompletedEvent;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Nested;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+import static org.assertj.core.api.Assertions.assertThatCode;
+import static org.mockito.Mockito.doThrow;
+import static org.mockito.Mockito.verify;
+
+@ExtendWith(MockitoExtension.class)
+class DailyLearningRecordListenerUnitTest {
+
+    @InjectMocks
+    private DailyLearningRecordListener dailyLearningRecordListener;
+
+    @Mock
+    private DailyLearningRecordService dailyLearningRecordService;
+
+    @Nested
+    @DisplayName("레슨 완료 이벤트를 처리할 때")
+    class HandleDailyLearningRecord {
+
+        @Test
+        void 이벤트_수신_시_서비스의_일일_학습_기록_처리_메서드를_호출한다() {
+            // given
+            long userId = 1L;
+            LessonCompletedEvent event = new LessonCompletedEvent(userId, 10L, 100L, 20, 80, 120, 0, 1);
+
+            // when
+            dailyLearningRecordListener.handleDailyLearningRecord(event);
+
+            // then
+            verify(dailyLearningRecordService).handleDailyLearningRecord(userId);
+        }
+
+        @Test
+        void 서비스에서_예외가_발생해도_외부로_전파되지_않는다() {
+            // given
+            long userId = 1L;
+            LessonCompletedEvent event = new LessonCompletedEvent(userId, 10L, 100L, 20, 80, 120, 0, 1);
+            doThrow(new RuntimeException("DB error"))
+                    .when(dailyLearningRecordService).handleDailyLearningRecord(userId);
+
+            // when & then
+            assertThatCode(() -> dailyLearningRecordListener.handleDailyLearningRecord(event))
+                    .doesNotThrowAnyException();
+            verify(dailyLearningRecordService).handleDailyLearningRecord(userId);
+        }
+    }
+}

--- a/src/test/java/gravit/code/dailyLearningRecord/service/DailyLearningRecordServiceIntegrationTest.java
+++ b/src/test/java/gravit/code/dailyLearningRecord/service/DailyLearningRecordServiceIntegrationTest.java
@@ -13,7 +13,9 @@ import org.springframework.test.context.jdbc.Sql;
 import java.time.DayOfWeek;
 import java.time.LocalDate;
 import java.time.ZoneId;
+import java.util.Optional;
 
+import static org.assertj.core.api.Assertions.assertThatCode;
 import static org.assertj.core.api.SoftAssertions.assertSoftly;
 
 @TCSpringBootTest
@@ -143,6 +145,97 @@ class DailyLearningRecordServiceIntegrationTest {
                 softly.assertThat(result.FRIDAY()).isFalse();
                 softly.assertThat(result.SATURDAY()).isFalse();
                 softly.assertThat(result.SUNDAY()).isFalse();
+            });
+        }
+    }
+
+    @Nested
+    @DisplayName("일일 학습 기록을 처리할 때")
+    class HandleDailyLearningRecord {
+
+        @Test
+        void 오늘_날짜_레코드가_없으면_새로_생성하고_카운트가_1이_된다() {
+            // given
+            long userId = 1L;
+            LocalDate today = LocalDate.now(KST);
+
+            // when
+            dailyLearningRecordService.handleDailyLearningRecord(userId);
+
+            // then
+            Optional<DailyLearningRecord> result = dailyLearningRecordRepository.findByUserIdAndSolvedDate(userId, today);
+            assertSoftly(softly -> {
+                softly.assertThat(result).isPresent();
+                softly.assertThat(result.get().getUserId()).isEqualTo(userId);
+                softly.assertThat(result.get().getSolvedDate()).isEqualTo(today);
+                softly.assertThat(result.get().getSolvedLessonCount()).isEqualTo(1);
+            });
+        }
+
+        @Test
+        void 오늘_날짜_레코드가_존재하면_카운트가_1_증가한다() {
+            // given
+            long userId = 1L;
+            LocalDate today = LocalDate.now(KST);
+            DailyLearningRecord existing = DailyLearningRecord.create(userId, today);
+            existing.increaseSolvedLessonCount();
+            dailyLearningRecordRepository.save(existing);
+
+            // when
+            dailyLearningRecordService.handleDailyLearningRecord(userId);
+
+            // then
+            DailyLearningRecord result = dailyLearningRecordRepository.findByUserIdAndSolvedDate(userId, today).orElseThrow();
+            assertSoftly(softly -> {
+                softly.assertThat(result.getId()).isEqualTo(existing.getId());
+                softly.assertThat(result.getSolvedLessonCount()).isEqualTo(2);
+                softly.assertThat(result.getSolvedDate()).isEqualTo(today);
+            });
+        }
+
+        @Test
+        void 같은_유저의_다른_날짜_레코드가_있어도_정상_처리된다() {
+            // given
+            long userId = 1L;
+            LocalDate today = LocalDate.now(KST);
+            LocalDate yesterday = today.minusDays(1);
+            LocalDate twoDaysAgo = today.minusDays(2);
+
+            DailyLearningRecord pastRecord1 = DailyLearningRecord.create(userId, yesterday);
+            pastRecord1.increaseSolvedLessonCount();
+            DailyLearningRecord pastRecord2 = DailyLearningRecord.create(userId, twoDaysAgo);
+            pastRecord2.increaseSolvedLessonCount();
+            dailyLearningRecordRepository.save(pastRecord1);
+            dailyLearningRecordRepository.save(pastRecord2);
+
+            // when & then
+            assertThatCode(() -> dailyLearningRecordService.handleDailyLearningRecord(userId))
+                    .doesNotThrowAnyException();
+
+            DailyLearningRecord todayRecord = dailyLearningRecordRepository.findByUserIdAndSolvedDate(userId, today).orElseThrow();
+            DailyLearningRecord yesterdayRecord = dailyLearningRecordRepository.findByUserIdAndSolvedDate(userId, yesterday).orElseThrow();
+            assertSoftly(softly -> {
+                softly.assertThat(todayRecord.getSolvedLessonCount()).isEqualTo(1);
+                softly.assertThat(yesterdayRecord.getSolvedLessonCount()).isEqualTo(1);
+            });
+        }
+
+        @Test
+        void 같은_메서드를_두_번_호출하면_카운트가_2가_된다() {
+            // given
+            long userId = 1L;
+            LocalDate today = LocalDate.now(KST);
+
+            // when
+            dailyLearningRecordService.handleDailyLearningRecord(userId);
+            dailyLearningRecordService.handleDailyLearningRecord(userId);
+
+            // then
+            DailyLearningRecord result = dailyLearningRecordRepository.findByUserIdAndSolvedDate(userId, today).orElseThrow();
+            assertSoftly(softly -> {
+                softly.assertThat(result.getSolvedLessonCount()).isEqualTo(2);
+                softly.assertThat(result.getUserId()).isEqualTo(userId);
+                softly.assertThat(result.getSolvedDate()).isEqualTo(today);
             });
         }
     }

--- a/src/test/java/gravit/code/dailyLearningRecord/service/DailyLearningRecordServiceUnitTest.java
+++ b/src/test/java/gravit/code/dailyLearningRecord/service/DailyLearningRecordServiceUnitTest.java
@@ -1,0 +1,100 @@
+package gravit.code.dailyLearningRecord.service;
+
+import gravit.code.dailyLearningRecord.domain.DailyLearningRecord;
+import gravit.code.dailyLearningRecord.repository.DailyLearningRecordRepository;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Nested;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.ArgumentCaptor;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+import java.time.LocalDate;
+import java.time.ZoneId;
+import java.util.Optional;
+
+import static org.assertj.core.api.SoftAssertions.assertSoftly;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+@ExtendWith(MockitoExtension.class)
+class DailyLearningRecordServiceUnitTest {
+
+    private static final ZoneId KST = ZoneId.of("Asia/Seoul");
+
+    @InjectMocks
+    private DailyLearningRecordService dailyLearningRecordService;
+
+    @Mock
+    private DailyLearningRecordRepository dailyLearningRecordRepository;
+
+    @Nested
+    @DisplayName("일일 학습 기록을 처리할 때")
+    class HandleDailyLearningRecord {
+
+        @Test
+        void 오늘_날짜_레코드가_존재하면_카운트가_1_증가한다() {
+            // given
+            long userId = 1L;
+            LocalDate today = LocalDate.now(KST);
+            DailyLearningRecord existing = DailyLearningRecord.create(userId, today);
+            existing.increaseSolvedLessonCount();
+
+            when(dailyLearningRecordRepository.findByUserIdAndSolvedDate(userId, today))
+                    .thenReturn(Optional.of(existing));
+
+            // when
+            dailyLearningRecordService.handleDailyLearningRecord(userId);
+
+            // then
+            assertSoftly(softly -> {
+                softly.assertThat(existing.getSolvedLessonCount()).isEqualTo(2);
+                softly.assertThat(existing.getUserId()).isEqualTo(userId);
+                softly.assertThat(existing.getSolvedDate()).isEqualTo(today);
+            });
+            verify(dailyLearningRecordRepository).save(existing);
+        }
+
+        @Test
+        void 오늘_날짜_레코드가_없으면_새로_생성하고_카운트가_1이_된다() {
+            // given
+            long userId = 1L;
+            LocalDate today = LocalDate.now(KST);
+
+            when(dailyLearningRecordRepository.findByUserIdAndSolvedDate(userId, today))
+                    .thenReturn(Optional.empty());
+
+            // when
+            dailyLearningRecordService.handleDailyLearningRecord(userId);
+
+            // then
+            ArgumentCaptor<DailyLearningRecord> captor = ArgumentCaptor.forClass(DailyLearningRecord.class);
+            verify(dailyLearningRecordRepository).save(captor.capture());
+
+            DailyLearningRecord saved = captor.getValue();
+            assertSoftly(softly -> {
+                softly.assertThat(saved.getUserId()).isEqualTo(userId);
+                softly.assertThat(saved.getSolvedDate()).isEqualTo(today);
+                softly.assertThat(saved.getSolvedLessonCount()).isEqualTo(1);
+            });
+        }
+
+        @Test
+        void 오늘_날짜를_조건으로_조회한다() {
+            // given
+            long userId = 1L;
+            LocalDate today = LocalDate.now(KST);
+
+            when(dailyLearningRecordRepository.findByUserIdAndSolvedDate(userId, today))
+                    .thenReturn(Optional.empty());
+
+            // when
+            dailyLearningRecordService.handleDailyLearningRecord(userId);
+
+            // then
+            verify(dailyLearningRecordRepository).findByUserIdAndSolvedDate(userId, today);
+        }
+    }
+}


### PR DESCRIPTION
### 1. 연관 이슈

---
 - close #334

<br>

### 2. 구현 사항

---
**구현 사항 1**

- 레슨 완료 이벤트(LessonCompletedEvent)를 비동기로 수신하여 일일 학습 기록을 처리하는 DailyLearningRecordListener를 추가하였습니다.
- 트랜잭션 커밋 후(AFTER_COMMIT) REQUIRES_NEW 전파 옵션으로 독립 트랜잭션에서 처리하며, 예외 발생 시 로깅 후 외부로 전파하지 않아 본 트랜잭션에 영향을 주지 않게 설계하였습니다.
- 전용 스레드풀(dailyLearningRecordAsync)을 AsyncConfig에 등록하여 다른 비동기 작업과 격리하였습니다.

<br>

**구현 사항 2**

- DailyLearningRecordService에 handleDailyLearningRecord 메서드를 추가하였습니다.
- 오늘 날짜의 레코드가 없으면 새로 생성하고, 있으면 카운트를 1 증가시킵니다.
- DailyLearningRecord 도메인에 increaseSolvedLessonCount 메서드를 추가하고, 생성 시 초기 카운트를 0으로 설정하여 - increaseSolvedLessonCount 호출로만 카운트를 증가시키도록 일관성을 맞췄습니다.

**구현 사항 3**

- DailyLearningRecordRepository에 userId와 solvedDate로 단건 조회하는 findByUserIdAndSolvedDate 메서드를 추가하였습니다.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## 릴리스 노트

* **New Features**
  * 일일 학습 기록을 자동으로 추적하고 처리하는 기능 추가
  * 레슨 완료 이벤트에 대한 비동기 처리 추가

* **Bug Fixes**
  * 예외 로깅을 개선하여 전체 스택 트레이스 포함

* **Tests**
  * 일일 학습 기록 처리 로직에 대한 통합 및 단위 테스트 추가
  * 테스트 예외 검증 규칙 강화

<!-- end of auto-generated comment: release notes by coderabbit.ai -->