### PR TITLE
feat: 소셜 피드 응답 개선 및 리그 히스토리 필드 추가

### DIFF
--- a/src/main/java/gravit/code/league/dto/response/LeagueHistoryResponse.java
+++ b/src/main/java/gravit/code/league/dto/response/LeagueHistoryResponse.java
@@ -15,7 +15,9 @@ public record LeagueHistoryResponse(
 ) {
     public record SeasonHistoryEntry(
             String seasonKey,
-            String leagueName
+            String leagueName,
+            int sortOrder,
+            boolean isCurrent
     ) {}
 
     public static LeagueHistoryResponse of(

--- a/src/main/java/gravit/code/social/dto/internal/SocialFeedProjection.java
+++ b/src/main/java/gravit/code/social/dto/internal/SocialFeedProjection.java
@@ -12,7 +12,6 @@ public record SocialFeedProjection(
         String actorHandle,
         FeedEventType eventType,
         String eventValue,
-        LocalDateTime createdAt,
-        LocalDateTime congratulatedAt
+        LocalDateTime createdAt
 ) {
 }

--- a/src/main/java/gravit/code/social/dto/response/SocialFeedResponse.java
+++ b/src/main/java/gravit/code/social/dto/response/SocialFeedResponse.java
@@ -4,6 +4,8 @@ import gravit.code.social.domain.FeedEventType;
 import gravit.code.social.dto.internal.SocialFeedProjection;
 
 import java.time.LocalDateTime;
+import java.time.ZoneId;
+import java.time.temporal.ChronoUnit;
 
 public record SocialFeedResponse(
         Long feedId,
@@ -12,10 +14,14 @@ public record SocialFeedResponse(
         int actorProfileImgNumber,
         String actorHandle,
         String message,
-        LocalDateTime createdAt,
-        LocalDateTime congratulatedAt
+        String timeAgo,
+        boolean canCongratulate,
+        LocalDateTime createdAt
 ) {
-    public static SocialFeedResponse from(SocialFeedProjection projection) {
+    public static SocialFeedResponse from(
+            SocialFeedProjection projection,
+            boolean canCongratulate
+    ) {
         return new SocialFeedResponse(
                 projection.id(),
                 projection.actorId(),
@@ -23,8 +29,9 @@ public record SocialFeedResponse(
                 projection.actorProfileImgNumber(),
                 projection.actorHandle(),
                 generateMessage(projection.eventType(), projection.actorNickname(), projection.eventValue()),
-                projection.createdAt(),
-                projection.congratulatedAt()
+                computeTimeAgo(projection.createdAt()),
+                canCongratulate,
+                projection.createdAt()
         );
     }
 
@@ -39,5 +46,19 @@ public record SocialFeedResponse(
             case TIER_PROMOTION -> nickname + "님이 " + eventValue + "로 승급했어요!";
             case LEVEL_UP -> nickname + "님이 LV." + eventValue + "로 레벨업했어요!";
         };
+    }
+
+    private static String computeTimeAgo(LocalDateTime createdAt) {
+        LocalDateTime now = LocalDateTime.now(ZoneId.of("Asia/Seoul"));
+        long minutes = ChronoUnit.MINUTES.between(createdAt, now);
+
+        if (minutes < 1) return "방금 전";
+        if (minutes < 60) return minutes + "분 전";
+
+        long hours = ChronoUnit.HOURS.between(createdAt, now);
+        if (hours < 24) return hours + "시간 전";
+
+        long days = ChronoUnit.DAYS.between(createdAt, now);
+        return Math.min(days, 7) + "일 전";
     }
 }

--- a/src/main/java/gravit/code/social/repository/CongratulationRepository.java
+++ b/src/main/java/gravit/code/social/repository/CongratulationRepository.java
@@ -6,6 +6,7 @@ import org.springframework.data.jpa.repository.Query;
 import org.springframework.data.repository.query.Param;
 
 import java.time.LocalDateTime;
+import java.util.List;
 
 public interface CongratulationRepository extends JpaRepository<Congratulation, Long> {
 
@@ -16,6 +17,17 @@ public interface CongratulationRepository extends JpaRepository<Congratulation, 
     long countTodayByUserIdAndActorId(
             @Param("userId") long userId,
             @Param("actorId") long actorId,
+            @Param("startOfDay") LocalDateTime startOfDay
+    );
+
+    @Query("""
+            SELECT c.actorId FROM Congratulation c
+            WHERE c.userId = :userId AND c.actorId IN :actorIds AND c.createdAt >= :startOfDay
+            GROUP BY c.actorId HAVING COUNT(c) >= 3
+            """)
+    List<Long> findActorIdsWithLimitReached(
+            @Param("userId") long userId,
+            @Param("actorIds") List<Long> actorIds,
             @Param("startOfDay") LocalDateTime startOfDay
     );
 

--- a/src/main/java/gravit/code/social/repository/UserFeedRepository.java
+++ b/src/main/java/gravit/code/social/repository/UserFeedRepository.java
@@ -15,7 +15,7 @@ public interface UserFeedRepository extends JpaRepository<UserFeed, Long> {
     @Query("""
             SELECT new gravit.code.social.dto.internal.SocialFeedProjection(
                 sf.id, sf.actorId, u.nickname, u.profileImgNumber, u.handle,
-                sf.eventType, sf.eventValue, sf.createdAt, uf.congratulatedAt
+                sf.eventType, sf.eventValue, sf.createdAt
             )
             FROM UserFeed uf
             JOIN SocialFeed sf ON sf.id = uf.feedId

--- a/src/main/java/gravit/code/social/service/SocialFeedService.java
+++ b/src/main/java/gravit/code/social/service/SocialFeedService.java
@@ -7,6 +7,7 @@ import gravit.code.social.domain.FeedEventType;
 import gravit.code.social.domain.SocialFeed;
 import gravit.code.social.dto.internal.SocialFeedProjection;
 import gravit.code.social.dto.response.SocialFeedResponse;
+import gravit.code.social.repository.CongratulationRepository;
 import gravit.code.social.repository.SocialFeedRepository;
 import gravit.code.social.repository.UserFeedRepository;
 import lombok.RequiredArgsConstructor;
@@ -16,14 +17,23 @@ import org.springframework.data.domain.Slice;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
+import java.time.LocalDate;
+import java.time.LocalDateTime;
+import java.time.ZoneId;
+import java.util.HashSet;
+import java.util.List;
+import java.util.Set;
+
 @Service
 @RequiredArgsConstructor
 public class SocialFeedService {
 
     private static final int PAGE_SIZE = 4;
+    private static final ZoneId SEOUL = ZoneId.of("Asia/Seoul");
 
     private final SocialFeedRepository socialFeedRepository;
     private final UserFeedRepository userFeedRepository;
+    private final CongratulationRepository congratulationRepository;
 
     @Transactional
     public SocialFeed createFeed(
@@ -42,8 +52,26 @@ public class SocialFeedService {
         int safePage = Math.max(0, page);
         Pageable pageable = PageRequest.of(safePage, PAGE_SIZE);
         Slice<SocialFeedProjection> projections = userFeedRepository.findVisibleFeedsByUserId(userId, pageable);
-        Slice<SocialFeedResponse> responses = projections.map(SocialFeedResponse::from);
+
+        Set<Long> limitReachedActorIds = resolveActorIdsWithLimitReached(userId, projections.getContent());
+        Slice<SocialFeedResponse> responses = projections.map(p ->
+                SocialFeedResponse.from(p, !limitReachedActorIds.contains(p.actorId())));
         return SliceResponse.of(responses);
+    }
+
+    private Set<Long> resolveActorIdsWithLimitReached(
+            long userId,
+            List<SocialFeedProjection> projections
+    ) {
+        List<Long> actorIds = projections.stream()
+                .map(SocialFeedProjection::actorId)
+                .distinct()
+                .toList();
+        if (actorIds.isEmpty()) {
+            return Set.of();
+        }
+        LocalDateTime startOfDay = LocalDate.now(SEOUL).atStartOfDay();
+        return new HashSet<>(congratulationRepository.findActorIdsWithLimitReached(userId, actorIds, startOfDay));
     }
 
     @Transactional(readOnly = true)

--- a/src/main/java/gravit/code/userLeagueHistory/controller/LeagueHistoryController.java
+++ b/src/main/java/gravit/code/userLeagueHistory/controller/LeagueHistoryController.java
@@ -8,6 +8,7 @@ import lombok.RequiredArgsConstructor;
 import org.springframework.http.ResponseEntity;
 import org.springframework.security.core.annotation.AuthenticationPrincipal;
 import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.PathVariable;
 import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RestController;
 
@@ -21,5 +22,10 @@ public class LeagueHistoryController implements LeagueHistoryControllerDocs {
     @GetMapping("/me")
     public ResponseEntity<LeagueHistoryResponse> getMyLeagueHistory(@AuthenticationPrincipal LoginUser loginUser) {
         return ResponseEntity.ok(leagueHistoryService.getMyLeagueHistory(loginUser.getId()));
+    }
+
+    @GetMapping("/{userId}")
+    public ResponseEntity<LeagueHistoryResponse> getUserLeagueHistory(@PathVariable long userId) {
+        return ResponseEntity.ok(leagueHistoryService.getUserLeagueHistory(userId));
     }
 }

--- a/src/main/java/gravit/code/userLeagueHistory/controller/docs/LeagueHistoryControllerDocs.java
+++ b/src/main/java/gravit/code/userLeagueHistory/controller/docs/LeagueHistoryControllerDocs.java
@@ -10,10 +10,12 @@ import io.swagger.v3.oas.annotations.media.Schema;
 import io.swagger.v3.oas.annotations.responses.ApiResponse;
 import io.swagger.v3.oas.annotations.responses.ApiResponses;
 import io.swagger.v3.oas.annotations.tags.Tag;
+import io.swagger.v3.oas.annotations.Parameter;
 import org.springframework.http.MediaType;
 import org.springframework.http.ResponseEntity;
 import org.springframework.security.core.annotation.AuthenticationPrincipal;
 import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.PathVariable;
 
 @Tag(name = "League History API", description = "리그 히스토리 관련 API")
 public interface LeagueHistoryControllerDocs {
@@ -40,5 +42,29 @@ public interface LeagueHistoryControllerDocs {
     @GetMapping("/me")
     ResponseEntity<LeagueHistoryResponse> getMyLeagueHistory(
             @AuthenticationPrincipal LoginUser loginUser
+    );
+
+    @Operation(
+            summary = "특정 유저 리그 히스토리 조회",
+            description = "특정 유저의 시즌별 최종 티어 기록을 조회합니다."
+    )
+    @ApiResponses({
+            @ApiResponse(responseCode = "200", description = "✅ 리그 히스토리 조회 성공"),
+            @ApiResponse(
+                    responseCode = "404",
+                    description = "🚨 ACTIVE 시즌 없음",
+                    content = @Content(
+                            mediaType = MediaType.APPLICATION_JSON_VALUE,
+                            schema = @Schema(implementation = ErrorResponse.class),
+                            examples = @ExampleObject(
+                                    name = "ACTIVE 시즌 없음",
+                                    value = "{\"error\":\"SEASON_4041\",\"message\":\"ACTIVE 시즌이 없습니다.\"}"
+                            )
+                    )
+            )
+    })
+    @GetMapping("/{userId}")
+    ResponseEntity<LeagueHistoryResponse> getUserLeagueHistory(
+            @Parameter(description = "조회할 유저 ID") @PathVariable long userId
     );
 }

--- a/src/main/java/gravit/code/userLeagueHistory/service/LeagueHistoryService.java
+++ b/src/main/java/gravit/code/userLeagueHistory/service/LeagueHistoryService.java
@@ -33,6 +33,11 @@ public class LeagueHistoryService {
         return buildLeagueHistory(userId);
     }
 
+    @Transactional(readOnly = true)
+    public LeagueHistoryResponse getUserLeagueHistory(long userId) {
+        return buildLeagueHistory(userId);
+    }
+
     private LeagueHistoryResponse buildLeagueHistory(long userId) {
         Season activeSeason = seasonRepository.findByStatus(SeasonStatus.ACTIVE)
                 .orElseThrow(() -> new RestApiException(CustomErrorCode.ACTIVE_SEASON_NOT_FOUND));
@@ -49,13 +54,17 @@ public class LeagueHistoryService {
         for (UserLeagueHistory h : histories) {
             seasonHistory.add(new LeagueHistoryResponse.SeasonHistoryEntry(
                     h.getSeason().getSeasonKey(),
-                    h.getFinalLeague().getName()
+                    h.getFinalLeague().getName(),
+                    h.getFinalLeague().getSortOrder(),
+                    false
             ));
         }
         currentUserLeague.ifPresent(ul -> seasonHistory.add(
                 new LeagueHistoryResponse.SeasonHistoryEntry(
                         activeSeason.getSeasonKey(),
-                        ul.getLeague().getName()
+                        ul.getLeague().getName(),
+                        ul.getLeague().getSortOrder(),
+                        true
                 )
         ));
 

--- a/src/test/java/gravit/code/social/facade/SocialFacadeIntegrationTest.java
+++ b/src/test/java/gravit/code/social/facade/SocialFacadeIntegrationTest.java
@@ -101,8 +101,9 @@ class SocialFacadeIntegrationTest {
                 softly.assertThat(response.actorHandle()).isEqualTo("h2");
                 softly.assertThat(response.actorProfileImgNumber()).isEqualTo(1);
                 softly.assertThat(response.message()).isEqualTo("유저2님이 LV.5로 레벨업했어요!");
+                softly.assertThat(response.timeAgo()).isNotNull();
+                softly.assertThat(response.canCongratulate()).isTrue();
                 softly.assertThat(response.createdAt()).isNotNull();
-                softly.assertThat(response.congratulatedAt()).isNull();
             });
         }
 

--- a/src/test/java/gravit/code/userLeagueHistory/service/LeagueHistoryServiceTest.java
+++ b/src/test/java/gravit/code/userLeagueHistory/service/LeagueHistoryServiceTest.java
@@ -77,6 +77,8 @@ class LeagueHistoryServiceTest {
                 softly.assertThat(result.bestLeagueName()).isEqualTo("브론즈 3");
                 softly.assertThat(result.seasonHistory()).hasSize(1);
                 softly.assertThat(result.seasonHistory().get(0).seasonKey()).isEqualTo("2025-S2");
+                softly.assertThat(result.seasonHistory().get(0).sortOrder()).isEqualTo(1); // bronze3
+                softly.assertThat(result.seasonHistory().get(0).isCurrent()).isTrue();
             });
         }
 
@@ -95,7 +97,11 @@ class LeagueHistoryServiceTest {
                 softly.assertThat(result.totalSeasonCount()).isEqualTo(2);
                 softly.assertThat(result.seasonHistory()).hasSize(2);
                 softly.assertThat(result.seasonHistory().get(0).seasonKey()).isEqualTo("2025-S1");
+                softly.assertThat(result.seasonHistory().get(0).sortOrder()).isEqualTo(4); // silver3
+                softly.assertThat(result.seasonHistory().get(0).isCurrent()).isFalse();
                 softly.assertThat(result.seasonHistory().get(1).seasonKey()).isEqualTo("2025-S2");
+                softly.assertThat(result.seasonHistory().get(1).sortOrder()).isEqualTo(1); // bronze3
+                softly.assertThat(result.seasonHistory().get(1).isCurrent()).isTrue();
             });
         }
 


### PR DESCRIPTION
### 1. 연관 이슈

---
없음

<br>

### 2. 구현 사항

---
**소셜 피드 응답 개선**

`SocialFeedResponse`에 `timeAgo`(상대 시간 문자열)와 `canCongratulate`(오늘 축하 가능 여부) 필드를 추가하고, 기존 `congratulatedAt` 필드를 제거했습니다.

- `timeAgo`: 피드 생성 시각을 "방금 전 / N분 전 / N시간 전 / N일 전" 형태의 문자열로 변환하여 클라이언트가 별도 계산 없이 바로 사용할 수 있도록 했습니다.
- `canCongratulate`: `CongratulationRepository`에서 오늘 이미 축하한 actor ID를 조회하여, 하루 축하 한도에 도달하지 않은 경우 `true`를 반환합니다. 단일 쿼리로 전체 피드의 축하 가능 여부를 일괄 처리합니다.
- `SocialFeedProjection`에서 `congratulatedAt` 제거, `UserFeedRepository` 및 `CongratulationRepository` 쿼리 업데이트.

**리그 히스토리 응답 필드 추가**

`LeagueHistoryResponse.SeasonHistoryEntry`에 `sortOrder`(리그 정렬 순서)와 `isCurrent`(현재 시즌 여부) 필드를 추가했습니다.

- `sortOrder`: 클라이언트가 리그 티어를 정렬할 수 있도록 `League.getSortOrder()` 값을 포함합니다.
- `isCurrent`: 현재 활성 시즌의 히스토리 항목에는 `true`, 과거 히스토리에는 `false`를 설정합니다.
- `LeagueHistoryService`에 타 서비스에서 호출 가능한 `getUserLeagueHistory(long userId)` public 메서드를 추가했습니다.