### PR TITLE
cicd: 인프라 서비스 설정 변경 시에만 재시작되도록 CD 개선 및 alloy-dev 추가(#348)

### DIFF
--- a/.claude/skills/create-pr/SKILL.md
+++ b/.claude/skills/create-pr/SKILL.md
@@ -1,0 +1,72 @@
+---
+name: create-pr
+description: |
+  PR을 생성한다. PULL_REQUEST_TEMPLATE.md 규격에 맞춰 본문을 작성하고 gh pr create를 실행한다.
+  Trigger: "PR 날려줘", "PR 만들어줘", "PR 생성해줘", "PR 올려줘"
+  Do NOT use for: 커밋 생성(직접 git commit), 브랜치 생성, 코드 리뷰
+  Boundary: PR 생성까지만 수행한다. 머지, 리뷰 요청, 라벨 설정은 범위 밖이다.
+allowed-tools: Bash(git *), Bash(gh *), Read
+---
+
+# PR 생성
+
+대상 브랜치: $ARGUMENTS (비어있으면 dev)
+
+## Phase 1: 현재 브랜치 및 변경 사항 파악
+
+1. `git branch --show-current`로 현재 브랜치명을 확인하라
+2. 브랜치명에서 이슈 번호를 추출하라 (형식: `{type}/#{이슈번호}-{설명}`)
+   - 예: `feat/#123-bookmark` → 이슈 번호 `123`
+   - 이슈 번호가 없으면 사용자에게 물어보라
+3. `git log dev..HEAD --oneline` (또는 $ARGUMENTS..HEAD)으로 이 브랜치의 커밋 목록을 확인하라
+4. `git diff dev...HEAD --stat`으로 변경된 파일 목록을 파악하라
+
+> 다음 Phase 조건: 이슈 번호와 변경 사항이 파악되었을 때
+
+> Skip 조건: 없음 (필수 Phase)
+
+## Phase 2: PR 제목 및 본문 작성
+
+1. `.github/PULL_REQUEST_TEMPLATE.md`를 Read로 읽어 템플릿 구조를 확인하라
+2. `.claude/rules/git-convention.md`를 Read로 읽어 커밋 타입과 네이밍 규칙을 확인하라
+3. 아래 템플릿에 맞춰 PR 본문을 작성하라:
+
+```
+### 1. 연관 이슈
+
+---
+ - close #{이슈번호}
+
+<br>
+
+### 2. 구현 사항
+
+---
+**{구현 사항 제목}**
+
+{변경된 파일과 커밋을 바탕으로 구현 내용을 구체적으로 설명. 왜 변경했는지, 어떻게 동작하는지 포함}
+```
+
+   - 구현 사항이 여러 개면 `**구현 사항 1**`, `**구현 사항 2**` 형태로 분리하라
+   - 커밋 메시지를 그대로 복사하지 말고, 변경 내용을 이해한 뒤 설명하라
+
+4. PR 제목은 git-convention.md의 커밋 메시지 형식을 따라라: `{type}: {설명}(#{이슈번호})`
+
+> 다음 Phase 조건: 제목과 본문이 완성되었을 때
+
+> Skip 조건: 없음 (필수 Phase)
+
+## Phase 3: PR 생성
+
+1. 대상 브랜치를 결정하라:
+   - $ARGUMENTS가 있으면 해당 브랜치로
+   - 없으면 `dev`로
+2. 현재 브랜치가 원격에 push되어 있는지 `git status`로 확인하라
+   - push되지 않았으면 사용자에게 알리고 중단하라
+3. 다음 명령으로 PR을 생성하라:
+   ```bash
+   gh pr create --title "{제목}" --body "{본문}" --base {대상 브랜치}
+   ```
+4. 생성된 PR URL을 사용자에게 보고하라
+
+> Skip 조건: 없음 (필수 Phase)

--- a/.claude/skills/create-pr/SKILL.md
+++ b/.claude/skills/create-pr/SKILL.md
@@ -15,8 +15,8 @@ allowed-tools: Bash(git *), Bash(gh *), Read
 ## Phase 1: 현재 브랜치 및 변경 사항 파악
 
 1. `git branch --show-current`로 현재 브랜치명을 확인하라
-2. 브랜치명에서 이슈 번호를 추출하라 (형식: `{type}/#{이슈번호}-{설명}`)
-   - 예: `feat/#123-bookmark` → 이슈 번호 `123`
+2. 브랜치명에서 이슈 번호를 추출하라 (형식: `{type}/{이슈번호}-{설명}`)
+   - 예: `feat/123-bookmark` → 이슈 번호 `123`
    - 이슈 번호가 없으면 사용자에게 물어보라
 3. `git log dev..HEAD --oneline` (또는 $ARGUMENTS..HEAD)으로 이 브랜치의 커밋 목록을 확인하라
 4. `git diff dev...HEAD --stat`으로 변경된 파일 목록을 파악하라

--- a/.github/workflows/cd-dev.yml
+++ b/.github/workflows/cd-dev.yml
@@ -87,7 +87,7 @@ jobs:
           username: ${{secrets.APPCENTER_SERVER_USERNAME}}
           password: ${{secrets.APPCENTER_SERVER_PASSWORD}}
           port: ${{secrets.APPCENTER_SERVER_PORT}}
-          source: "docker-compose-dev.yml"
+          source: "docker-compose-dev.yml,infra/config.alloy"
           target: "/home/serverking/gravit/dev"
 
       - name: 앱센터 서버에 배포

--- a/.github/workflows/cd-dev.yml
+++ b/.github/workflows/cd-dev.yml
@@ -105,6 +105,11 @@ jobs:
 
             echo "DOCKER_HUB_USERNAME=$DOCKER_HUB_USERNAME" > .env
 
+            # 인프라 서비스: compose 설정이 변경된 경우에만 재시작
+            docker-compose -f docker-compose-dev.yml up -d --no-deps gravit-redis-dev alloy-dev
+
+            # 앱 서버: 항상 최신 이미지로 재시작
             docker-compose -f docker-compose-dev.yml pull gravit-server-dev
             docker-compose -f docker-compose-dev.yml up -d --no-deps --force-recreate gravit-server-dev
+
             docker image prune -f

--- a/.github/workflows/cd-prod.yml
+++ b/.github/workflows/cd-prod.yml
@@ -118,6 +118,10 @@ jobs:
             echo "DOCKER_HUB_USERNAME=$DOCKER_HUB_USERNAME" > .env
             echo "IMAGE_TAG=$IMAGE_TAG" >> .env
 
+            # 인프라 서비스: compose 설정이 변경된 경우에만 재시작
+            docker-compose -f docker-compose-prod.yml up -d --no-deps gravit-redis-prod alloy
+
+            # 앱 서버: 항상 최신 이미지로 재시작
             docker-compose -f docker-compose-prod.yml pull gravit-server-prod
             docker-compose -f docker-compose-prod.yml up -d --no-deps --force-recreate gravit-server-prod
 

--- a/.github/workflows/cd-prod.yml
+++ b/.github/workflows/cd-prod.yml
@@ -98,7 +98,7 @@ jobs:
           username: ${{secrets.APPCENTER_SERVER_USERNAME}}
           password: ${{secrets.APPCENTER_SERVER_PASSWORD}}
           port: ${{secrets.APPCENTER_SERVER_PORT}}
-          source: "docker-compose-prod.yml"
+          source: "docker-compose-prod.yml,infra/config.alloy"
           target: "/home/serverking/gravit/prod"
 
       - name: 앱센터 서버에 배포

--- a/docker-compose-dev.yml
+++ b/docker-compose-dev.yml
@@ -43,7 +43,7 @@ services:
       - ALLOY_ENV=dev
     command: ["run", "/etc/alloy/config.alloy"]
     networks:
-      - gravit-monitoring
+      - gravit-dev
 
 volumes:
   redis_data:
@@ -51,5 +51,3 @@ volumes:
 networks:
   gravit-dev:
     driver: bridge
-  gravit-monitoring:
-    external: true

--- a/docker-compose-dev.yml
+++ b/docker-compose-dev.yml
@@ -31,9 +31,25 @@ services:
           cpus: '1'
           memory: 512M
 
+  alloy-dev:
+    image: grafana/alloy:latest
+    container_name: alloy-dev
+    ports:
+      - "12346:12345"
+    volumes:
+      - ./logs:/var/log/spring
+      - ./infra/config.alloy:/etc/alloy/config.alloy:ro
+    environment:
+      - ALLOY_ENV=dev
+    command: ["run", "/etc/alloy/config.alloy"]
+    networks:
+      - gravit-monitoring
+
 volumes:
   redis_data:
 
 networks:
   gravit-dev:
     driver: bridge
+  gravit-monitoring:
+    external: true

--- a/docker-compose-prod.yml
+++ b/docker-compose-prod.yml
@@ -48,10 +48,8 @@ services:
       - ALLOY_ENV=prod
     command: [ "run", "/etc/alloy/config.alloy" ]
     networks:
-      - gravit-monitoring
+      - gravit-prod
 
 networks:
   gravit-prod:
     driver: bridge
-  gravit-monitoring:
-    external: true

--- a/docker-compose-prod.yml
+++ b/docker-compose-prod.yml
@@ -45,10 +45,13 @@ services:
       - ./logs:/var/log/spring
       - ./infra/config.alloy:/etc/alloy/config.alloy:ro
     environment:
-      - ALLOY_ENV=production
+      - ALLOY_ENV=prod
     command: [ "run", "/etc/alloy/config.alloy" ]
     networks:
-      - gravit-prod
+      - gravit-monitoring
 
 networks:
   gravit-prod:
+    driver: bridge
+  gravit-monitoring:
+    external: true


### PR DESCRIPTION
### 1. 연관 이슈

---
 - close #348

<br>

### 2. 구현 사항

---
**인프라 서비스(Redis, Alloy) 변경 시에만 재시작되도록 CD 개선**

기존에는 매 배포마다 앱 서버만 재시작하고 Redis, Alloy는 항상 건드리지 않아 compose 설정이 변경되어도 반영되지 않는 문제가 있었습니다. `--force-recreate` 없이 `docker-compose up -d`를 실행하면 Docker Compose가 현재 실행 중인 컨테이너 설정과 compose 파일을 비교해 변경된 경우에만 재시작합니다.

**alloy-dev 서비스 추가**

dev 서버 로그를 기존 Loki 서버로 전송하기 위해 `docker-compose-dev.yml`에 `alloy-dev`를 추가했습니다. `ALLOY_ENV=dev` 환경변수로 Loki label을 구분하며, `gravit-dev` 네트워크에서 Loki에 접근합니다. (Loki가 `gravit-dev` 네트워크에 참여해야 합니다 — `monitoring-config.yml` 별도 수정 필요)

**config.alloy 서버 전송 추가**

기존 CD에서 compose 파일만 서버에 전송하고 `infra/config.alloy`는 전송하지 않아 Alloy 컨테이너 마운트 실패 문제가 있었습니다. SCP 전송 대상에 `infra/config.alloy`를 추가해 dev, prod 모두 수정했습니다.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## 릴리스 노트

* **Chores**
  * 배포 워크플로우에서 인프라 설정 파일 배포 범위 확대
  * 개발 및 운영 환경 서비스 재시작 로직 최적화
  * 모니터링 서비스 컨테이너 구성 추가
  * 개발팀 내부 문서 및 절차 가이드라인 추가

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/Team-Gravit/gravit-server/pull/350)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->