### PR TITLE
hotfix: 프로덕션 CD에 workflow_dispatch 트리거 추가

### DIFF
--- a/.github/workflows/cd-prod.yml
+++ b/.github/workflows/cd-prod.yml
@@ -3,6 +3,12 @@ name: 프로덕션 서버 CD
 on:
   release:
     types: [published]
+  workflow_dispatch:
+    inputs:
+      image_tag:
+        description: '배포할 이미지 태그 (예: v1.0.0)'
+        required: true
+        default: 'v1.0.0'
 
 jobs:
   build:
@@ -14,6 +20,7 @@ jobs:
         uses: actions/checkout@v4
         with:
           submodules: 'recursive'
+          ref: ${{ github.event.inputs.image_tag || github.event.release.tag_name }}
 
       - name: JDK 버전 설정
         uses: actions/setup-java@v4
@@ -66,7 +73,7 @@ jobs:
 
       - name: 도커 이미지 빌드
         env:
-          IMAGE_TAG: ${{ github.event.release.tag_name }}
+          IMAGE_TAG: ${{ github.event.inputs.image_tag || github.event.release.tag_name }}
           DOCKER_USERNAME: ${{ secrets.DOCKER_HUB_USERNAME }}
         run: |
           docker build \
@@ -76,7 +83,7 @@ jobs:
 
       - name: 도커 이미지 푸쉬
         env:
-          IMAGE_TAG: ${{ github.event.release.tag_name }}
+          IMAGE_TAG: ${{ github.event.inputs.image_tag || github.event.release.tag_name }}
           DOCKER_USERNAME: ${{ secrets.DOCKER_HUB_USERNAME }}
         run: |
           docker push "$DOCKER_USERNAME/gravit-server:$IMAGE_TAG"
@@ -104,7 +111,7 @@ jobs:
       - name: 앱센터 서버에 배포
         uses: appleboy/ssh-action@v1.2.5
         env:
-          IMAGE_TAG: ${{ github.event.release.tag_name }}
+          IMAGE_TAG: ${{ github.event.inputs.image_tag || github.event.release.tag_name }}
           DOCKER_HUB_USERNAME: ${{ secrets.DOCKER_HUB_USERNAME }}
         with:
           host: ${{secrets.APPCENTER_SERVER_IP}}


### PR DESCRIPTION
## Summary
- 긴급 롤백을 위해 `workflow_dispatch` 수동 트리거 추가
- `image_tag` 입력값으로 원하는 버전을 직접 지정해 배포 가능
- release 이벤트 동작은 기존과 동일하게 유지

## 사용법 (머지 후)
Actions → 프로덕션 서버 CD → Run workflow → image_tag: v1.0.0