### PR TITLE
feat: 팔로워 목록 조회 시 맞팔 여부(isFollowing) 추가

### DIFF
--- a/src/main/java/gravit/code/friend/controller/docs/FriendControllerDocs.java
+++ b/src/main/java/gravit/code/friend/controller/docs/FriendControllerDocs.java
@@ -145,10 +145,38 @@ public interface FriendControllerDocs {
     @Operation(summary = "팔로워 목록 조회", description = "현재 사용자를 팔로우하고 있는 사용자 목록을 조회합니다<br>" +
             "🔐 <strong>Jwt 필요</strong><br>" +
             "<strong>Slice 페이징을 적용합니다</strong><br>" +
-            "쿼리 파라미터로 page 값을 보내주세요(0부터 시작)"
+            "쿼리 파라미터로 page 값을 보내주세요(0부터 시작)<br>" +
+            "<strong>isFollowing</strong>: 내가 해당 팔로워를 팔로우하고 있으면 true (맞팔 여부)"
     )
     @ApiResponses({
-            @ApiResponse(responseCode = "200", description = "✅ 팔로워 목록 조회 성공"),
+            @ApiResponse(responseCode = "200", description = "✅ 팔로워 목록 조회 성공",
+                    content = @Content(mediaType = MediaType.APPLICATION_JSON_VALUE,
+                            examples = @ExampleObject(
+                                    name = "성공 예시",
+                                    value = """
+                                            {
+                                              "hasNextPage": false,
+                                              "contents": [
+                                                {
+                                                  "id": 1,
+                                                  "nickname": "김나영",
+                                                  "profileImgNumber": 2,
+                                                  "handle": "@1235cws",
+                                                  "isFollowing": false
+                                                },
+                                                {
+                                                  "id": 2,
+                                                  "nickname": "이철수",
+                                                  "profileImgNumber": 3,
+                                                  "handle": "@iron99",
+                                                  "isFollowing": true
+                                                }
+                                              ]
+                                            }
+                                            """
+                            )
+                    )
+            ),
             @ApiResponse(responseCode = "500", description = "🚨 예기치 못한 예외 발생",
                     content = @Content(mediaType = MediaType.APPLICATION_JSON_VALUE,
                             examples = {

--- a/src/main/java/gravit/code/friend/dto/response/FollowerResponse.java
+++ b/src/main/java/gravit/code/friend/dto/response/FollowerResponse.java
@@ -9,6 +9,7 @@ public record FollowerResponse(
         String nickname,
         int profileImgNumber,
         @NotNull
-        String handle
+        String handle,
+        boolean isFollowing
 ) {
 }

--- a/src/main/java/gravit/code/friend/repository/FriendRepository.java
+++ b/src/main/java/gravit/code/friend/repository/FriendRepository.java
@@ -29,10 +29,12 @@ public interface FriendRepository extends JpaRepository<Friend, Long>, FriendSea
                 u.id,
                 u.nickname,
                 u.profileImgNumber,
-                u.handle
+                u.handle,
+                case when f2.id is not null then true else false end
             )
             from Friend f
             join User u on u.id = f.followerId
+            left join Friend f2 on f2.followerId = :followeeId and f2.followeeId = u.id
             where f.followeeId = :followeeId
             """)
     Slice<FollowerResponse> findFollowersByFolloweeId(

--- a/src/test/java/gravit/code/friend/service/FriendServiceTest.java
+++ b/src/test/java/gravit/code/friend/service/FriendServiceTest.java
@@ -1,142 +1,139 @@
-//package gravit.code.friend.service;
-//
-//import gravit.code.friend.domain.Friend;
-//import gravit.code.friend.domain.FriendRepository;
-//import gravit.code.friend.dto.response.FollowerResponse;
-//import gravit.code.friend.dto.response.FollowingResponse;
-//import gravit.code.friend.dto.response.FriendResponse;
-//import gravit.code.global.dto.response.SliceResponse;
-//import gravit.code.support.TCSpringBootTest;
-//import gravit.code.user.domain.Role;
-//import gravit.code.user.domain.User;
-//import gravit.code.user.domain.UserRepository;
-//import org.junit.jupiter.api.Test;
-//import org.springframework.beans.factory.annotation.Autowired;
-//import org.springframework.data.domain.PageRequest;
-//import org.springframework.data.domain.Pageable;
-//import org.springframework.data.domain.Slice;
-//import org.springframework.test.context.jdbc.Sql;
-//
-//import static org.assertj.core.api.AssertionsForClassTypes.assertThat;
-//import static org.junit.jupiter.api.Assertions.*;
-//
-//@TCSpringBootTest
-//@Sql(scripts = "classpath:sql/truncate_all.sql", executionPhase = Sql.ExecutionPhase.BEFORE_TEST_METHOD)
-//class FriendServiceTest {
-//
-//    @Autowired
-//    private FriendService friendService;
-//
-//    @Autowired
-//    private UserRepository userRepository;
-//
-//    @Autowired
-//    private FriendRepository friendRepository;
-//
-//    @Test
-//    void 상호_팔로우_가능한지_검증() {
-//        // given
-//        User user1 = User.create("user1@example.com", "kakao1231513141231", "User1", "@user1", 1, Role.USER);
-//        userRepository.save(user1);
-//        User user2 = User.create("user2@example.com", "google123677438112", "User2", "@user2", 2, Role.USER);
-//        userRepository.save(user2);
-//
-//        // when
-//        FriendResponse response1 = friendService.following(user1.getId(), user2.getId()); // user2 -> user1
-//        FriendResponse response2 = friendService.following(user2.getId(), user1.getId()); // user1 -> user2
-//
-//
-//        // then
-//        assertEquals(response1.followerId(), user1.getId());
-//        assertEquals(response1.followeeId(), user2.getId());
-//
-//        assertEquals(response2.followerId(), user2.getId());
-//        assertEquals(response2.followeeId(), user1.getId());
-//
-//        // 추가 검증
-//        assertTrue(friendRepository.existsByFollowerIdAndFolloweeId(user1.getId(), user2.getId()));
-//        assertTrue(friendRepository.existsByFollowerIdAndFolloweeId(user2.getId(), user1.getId()));
-//
-//    }
-//
-//    @Test
-//    void 팔로잉을_한_유저를_대상으로_팔로잉을_취소합니다() {
-//        // given
-//        User user1 = User.create("user1@example.com", "kakao1231513141231", "User1", "@user1", 1,Role.USER);
-//        userRepository.save(user1);
-//        User user2 = User.create("user2@example.com", "google123677438112", "User2", "@user2", 2, Role.USER);
-//        userRepository.save(user2);
-//        friendService.following(user1.getId(), user2.getId());
-//        Pageable pageable = PageRequest.of(0, 10);
-//
-//        // when
-//        friendService.unFollowing(user1.getId(), user2.getId());
-//
-//        // then
-//        Slice<FollowingResponse> followings = friendRepository.findFollowingsByFollowerId(user1.getId(), pageable);
-//        assertThat(followings.getContent().isEmpty()).isTrue();
-//    }
-//
-//    @Test
-//    void 나를_팔로우_한_사람들을_조회합니다() {
-//        // given
-//        User user1 = User.create("user1@example.com", "kakao1231513141231", "User1", "@user1", 1, Role.USER);
-//        userRepository.save(user1);
-//        User user2 = User.create("user2@example.com", "kakao1258853439443", "User2", "@user2", 1, Role.USER);
-//        userRepository.save(user2);
-//        User user3 = User.create("user3@example.com", "kakao6438123471324", "User3", "@user3", 1, Role.USER);
-//        userRepository.save(user3);
-//
-//        Friend friend1 = Friend.create(user1.getId(), user2.getId());
-//        friendRepository.save(friend1);
-//        Friend friend2 = Friend.create(user1.getId(), user3.getId());
-//        friendRepository.save(friend2);
-//        Friend friend3 = Friend.create(user2.getId(), user1.getId());
-//        friendRepository.save(friend3);
-//        Friend friend4 = Friend.create(user3.getId(), user1.getId());
-//        friendRepository.save(friend4);
-//
-//        // when
-//        SliceResponse<FollowerResponse> followerResponses = friendService.getFollowers(user1.getId(), 0);
-//
-//        // then
-//        assertEquals(2, followerResponses.contents().size());
-//        for (FollowerResponse followerResponse : followerResponses.contents()) {
-//            assertNotNull(followerResponse.nickname());
-//            assertNotNull(followerResponse.handle());
-//            assertTrue(followerResponse.profileImgNumber() > 0);
-//        }
-//    }
-//
-//    @Test
-//    void 내가_팔로우_한_사람들을_조회합니다() {
-//        // given
-//        User user1 = User.create("user1@example.com", "kakao1231513141231", "User1", "@user1", 1, Role.USER);
-//        userRepository.save(user1);
-//        User user2 = User.create("user2@example.com", "kakao1258853439443", "User2", "@user2", 1, Role.USER);
-//        userRepository.save(user2);
-//        User user3 = User.create("user3@example.com", "kakao6438123471324", "User3", "@user3", 1, Role.USER);
-//        userRepository.save(user3);
-//
-//        Friend friend1 = Friend.create(user1.getId(), user2.getId());
-//        friendRepository.save(friend1);
-//        Friend friend2 = Friend.create(user1.getId(), user3.getId());
-//        friendRepository.save(friend2);
-//        Friend friend3 = Friend.create(user2.getId(), user1.getId());
-//        friendRepository.save(friend3);
-//        Friend friend4 = Friend.create(user3.getId(), user1.getId());
-//        friendRepository.save(friend4);
-//
-//        // when
-//        SliceResponse<FollowingResponse> followingResponses = friendService.getFollowings(user1.getId(), 0);
-//
-//        // then
-//        assertEquals(2, followingResponses.contents().size());
-//
-//        for (FollowingResponse followingResponse : followingResponses.contents()) {
-//            assertNotNull(followingResponse.nickname());
-//            assertNotNull(followingResponse.handle());
-//            assertTrue(followingResponse.profileImgNumber() > 0);
-//        }
-//    }
-//}
+package gravit.code.friend.service;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+
+import gravit.code.friend.dto.response.FollowerResponse;
+import gravit.code.friend.fixture.FriendFixture;
+import gravit.code.global.dto.response.SliceResponse;
+import gravit.code.global.exception.domain.RestApiException;
+import gravit.code.support.TCSpringBootTest;
+import gravit.code.user.domain.User;
+import gravit.code.user.fixture.UserFixture;
+import java.util.List;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+
+@TCSpringBootTest
+class FriendServiceTest {
+
+    @Autowired
+    private FriendService friendService;
+
+    @Autowired
+    private UserFixture userFixture;
+
+    @Autowired
+    private FriendFixture friendFixture;
+
+    @Test
+    void 나를_팔로우한_사람을_내가_팔로우하지_않으면_isFollowing이_false다() {
+        // given
+        User me = userFixture.일반_유저(1);
+        User follower = userFixture.일반_유저(2);
+        friendFixture.팔로우(follower, me);
+
+        // when
+        SliceResponse<FollowerResponse> result = friendService.getFollowers(me.getId(), 0);
+
+        // then
+        assertThat(result.contents()).hasSize(1);
+        assertThat(result.contents().get(0).id()).isEqualTo(follower.getId());
+        assertThat(result.contents().get(0).isFollowing()).isFalse();
+    }
+
+    @Test
+    void 나를_팔로우한_사람을_내가도_팔로우하면_isFollowing이_true다() {
+        // given
+        User me = userFixture.일반_유저(1);
+        User follower = userFixture.일반_유저(2);
+        friendFixture.팔로우(follower, me);
+        friendFixture.팔로우(me, follower);
+
+        // when
+        SliceResponse<FollowerResponse> result = friendService.getFollowers(me.getId(), 0);
+
+        // then
+        assertThat(result.contents()).hasSize(1);
+        assertThat(result.contents().get(0).isFollowing()).isTrue();
+    }
+
+    @Test
+    void 팔로워_목록에서_맞팔과_단방향_팔로워가_혼재할_때_isFollowing이_각각_올바르게_반환된다() {
+        // given
+        User me = userFixture.일반_유저(1);
+        User mutualFollower = userFixture.일반_유저(2);
+        User oneWayFollower = userFixture.일반_유저(3);
+
+        friendFixture.팔로우(mutualFollower, me);
+        friendFixture.팔로우(me, mutualFollower); // 맞팔
+        friendFixture.팔로우(oneWayFollower, me); // 단방향
+
+        // when
+        SliceResponse<FollowerResponse> result = friendService.getFollowers(me.getId(), 0);
+
+        // then
+        assertThat(result.contents()).hasSize(2);
+        List<FollowerResponse> contents = result.contents();
+
+        FollowerResponse mutual = contents.stream()
+                .filter(r -> r.id() == mutualFollower.getId())
+                .findFirst().orElseThrow();
+        FollowerResponse oneWay = contents.stream()
+                .filter(r -> r.id() == oneWayFollower.getId())
+                .findFirst().orElseThrow();
+
+        assertThat(mutual.isFollowing()).isTrue();
+        assertThat(oneWay.isFollowing()).isFalse();
+    }
+
+    @Test
+    void 팔로워가_없으면_빈_목록을_반환한다() {
+        // given
+        User me = userFixture.일반_유저(1);
+
+        // when
+        SliceResponse<FollowerResponse> result = friendService.getFollowers(me.getId(), 0);
+
+        // then
+        assertThat(result.contents()).isEmpty();
+        assertThat(result.hasNextPage()).isFalse();
+    }
+
+    @Test
+    void 자기_자신에게_팔로잉하면_예외가_발생한다() {
+        // given
+        User me = userFixture.일반_유저(1);
+
+        // when & then
+        assertThatThrownBy(() -> friendService.following(me.getId(), me.getId()))
+                .isInstanceOf(RestApiException.class);
+    }
+
+    @Test
+    void 이미_팔로잉_중인_유저에게_팔로잉하면_예외가_발생한다() {
+        // given
+        User me = userFixture.일반_유저(1);
+        User target = userFixture.일반_유저(2);
+        friendFixture.팔로우(me, target);
+
+        // when & then
+        assertThatThrownBy(() -> friendService.following(me.getId(), target.getId()))
+                .isInstanceOf(RestApiException.class);
+    }
+
+    @Test
+    void 팔로잉_취소_시_팔로워_목록에서_제거된다() {
+        // given
+        User me = userFixture.일반_유저(1);
+        User follower = userFixture.일반_유저(2);
+        friendFixture.팔로우(me, follower);
+
+        // when
+        friendService.unFollowing(me.getId(), follower.getId());
+
+        // then
+        SliceResponse<FollowerResponse> result = friendService.getFollowers(follower.getId(), 0);
+        assertThat(result.contents()).isEmpty();
+    }
+}


### PR DESCRIPTION
### 1. 연관 이슈

---
없음

<br>

### 2. 구현 사항

---
**팔로워 목록 응답에 isFollowing 필드 추가**

`GET /api/v1/friends/follower` API의 응답에 `isFollowing` 필드를 추가했습니다.

팔로워 목록은 "나를 팔로우하는 사람들"의 목록이므로, 각 팔로워에 대해 내가 맞팔로우하고 있는지 여부를 클라이언트가 알 수 없었습니다. 이를 해결하기 위해 `FollowerResponse`에 `isFollowing: boolean` 필드를 추가했습니다.

- `isFollowing = false` → 내가 해당 팔로워를 팔로우하지 않은 상태 (팔로우 버튼 표시)
- `isFollowing = true` → 내가 해당 팔로워를 팔로우하는 상태, 즉 맞팔 (맞팔로우 / 팔로우 취소 버튼 표시)

**구현 방식**

`FriendRepository`의 JPQL 쿼리에 `LEFT JOIN + CASE WHEN`을 사용하여 맞팔 여부를 단일 쿼리로 조회합니다.

```sql
left join Friend f2 on f2.followerId = :followeeId and f2.followeeId = u.id
...
case when f2.id is not null then true else false end
```

EXISTS 서브쿼리 방식은 Hibernate 6 HQL 전용 확장이라 IntelliJ JPQL 검사기에서 에러가 발생하므로, 표준 JPQL 범위 내의 LEFT JOIN 방식으로 구현했습니다.

**테스트 추가**

`FriendServiceTest`를 새로 작성하여 아래 케이스를 검증합니다.
- 단방향 팔로워 → `isFollowing = false`
- 맞팔 팔로워 → `isFollowing = true`
- 맞팔/단방향 혼재 시 각각 올바르게 반환
- 팔로워 없을 때 빈 목록 반환
- 셀프 팔로우 / 중복 팔로우 예외 처리
- 언팔 후 팔로워 목록에서 제거 확인

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **새로운 기능**
  * 팔로워 목록 조회 시 각 팔로워에 대한 팔로우 여부 정보 추가
  * 팔로워 응답 데이터에 팔로우 상태 필드 포함

* **문서**
  * 팔로워 목록 조회 API 문서 개선 (쿼리 파라미터 설명 및 응답 구조 상세화)

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/Team-Gravit/gravit-server/pull/361?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->