### PR TITLE
docs: OAuth dest 파라미터 설명에 dev 추가

### DIFF
--- a/src/main/java/gravit/code/auth/controller/docs/OAuthControllerDocs.java
+++ b/src/main/java/gravit/code/auth/controller/docs/OAuthControllerDocs.java
@@ -50,7 +50,7 @@ public interface OAuthControllerDocs {
     })
     @GetMapping("/login-url/{provider}")
     ResponseEntity<Map<String, String>> authorizeUrl(@Parameter(description = "제공자(kakao, naver, google) 이름") @PathVariable("provider") String provider,
-                                                     @Parameter(description = "Dest(local, prod)")  @RequestParam String dest);
+                                                     @Parameter(description = "Dest(local, dev, prod)")  @RequestParam String dest);
 
     @Operation(summary = "OAuth 회원가입/로그인 처리", description = "AuthCode를 기반으로 사용자 정보를 조회하고 회원가입 및 로그인 처리를 합니다")
     @ApiResponses({
@@ -89,5 +89,5 @@ public interface OAuthControllerDocs {
     @PostMapping("/{provider}")
     ResponseEntity<LoginResponse> oauthLogin(@Parameter(description = "제공자(kakao, naver, google) 이름") @PathVariable("provider") String provider,
                                              @RequestBody AuthCodeRequest authCodeRequest,
-                                             @Parameter(description = "Dest(local, prod)") @RequestParam String dest);
+                                             @Parameter(description = "Dest(local, dev, prod)") @RequestParam String dest);
 }


### PR DESCRIPTION
### 1. 연관 이슈

---
 - 없음

<br>

### 2. 구현 사항

---
**OAuth Swagger 파라미터 설명 업데이트**

`OAuthControllerDocs`의 `dest` 파라미터 설명이 `Dest(local, prod)`로만 기재되어 있어 `dev` dest가 누락된 상태였습니다. 실제로는 `local`, `dev`, `prod` 세 가지 dest를 모두 지원하므로 Swagger 문서의 파라미터 설명을 `Dest(local, dev, prod)`로 수정했습니다. 로그인 URL 조회(`GET /login-url/{provider}`)와 OAuth 로그인 처리(`POST /{provider}`) 두 엔드포인트 모두 반영했습니다.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## 릴리스 노트

* **문서 개선**
  * OAuth 로그인 API의 `dest` 파라미터 설명이 업데이트되었습니다. 이제 로컬, 개발, 프로덕션 환경을 모두 지원하는 것을 명확히 표시합니다.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/Team-Gravit/gravit-server/pull/353?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->