### PR TITLE
hotfix: Loki 버전을 2.9.8에서 latest로 업그레이드

### DIFF
--- a/docker-compose-local-monitor.yml
+++ b/docker-compose-local-monitor.yml
@@ -27,7 +27,7 @@ services:
     user: root
 
   loki:
-    image: grafana/loki:2.9.8
+    image: grafana/loki:latest
     container_name: gravit_loki
     ports:
       - "3100:3100"


### PR DESCRIPTION
### 1. 연관 이슈

---
없음

<br>

### 2. 구현 사항

---
**Loki 버전 업그레이드 (2.9.8 → latest)**

- Grafana 11.x와 Loki 2.9.8 간 버전 불일치로 로그 라벨 하이라이팅 및 색상이 표시되지 않는 문제 수정
- Loki 3.x부터 지원되는 `detected_level` 기능으로 로그 레벨(info/warn/error) 색상 자동 감지 가능
- `docker-compose-local-monitor.yml`의 loki 이미지를 `grafana/loki:latest`로 변경

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## 릴리스 노트

* **Chores**
  * 로컬 모니터링 환경의 Docker 이미지 버전을 최신 버전으로 업데이트했습니다.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/Team-Gravit/gravit-server/pull/352?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->