### PR TITLE
fix: 유닛 진행도를 미완료/완료 2단계에서 미완료/진행중/완료 3단계로 세분화(#359)

### DIFF
--- a/src/main/java/gravit/code/unit/domain/UnitProgressStatus.java
+++ b/src/main/java/gravit/code/unit/domain/UnitProgressStatus.java
@@ -1,0 +1,7 @@
+package gravit.code.unit.domain;
+
+public enum UnitProgressStatus {
+    NOT_STARTED,
+    IN_PROGRESS,
+    COMPLETED
+}

--- a/src/main/java/gravit/code/unit/dto/internal/UnitProgressRowDto.java
+++ b/src/main/java/gravit/code/unit/dto/internal/UnitProgressRowDto.java
@@ -1,6 +1,9 @@
 package gravit.code.unit.dto.internal;
 
+import gravit.code.unit.domain.UnitProgressStatus;
 import gravit.code.unit.dto.response.UnitProgressSummaryResponse;
+
+import static gravit.code.unit.domain.UnitProgressStatus.*;
 
 public record UnitProgressRowDto(
     long unitId,
@@ -9,8 +12,16 @@ public record UnitProgressRowDto(
     long solvedLessons
 ) {
     public UnitProgressSummaryResponse toSummary(){
-        boolean completed = totalLessons > 0 && totalLessons == solvedLessons;
+        UnitProgressStatus unitProgressStatus;
 
-        return UnitProgressSummaryResponse.of(unitId, title, completed);
+        if(solvedLessons == 0){
+            unitProgressStatus = NOT_STARTED;
+        }else if(solvedLessons >= totalLessons){
+            unitProgressStatus = COMPLETED;
+        }else{
+            unitProgressStatus = IN_PROGRESS;
+        }
+
+        return UnitProgressSummaryResponse.of(unitId, title, unitProgressStatus);
     }
 }

--- a/src/main/java/gravit/code/unit/dto/response/UnitProgressSummaryResponse.java
+++ b/src/main/java/gravit/code/unit/dto/response/UnitProgressSummaryResponse.java
@@ -1,5 +1,6 @@
 package gravit.code.unit.dto.response;
 
+import gravit.code.unit.domain.UnitProgressStatus;
 import lombok.Builder;
 
 import static lombok.AccessLevel.PRIVATE;
@@ -8,17 +9,17 @@ import static lombok.AccessLevel.PRIVATE;
 public record UnitProgressSummaryResponse(
         long unitId,
         String title,
-        boolean isCompleted
+        UnitProgressStatus status
 ) {
     public static UnitProgressSummaryResponse of(
             long unitId,
             String title,
-            boolean isCompleted
+            UnitProgressStatus status
     ){
         return UnitProgressSummaryResponse.builder()
                 .unitId(unitId)
                 .title(title)
-                .isCompleted(isCompleted)
+                .status(status)
                 .build();
     }
 }

--- a/src/test/java/gravit/code/unit/service/UnitQueryServiceIntegrationTest.java
+++ b/src/test/java/gravit/code/unit/service/UnitQueryServiceIntegrationTest.java
@@ -163,7 +163,7 @@ class UnitQueryServiceIntegrationTest {
             assertSoftly(softly -> {
                 softly.assertThat(result).hasSize(1);
                 softly.assertThat(result.get(0).unitId()).isEqualTo(unit.getId());
-                softly.assertThat(result.get(0).isCompleted()).isTrue();
+                softly.assertThat(result.get(0).status()).isTrue();
             });
         }
 
@@ -183,7 +183,7 @@ class UnitQueryServiceIntegrationTest {
             // then
             assertSoftly(softly -> {
                 softly.assertThat(result).hasSize(1);
-                softly.assertThat(result.get(0).isCompleted()).isFalse();
+                softly.assertThat(result.get(0).status()).isFalse();
             });
         }
 
@@ -200,7 +200,7 @@ class UnitQueryServiceIntegrationTest {
             // then
             assertSoftly(softly -> {
                 softly.assertThat(result).hasSize(1);
-                softly.assertThat(result.get(0).isCompleted()).isFalse();
+                softly.assertThat(result.get(0).status()).isFalse();
             });
         }
 

--- a/src/test/java/gravit/code/unit/service/UnitQueryServiceIntegrationTest.java
+++ b/src/test/java/gravit/code/unit/service/UnitQueryServiceIntegrationTest.java
@@ -22,6 +22,9 @@ import org.springframework.test.context.jdbc.Sql;
 import java.util.List;
 
 import static gravit.code.global.exception.domain.CustomErrorCode.UNIT_NOT_FOUND;
+import static gravit.code.unit.domain.UnitProgressStatus.COMPLETED;
+import static gravit.code.unit.domain.UnitProgressStatus.IN_PROGRESS;
+import static gravit.code.unit.domain.UnitProgressStatus.NOT_STARTED;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
 import static org.assertj.core.api.SoftAssertions.assertSoftly;
@@ -163,12 +166,12 @@ class UnitQueryServiceIntegrationTest {
             assertSoftly(softly -> {
                 softly.assertThat(result).hasSize(1);
                 softly.assertThat(result.get(0).unitId()).isEqualTo(unit.getId());
-                softly.assertThat(result.get(0).status()).isTrue();
+                softly.assertThat(result.get(0).status()).isEqualTo(COMPLETED);
             });
         }
 
         @Test
-        void 일부_레슨만_푼_유닛은_미완료로_표시된다() {
+        void 일부_레슨만_푼_유닛은_진행중으로_표시된다() {
             // given
             long userId = 1L;
             Chapter chapter = chapterRepository.save(Chapter.create("운영체제", "운영체제 기초 개념"));
@@ -183,12 +186,12 @@ class UnitQueryServiceIntegrationTest {
             // then
             assertSoftly(softly -> {
                 softly.assertThat(result).hasSize(1);
-                softly.assertThat(result.get(0).status()).isFalse();
+                softly.assertThat(result.get(0).status()).isEqualTo(IN_PROGRESS);
             });
         }
 
         @Test
-        void 레슨이_없는_유닛은_미완료로_표시된다() {
+        void 레슨이_없는_유닛은_시작전으로_표시된다() {
             // given
             long userId = 1L;
             Chapter chapter = chapterRepository.save(Chapter.create("운영체제", "운영체제 기초 개념"));
@@ -200,7 +203,7 @@ class UnitQueryServiceIntegrationTest {
             // then
             assertSoftly(softly -> {
                 softly.assertThat(result).hasSize(1);
-                softly.assertThat(result.get(0).status()).isFalse();
+                softly.assertThat(result.get(0).status()).isEqualTo(NOT_STARTED);
             });
         }
 


### PR DESCRIPTION
### 1. 연관 이슈

---
 - close #359

<br>

### 2. 구현 사항

---
**유닛 진행도 상태 3단계 세분화**

기존에는 챕터 내 유닛 진행도를 `isCompleted` boolean 값(완료 / 미완료)으로만 표현했으나, 프론트에서 "시작 전 / 진행 중 / 완료" 3단계를 구분해 노출해야 하는 요구사항이 생겨 응답 스펙을 변경했습니다.

- `UnitProgressStatus` enum 신규 추가 (`NOT_STARTED`, `IN_PROGRESS`, `COMPLETED`)
- `UnitProgressSummaryResponse`의 `isCompleted: boolean` 필드를 `status: UnitProgressStatus`로 교체
- `UnitProgressRowDto.toSummary()`에서 `solvedLessons` 와 `totalLessons` 비교를 통해 상태를 결정하도록 분기 추가
  - `solvedLessons == 0` → `NOT_STARTED` (레슨이 없는 빈 유닛도 동일하게 처리)
  - `solvedLessons >= totalLessons` → `COMPLETED`
  - 그 외 → `IN_PROGRESS`
- 관련 통합 테스트(`UnitQueryServiceIntegrationTest`)를 새 enum 기준으로 수정하고, 일부 레슨만 푼 케이스 / 빈 유닛 케이스의 메서드명을 의미에 맞게 변경했습니다.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## 릴리스 노트

* **새로운 기능**
  * 유닛 진행 상태 표시 개선: 기존의 단순 완료/미완료 표시에서 "시작 전", "진행 중", "완료"의 세 가지 상태로 세분화되어 학습 진행도를 더욱 정확하게 추적할 수 있습니다.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/Team-Gravit/gravit-server/pull/360?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->