### PR TITLE
feat: 소셜 피드 message에서 닉네임 제거

### DIFF
--- a/src/main/java/gravit/code/friend/controller/docs/FriendControllerDocs.java
+++ b/src/main/java/gravit/code/friend/controller/docs/FriendControllerDocs.java
@@ -145,10 +145,38 @@ public interface FriendControllerDocs {
     @Operation(summary = "팔로워 목록 조회", description = "현재 사용자를 팔로우하고 있는 사용자 목록을 조회합니다<br>" +
             "🔐 <strong>Jwt 필요</strong><br>" +
             "<strong>Slice 페이징을 적용합니다</strong><br>" +
-            "쿼리 파라미터로 page 값을 보내주세요(0부터 시작)"
+            "쿼리 파라미터로 page 값을 보내주세요(0부터 시작)<br>" +
+            "<strong>isFollowing</strong>: 내가 해당 팔로워를 팔로우하고 있으면 true (맞팔 여부)"
     )
     @ApiResponses({
-            @ApiResponse(responseCode = "200", description = "✅ 팔로워 목록 조회 성공"),
+            @ApiResponse(responseCode = "200", description = "✅ 팔로워 목록 조회 성공",
+                    content = @Content(mediaType = MediaType.APPLICATION_JSON_VALUE,
+                            examples = @ExampleObject(
+                                    name = "성공 예시",
+                                    value = """
+                                            {
+                                              "hasNextPage": false,
+                                              "contents": [
+                                                {
+                                                  "id": 1,
+                                                  "nickname": "김나영",
+                                                  "profileImgNumber": 2,
+                                                  "handle": "@1235cws",
+                                                  "isFollowing": false
+                                                },
+                                                {
+                                                  "id": 2,
+                                                  "nickname": "이철수",
+                                                  "profileImgNumber": 3,
+                                                  "handle": "@iron99",
+                                                  "isFollowing": true
+                                                }
+                                              ]
+                                            }
+                                            """
+                            )
+                    )
+            ),
             @ApiResponse(responseCode = "500", description = "🚨 예기치 못한 예외 발생",
                     content = @Content(mediaType = MediaType.APPLICATION_JSON_VALUE,
                             examples = {

--- a/src/main/java/gravit/code/friend/dto/response/FollowerResponse.java
+++ b/src/main/java/gravit/code/friend/dto/response/FollowerResponse.java
@@ -9,6 +9,7 @@ public record FollowerResponse(
         String nickname,
         int profileImgNumber,
         @NotNull
-        String handle
+        String handle,
+        boolean isFollowing
 ) {
 }

--- a/src/main/java/gravit/code/friend/repository/FriendRepository.java
+++ b/src/main/java/gravit/code/friend/repository/FriendRepository.java
@@ -29,10 +29,12 @@ public interface FriendRepository extends JpaRepository<Friend, Long>, FriendSea
                 u.id,
                 u.nickname,
                 u.profileImgNumber,
-                u.handle
+                u.handle,
+                case when f2.id is not null then true else false end
             )
             from Friend f
             join User u on u.id = f.followerId
+            left join Friend f2 on f2.followerId = :followeeId and f2.followeeId = u.id
             where f.followeeId = :followeeId
             """)
     Slice<FollowerResponse> findFollowersByFolloweeId(

--- a/src/main/java/gravit/code/league/dto/response/LeagueHistoryResponse.java
+++ b/src/main/java/gravit/code/league/dto/response/LeagueHistoryResponse.java
@@ -15,7 +15,9 @@ public record LeagueHistoryResponse(
 ) {
     public record SeasonHistoryEntry(
             String seasonKey,
-            String leagueName
+            String leagueName,
+            int sortOrder,
+            boolean isCurrent
     ) {}
 
     public static LeagueHistoryResponse of(

--- a/src/main/java/gravit/code/social/controller/docs/SocialControllerDocs.java
+++ b/src/main/java/gravit/code/social/controller/docs/SocialControllerDocs.java
@@ -145,7 +145,7 @@ public interface SocialControllerDocs {
                                                   "actorNickname": "테스터",
                                                   "actorProfileImgNumber": 3,
                                                   "actorHandle": "@tester01",
-                                                  "message": "테스터님이 지구 행성을 정복했어요!",
+                                                  "message": "지구 행성을 정복했어요!",
                                                   "createdAt": "2026-05-22T10:00:00"
                                                 }
                                               ]

--- a/src/main/java/gravit/code/social/dto/internal/SocialFeedProjection.java
+++ b/src/main/java/gravit/code/social/dto/internal/SocialFeedProjection.java
@@ -12,7 +12,6 @@ public record SocialFeedProjection(
         String actorHandle,
         FeedEventType eventType,
         String eventValue,
-        LocalDateTime createdAt,
-        LocalDateTime congratulatedAt
+        LocalDateTime createdAt
 ) {
 }

--- a/src/main/java/gravit/code/social/dto/response/SocialFeedResponse.java
+++ b/src/main/java/gravit/code/social/dto/response/SocialFeedResponse.java
@@ -4,6 +4,8 @@ import gravit.code.social.domain.FeedEventType;
 import gravit.code.social.dto.internal.SocialFeedProjection;
 
 import java.time.LocalDateTime;
+import java.time.ZoneId;
+import java.time.temporal.ChronoUnit;
 
 public record SocialFeedResponse(
         Long feedId,
@@ -12,10 +14,14 @@ public record SocialFeedResponse(
         int actorProfileImgNumber,
         String actorHandle,
         String message,
-        LocalDateTime createdAt,
-        LocalDateTime congratulatedAt
+        String timeAgo,
+        boolean canCongratulate,
+        LocalDateTime createdAt
 ) {
-    public static SocialFeedResponse from(SocialFeedProjection projection) {
+    public static SocialFeedResponse from(
+            SocialFeedProjection projection,
+            boolean canCongratulate
+    ) {
         return new SocialFeedResponse(
                 projection.id(),
                 projection.actorId(),
@@ -23,8 +29,9 @@ public record SocialFeedResponse(
                 projection.actorProfileImgNumber(),
                 projection.actorHandle(),
                 generateMessage(projection.eventType(), projection.actorNickname(), projection.eventValue()),
-                projection.createdAt(),
-                projection.congratulatedAt()
+                computeTimeAgo(projection.createdAt()),
+                canCongratulate,
+                projection.createdAt()
         );
     }
 
@@ -39,5 +46,19 @@ public record SocialFeedResponse(
             case TIER_PROMOTION -> nickname + "님이 " + eventValue + "로 승급했어요!";
             case LEVEL_UP -> nickname + "님이 LV." + eventValue + "로 레벨업했어요!";
         };
+    }
+
+    private static String computeTimeAgo(LocalDateTime createdAt) {
+        LocalDateTime now = LocalDateTime.now(ZoneId.of("Asia/Seoul"));
+        long minutes = ChronoUnit.MINUTES.between(createdAt, now);
+
+        if (minutes < 1) return "방금 전";
+        if (minutes < 60) return minutes + "분 전";
+
+        long hours = ChronoUnit.HOURS.between(createdAt, now);
+        if (hours < 24) return hours + "시간 전";
+
+        long days = ChronoUnit.DAYS.between(createdAt, now);
+        return Math.min(days, 7) + "일 전";
     }
 }

--- a/src/main/java/gravit/code/social/dto/response/SocialFeedResponse.java
+++ b/src/main/java/gravit/code/social/dto/response/SocialFeedResponse.java
@@ -28,7 +28,7 @@ public record SocialFeedResponse(
                 projection.actorNickname(),
                 projection.actorProfileImgNumber(),
                 projection.actorHandle(),
-                generateMessage(projection.eventType(), projection.actorNickname(), projection.eventValue()),
+                generateMessage(projection.eventType(), projection.eventValue()),
                 computeTimeAgo(projection.createdAt()),
                 canCongratulate,
                 projection.createdAt()
@@ -37,14 +37,13 @@ public record SocialFeedResponse(
 
     private static String generateMessage(
             FeedEventType eventType,
-            String nickname,
             String eventValue
     ) {
         return switch (eventType) {
-            case PLANET_COMPLETE -> nickname + "님이 " + eventValue + " 행성을 정복했어요!";
-            case STREAK_DAYS -> nickname + "님이 " + eventValue + "일 연속 학습을 달성했어요!";
-            case TIER_PROMOTION -> nickname + "님이 " + eventValue + "로 승급했어요!";
-            case LEVEL_UP -> nickname + "님이 LV." + eventValue + "로 레벨업했어요!";
+            case PLANET_COMPLETE -> eventValue + " 행성을 정복했어요!";
+            case STREAK_DAYS -> eventValue + "일 연속 학습을 달성했어요!";
+            case TIER_PROMOTION -> eventValue + "로 승급했어요!";
+            case LEVEL_UP -> "LV." + eventValue + "로 레벨업했어요!";
         };
     }
 

--- a/src/main/java/gravit/code/social/repository/CongratulationRepository.java
+++ b/src/main/java/gravit/code/social/repository/CongratulationRepository.java
@@ -6,6 +6,7 @@ import org.springframework.data.jpa.repository.Query;
 import org.springframework.data.repository.query.Param;
 
 import java.time.LocalDateTime;
+import java.util.List;
 
 public interface CongratulationRepository extends JpaRepository<Congratulation, Long> {
 
@@ -16,6 +17,17 @@ public interface CongratulationRepository extends JpaRepository<Congratulation, 
     long countTodayByUserIdAndActorId(
             @Param("userId") long userId,
             @Param("actorId") long actorId,
+            @Param("startOfDay") LocalDateTime startOfDay
+    );
+
+    @Query("""
+            SELECT c.actorId FROM Congratulation c
+            WHERE c.userId = :userId AND c.actorId IN :actorIds AND c.createdAt >= :startOfDay
+            GROUP BY c.actorId HAVING COUNT(c) >= 3
+            """)
+    List<Long> findActorIdsWithLimitReached(
+            @Param("userId") long userId,
+            @Param("actorIds") List<Long> actorIds,
             @Param("startOfDay") LocalDateTime startOfDay
     );
 

--- a/src/main/java/gravit/code/social/repository/UserFeedRepository.java
+++ b/src/main/java/gravit/code/social/repository/UserFeedRepository.java
@@ -15,7 +15,7 @@ public interface UserFeedRepository extends JpaRepository<UserFeed, Long> {
     @Query("""
             SELECT new gravit.code.social.dto.internal.SocialFeedProjection(
                 sf.id, sf.actorId, u.nickname, u.profileImgNumber, u.handle,
-                sf.eventType, sf.eventValue, sf.createdAt, uf.congratulatedAt
+                sf.eventType, sf.eventValue, sf.createdAt
             )
             FROM UserFeed uf
             JOIN SocialFeed sf ON sf.id = uf.feedId

--- a/src/main/java/gravit/code/social/service/SocialFeedService.java
+++ b/src/main/java/gravit/code/social/service/SocialFeedService.java
@@ -7,6 +7,7 @@ import gravit.code.social.domain.FeedEventType;
 import gravit.code.social.domain.SocialFeed;
 import gravit.code.social.dto.internal.SocialFeedProjection;
 import gravit.code.social.dto.response.SocialFeedResponse;
+import gravit.code.social.repository.CongratulationRepository;
 import gravit.code.social.repository.SocialFeedRepository;
 import gravit.code.social.repository.UserFeedRepository;
 import lombok.RequiredArgsConstructor;
@@ -16,14 +17,23 @@ import org.springframework.data.domain.Slice;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
+import java.time.LocalDate;
+import java.time.LocalDateTime;
+import java.time.ZoneId;
+import java.util.HashSet;
+import java.util.List;
+import java.util.Set;
+
 @Service
 @RequiredArgsConstructor
 public class SocialFeedService {
 
     private static final int PAGE_SIZE = 4;
+    private static final ZoneId SEOUL = ZoneId.of("Asia/Seoul");
 
     private final SocialFeedRepository socialFeedRepository;
     private final UserFeedRepository userFeedRepository;
+    private final CongratulationRepository congratulationRepository;
 
     @Transactional
     public SocialFeed createFeed(
@@ -42,8 +52,26 @@ public class SocialFeedService {
         int safePage = Math.max(0, page);
         Pageable pageable = PageRequest.of(safePage, PAGE_SIZE);
         Slice<SocialFeedProjection> projections = userFeedRepository.findVisibleFeedsByUserId(userId, pageable);
-        Slice<SocialFeedResponse> responses = projections.map(SocialFeedResponse::from);
+
+        Set<Long> limitReachedActorIds = resolveActorIdsWithLimitReached(userId, projections.getContent());
+        Slice<SocialFeedResponse> responses = projections.map(p ->
+                SocialFeedResponse.from(p, !limitReachedActorIds.contains(p.actorId())));
         return SliceResponse.of(responses);
+    }
+
+    private Set<Long> resolveActorIdsWithLimitReached(
+            long userId,
+            List<SocialFeedProjection> projections
+    ) {
+        List<Long> actorIds = projections.stream()
+                .map(SocialFeedProjection::actorId)
+                .distinct()
+                .toList();
+        if (actorIds.isEmpty()) {
+            return Set.of();
+        }
+        LocalDateTime startOfDay = LocalDate.now(SEOUL).atStartOfDay();
+        return new HashSet<>(congratulationRepository.findActorIdsWithLimitReached(userId, actorIds, startOfDay));
     }
 
     @Transactional(readOnly = true)

--- a/src/main/java/gravit/code/userLeagueHistory/controller/LeagueHistoryController.java
+++ b/src/main/java/gravit/code/userLeagueHistory/controller/LeagueHistoryController.java
@@ -8,6 +8,7 @@ import lombok.RequiredArgsConstructor;
 import org.springframework.http.ResponseEntity;
 import org.springframework.security.core.annotation.AuthenticationPrincipal;
 import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.PathVariable;
 import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RestController;
 
@@ -21,5 +22,10 @@ public class LeagueHistoryController implements LeagueHistoryControllerDocs {
     @GetMapping("/me")
     public ResponseEntity<LeagueHistoryResponse> getMyLeagueHistory(@AuthenticationPrincipal LoginUser loginUser) {
         return ResponseEntity.ok(leagueHistoryService.getMyLeagueHistory(loginUser.getId()));
+    }
+
+    @GetMapping("/{userId}")
+    public ResponseEntity<LeagueHistoryResponse> getUserLeagueHistory(@PathVariable long userId) {
+        return ResponseEntity.ok(leagueHistoryService.getUserLeagueHistory(userId));
     }
 }

--- a/src/main/java/gravit/code/userLeagueHistory/controller/docs/LeagueHistoryControllerDocs.java
+++ b/src/main/java/gravit/code/userLeagueHistory/controller/docs/LeagueHistoryControllerDocs.java
@@ -10,10 +10,12 @@ import io.swagger.v3.oas.annotations.media.Schema;
 import io.swagger.v3.oas.annotations.responses.ApiResponse;
 import io.swagger.v3.oas.annotations.responses.ApiResponses;
 import io.swagger.v3.oas.annotations.tags.Tag;
+import io.swagger.v3.oas.annotations.Parameter;
 import org.springframework.http.MediaType;
 import org.springframework.http.ResponseEntity;
 import org.springframework.security.core.annotation.AuthenticationPrincipal;
 import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.PathVariable;
 
 @Tag(name = "League History API", description = "리그 히스토리 관련 API")
 public interface LeagueHistoryControllerDocs {
@@ -40,5 +42,29 @@ public interface LeagueHistoryControllerDocs {
     @GetMapping("/me")
     ResponseEntity<LeagueHistoryResponse> getMyLeagueHistory(
             @AuthenticationPrincipal LoginUser loginUser
+    );
+
+    @Operation(
+            summary = "특정 유저 리그 히스토리 조회",
+            description = "특정 유저의 시즌별 최종 티어 기록을 조회합니다."
+    )
+    @ApiResponses({
+            @ApiResponse(responseCode = "200", description = "✅ 리그 히스토리 조회 성공"),
+            @ApiResponse(
+                    responseCode = "404",
+                    description = "🚨 ACTIVE 시즌 없음",
+                    content = @Content(
+                            mediaType = MediaType.APPLICATION_JSON_VALUE,
+                            schema = @Schema(implementation = ErrorResponse.class),
+                            examples = @ExampleObject(
+                                    name = "ACTIVE 시즌 없음",
+                                    value = "{\"error\":\"SEASON_4041\",\"message\":\"ACTIVE 시즌이 없습니다.\"}"
+                            )
+                    )
+            )
+    })
+    @GetMapping("/{userId}")
+    ResponseEntity<LeagueHistoryResponse> getUserLeagueHistory(
+            @Parameter(description = "조회할 유저 ID") @PathVariable long userId
     );
 }

--- a/src/main/java/gravit/code/userLeagueHistory/service/LeagueHistoryService.java
+++ b/src/main/java/gravit/code/userLeagueHistory/service/LeagueHistoryService.java
@@ -33,6 +33,11 @@ public class LeagueHistoryService {
         return buildLeagueHistory(userId);
     }
 
+    @Transactional(readOnly = true)
+    public LeagueHistoryResponse getUserLeagueHistory(long userId) {
+        return buildLeagueHistory(userId);
+    }
+
     private LeagueHistoryResponse buildLeagueHistory(long userId) {
         Season activeSeason = seasonRepository.findByStatus(SeasonStatus.ACTIVE)
                 .orElseThrow(() -> new RestApiException(CustomErrorCode.ACTIVE_SEASON_NOT_FOUND));
@@ -49,13 +54,17 @@ public class LeagueHistoryService {
         for (UserLeagueHistory h : histories) {
             seasonHistory.add(new LeagueHistoryResponse.SeasonHistoryEntry(
                     h.getSeason().getSeasonKey(),
-                    h.getFinalLeague().getName()
+                    h.getFinalLeague().getName(),
+                    h.getFinalLeague().getSortOrder(),
+                    false
             ));
         }
         currentUserLeague.ifPresent(ul -> seasonHistory.add(
                 new LeagueHistoryResponse.SeasonHistoryEntry(
                         activeSeason.getSeasonKey(),
-                        ul.getLeague().getName()
+                        ul.getLeague().getName(),
+                        ul.getLeague().getSortOrder(),
+                        true
                 )
         ));
 

--- a/src/test/java/gravit/code/friend/service/FriendServiceTest.java
+++ b/src/test/java/gravit/code/friend/service/FriendServiceTest.java
@@ -1,142 +1,139 @@
-//package gravit.code.friend.service;
-//
-//import gravit.code.friend.domain.Friend;
-//import gravit.code.friend.domain.FriendRepository;
-//import gravit.code.friend.dto.response.FollowerResponse;
-//import gravit.code.friend.dto.response.FollowingResponse;
-//import gravit.code.friend.dto.response.FriendResponse;
-//import gravit.code.global.dto.response.SliceResponse;
-//import gravit.code.support.TCSpringBootTest;
-//import gravit.code.user.domain.Role;
-//import gravit.code.user.domain.User;
-//import gravit.code.user.domain.UserRepository;
-//import org.junit.jupiter.api.Test;
-//import org.springframework.beans.factory.annotation.Autowired;
-//import org.springframework.data.domain.PageRequest;
-//import org.springframework.data.domain.Pageable;
-//import org.springframework.data.domain.Slice;
-//import org.springframework.test.context.jdbc.Sql;
-//
-//import static org.assertj.core.api.AssertionsForClassTypes.assertThat;
-//import static org.junit.jupiter.api.Assertions.*;
-//
-//@TCSpringBootTest
-//@Sql(scripts = "classpath:sql/truncate_all.sql", executionPhase = Sql.ExecutionPhase.BEFORE_TEST_METHOD)
-//class FriendServiceTest {
-//
-//    @Autowired
-//    private FriendService friendService;
-//
-//    @Autowired
-//    private UserRepository userRepository;
-//
-//    @Autowired
-//    private FriendRepository friendRepository;
-//
-//    @Test
-//    void 상호_팔로우_가능한지_검증() {
-//        // given
-//        User user1 = User.create("user1@example.com", "kakao1231513141231", "User1", "@user1", 1, Role.USER);
-//        userRepository.save(user1);
-//        User user2 = User.create("user2@example.com", "google123677438112", "User2", "@user2", 2, Role.USER);
-//        userRepository.save(user2);
-//
-//        // when
-//        FriendResponse response1 = friendService.following(user1.getId(), user2.getId()); // user2 -> user1
-//        FriendResponse response2 = friendService.following(user2.getId(), user1.getId()); // user1 -> user2
-//
-//
-//        // then
-//        assertEquals(response1.followerId(), user1.getId());
-//        assertEquals(response1.followeeId(), user2.getId());
-//
-//        assertEquals(response2.followerId(), user2.getId());
-//        assertEquals(response2.followeeId(), user1.getId());
-//
-//        // 추가 검증
-//        assertTrue(friendRepository.existsByFollowerIdAndFolloweeId(user1.getId(), user2.getId()));
-//        assertTrue(friendRepository.existsByFollowerIdAndFolloweeId(user2.getId(), user1.getId()));
-//
-//    }
-//
-//    @Test
-//    void 팔로잉을_한_유저를_대상으로_팔로잉을_취소합니다() {
-//        // given
-//        User user1 = User.create("user1@example.com", "kakao1231513141231", "User1", "@user1", 1,Role.USER);
-//        userRepository.save(user1);
-//        User user2 = User.create("user2@example.com", "google123677438112", "User2", "@user2", 2, Role.USER);
-//        userRepository.save(user2);
-//        friendService.following(user1.getId(), user2.getId());
-//        Pageable pageable = PageRequest.of(0, 10);
-//
-//        // when
-//        friendService.unFollowing(user1.getId(), user2.getId());
-//
-//        // then
-//        Slice<FollowingResponse> followings = friendRepository.findFollowingsByFollowerId(user1.getId(), pageable);
-//        assertThat(followings.getContent().isEmpty()).isTrue();
-//    }
-//
-//    @Test
-//    void 나를_팔로우_한_사람들을_조회합니다() {
-//        // given
-//        User user1 = User.create("user1@example.com", "kakao1231513141231", "User1", "@user1", 1, Role.USER);
-//        userRepository.save(user1);
-//        User user2 = User.create("user2@example.com", "kakao1258853439443", "User2", "@user2", 1, Role.USER);
-//        userRepository.save(user2);
-//        User user3 = User.create("user3@example.com", "kakao6438123471324", "User3", "@user3", 1, Role.USER);
-//        userRepository.save(user3);
-//
-//        Friend friend1 = Friend.create(user1.getId(), user2.getId());
-//        friendRepository.save(friend1);
-//        Friend friend2 = Friend.create(user1.getId(), user3.getId());
-//        friendRepository.save(friend2);
-//        Friend friend3 = Friend.create(user2.getId(), user1.getId());
-//        friendRepository.save(friend3);
-//        Friend friend4 = Friend.create(user3.getId(), user1.getId());
-//        friendRepository.save(friend4);
-//
-//        // when
-//        SliceResponse<FollowerResponse> followerResponses = friendService.getFollowers(user1.getId(), 0);
-//
-//        // then
-//        assertEquals(2, followerResponses.contents().size());
-//        for (FollowerResponse followerResponse : followerResponses.contents()) {
-//            assertNotNull(followerResponse.nickname());
-//            assertNotNull(followerResponse.handle());
-//            assertTrue(followerResponse.profileImgNumber() > 0);
-//        }
-//    }
-//
-//    @Test
-//    void 내가_팔로우_한_사람들을_조회합니다() {
-//        // given
-//        User user1 = User.create("user1@example.com", "kakao1231513141231", "User1", "@user1", 1, Role.USER);
-//        userRepository.save(user1);
-//        User user2 = User.create("user2@example.com", "kakao1258853439443", "User2", "@user2", 1, Role.USER);
-//        userRepository.save(user2);
-//        User user3 = User.create("user3@example.com", "kakao6438123471324", "User3", "@user3", 1, Role.USER);
-//        userRepository.save(user3);
-//
-//        Friend friend1 = Friend.create(user1.getId(), user2.getId());
-//        friendRepository.save(friend1);
-//        Friend friend2 = Friend.create(user1.getId(), user3.getId());
-//        friendRepository.save(friend2);
-//        Friend friend3 = Friend.create(user2.getId(), user1.getId());
-//        friendRepository.save(friend3);
-//        Friend friend4 = Friend.create(user3.getId(), user1.getId());
-//        friendRepository.save(friend4);
-//
-//        // when
-//        SliceResponse<FollowingResponse> followingResponses = friendService.getFollowings(user1.getId(), 0);
-//
-//        // then
-//        assertEquals(2, followingResponses.contents().size());
-//
-//        for (FollowingResponse followingResponse : followingResponses.contents()) {
-//            assertNotNull(followingResponse.nickname());
-//            assertNotNull(followingResponse.handle());
-//            assertTrue(followingResponse.profileImgNumber() > 0);
-//        }
-//    }
-//}
+package gravit.code.friend.service;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+
+import gravit.code.friend.dto.response.FollowerResponse;
+import gravit.code.friend.fixture.FriendFixture;
+import gravit.code.global.dto.response.SliceResponse;
+import gravit.code.global.exception.domain.RestApiException;
+import gravit.code.support.TCSpringBootTest;
+import gravit.code.user.domain.User;
+import gravit.code.user.fixture.UserFixture;
+import java.util.List;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+
+@TCSpringBootTest
+class FriendServiceTest {
+
+    @Autowired
+    private FriendService friendService;
+
+    @Autowired
+    private UserFixture userFixture;
+
+    @Autowired
+    private FriendFixture friendFixture;
+
+    @Test
+    void 나를_팔로우한_사람을_내가_팔로우하지_않으면_isFollowing이_false다() {
+        // given
+        User me = userFixture.일반_유저(1);
+        User follower = userFixture.일반_유저(2);
+        friendFixture.팔로우(follower, me);
+
+        // when
+        SliceResponse<FollowerResponse> result = friendService.getFollowers(me.getId(), 0);
+
+        // then
+        assertThat(result.contents()).hasSize(1);
+        assertThat(result.contents().get(0).id()).isEqualTo(follower.getId());
+        assertThat(result.contents().get(0).isFollowing()).isFalse();
+    }
+
+    @Test
+    void 나를_팔로우한_사람을_내가도_팔로우하면_isFollowing이_true다() {
+        // given
+        User me = userFixture.일반_유저(1);
+        User follower = userFixture.일반_유저(2);
+        friendFixture.팔로우(follower, me);
+        friendFixture.팔로우(me, follower);
+
+        // when
+        SliceResponse<FollowerResponse> result = friendService.getFollowers(me.getId(), 0);
+
+        // then
+        assertThat(result.contents()).hasSize(1);
+        assertThat(result.contents().get(0).isFollowing()).isTrue();
+    }
+
+    @Test
+    void 팔로워_목록에서_맞팔과_단방향_팔로워가_혼재할_때_isFollowing이_각각_올바르게_반환된다() {
+        // given
+        User me = userFixture.일반_유저(1);
+        User mutualFollower = userFixture.일반_유저(2);
+        User oneWayFollower = userFixture.일반_유저(3);
+
+        friendFixture.팔로우(mutualFollower, me);
+        friendFixture.팔로우(me, mutualFollower); // 맞팔
+        friendFixture.팔로우(oneWayFollower, me); // 단방향
+
+        // when
+        SliceResponse<FollowerResponse> result = friendService.getFollowers(me.getId(), 0);
+
+        // then
+        assertThat(result.contents()).hasSize(2);
+        List<FollowerResponse> contents = result.contents();
+
+        FollowerResponse mutual = contents.stream()
+                .filter(r -> r.id() == mutualFollower.getId())
+                .findFirst().orElseThrow();
+        FollowerResponse oneWay = contents.stream()
+                .filter(r -> r.id() == oneWayFollower.getId())
+                .findFirst().orElseThrow();
+
+        assertThat(mutual.isFollowing()).isTrue();
+        assertThat(oneWay.isFollowing()).isFalse();
+    }
+
+    @Test
+    void 팔로워가_없으면_빈_목록을_반환한다() {
+        // given
+        User me = userFixture.일반_유저(1);
+
+        // when
+        SliceResponse<FollowerResponse> result = friendService.getFollowers(me.getId(), 0);
+
+        // then
+        assertThat(result.contents()).isEmpty();
+        assertThat(result.hasNextPage()).isFalse();
+    }
+
+    @Test
+    void 자기_자신에게_팔로잉하면_예외가_발생한다() {
+        // given
+        User me = userFixture.일반_유저(1);
+
+        // when & then
+        assertThatThrownBy(() -> friendService.following(me.getId(), me.getId()))
+                .isInstanceOf(RestApiException.class);
+    }
+
+    @Test
+    void 이미_팔로잉_중인_유저에게_팔로잉하면_예외가_발생한다() {
+        // given
+        User me = userFixture.일반_유저(1);
+        User target = userFixture.일반_유저(2);
+        friendFixture.팔로우(me, target);
+
+        // when & then
+        assertThatThrownBy(() -> friendService.following(me.getId(), target.getId()))
+                .isInstanceOf(RestApiException.class);
+    }
+
+    @Test
+    void 팔로잉_취소_시_팔로워_목록에서_제거된다() {
+        // given
+        User me = userFixture.일반_유저(1);
+        User follower = userFixture.일반_유저(2);
+        friendFixture.팔로우(me, follower);
+
+        // when
+        friendService.unFollowing(me.getId(), follower.getId());
+
+        // then
+        SliceResponse<FollowerResponse> result = friendService.getFollowers(follower.getId(), 0);
+        assertThat(result.contents()).isEmpty();
+    }
+}

--- a/src/test/java/gravit/code/social/facade/SocialFacadeIntegrationTest.java
+++ b/src/test/java/gravit/code/social/facade/SocialFacadeIntegrationTest.java
@@ -101,8 +101,9 @@ class SocialFacadeIntegrationTest {
                 softly.assertThat(response.actorHandle()).isEqualTo("h2");
                 softly.assertThat(response.actorProfileImgNumber()).isEqualTo(1);
                 softly.assertThat(response.message()).isEqualTo("유저2님이 LV.5로 레벨업했어요!");
+                softly.assertThat(response.timeAgo()).isNotNull();
+                softly.assertThat(response.canCongratulate()).isTrue();
                 softly.assertThat(response.createdAt()).isNotNull();
-                softly.assertThat(response.congratulatedAt()).isNull();
             });
         }
 

--- a/src/test/java/gravit/code/social/facade/SocialFacadeIntegrationTest.java
+++ b/src/test/java/gravit/code/social/facade/SocialFacadeIntegrationTest.java
@@ -100,7 +100,7 @@ class SocialFacadeIntegrationTest {
                 softly.assertThat(response.actorNickname()).isEqualTo("유저2");
                 softly.assertThat(response.actorHandle()).isEqualTo("h2");
                 softly.assertThat(response.actorProfileImgNumber()).isEqualTo(1);
-                softly.assertThat(response.message()).isEqualTo("유저2님이 LV.5로 레벨업했어요!");
+                softly.assertThat(response.message()).isEqualTo("LV.5로 레벨업했어요!");
                 softly.assertThat(response.timeAgo()).isNotNull();
                 softly.assertThat(response.canCongratulate()).isTrue();
                 softly.assertThat(response.createdAt()).isNotNull();

--- a/src/test/java/gravit/code/social/service/SocialFeedServiceIntegrationTest.java
+++ b/src/test/java/gravit/code/social/service/SocialFeedServiceIntegrationTest.java
@@ -195,7 +195,7 @@ class SocialFeedServiceIntegrationTest {
             SliceResponse<SocialFeedResponse> result = socialFeedService.getFeed(requester.getId(), 0);
 
             // then
-            assertThat(result.contents().get(0).message()).isEqualTo("유저2님이 LV.5로 레벨업했어요!");
+            assertThat(result.contents().get(0).message()).isEqualTo("LV.5로 레벨업했어요!");
         }
 
         @Test
@@ -210,7 +210,7 @@ class SocialFeedServiceIntegrationTest {
             SliceResponse<SocialFeedResponse> result = socialFeedService.getFeed(requester.getId(), 0);
 
             // then
-            assertThat(result.contents().get(0).message()).isEqualTo("유저2님이 30일 연속 학습을 달성했어요!");
+            assertThat(result.contents().get(0).message()).isEqualTo("30일 연속 학습을 달성했어요!");
         }
 
         @Test
@@ -225,7 +225,7 @@ class SocialFeedServiceIntegrationTest {
             SliceResponse<SocialFeedResponse> result = socialFeedService.getFeed(requester.getId(), 0);
 
             // then
-            assertThat(result.contents().get(0).message()).isEqualTo("유저2님이 골드로 승급했어요!");
+            assertThat(result.contents().get(0).message()).isEqualTo("골드로 승급했어요!");
         }
 
         @Test
@@ -240,7 +240,7 @@ class SocialFeedServiceIntegrationTest {
             SliceResponse<SocialFeedResponse> result = socialFeedService.getFeed(requester.getId(), 0);
 
             // then
-            assertThat(result.contents().get(0).message()).isEqualTo("유저2님이 지구 행성을 정복했어요!");
+            assertThat(result.contents().get(0).message()).isEqualTo("지구 행성을 정복했어요!");
         }
     }
 }

--- a/src/test/java/gravit/code/userLeagueHistory/service/LeagueHistoryServiceTest.java
+++ b/src/test/java/gravit/code/userLeagueHistory/service/LeagueHistoryServiceTest.java
@@ -77,6 +77,8 @@ class LeagueHistoryServiceTest {
                 softly.assertThat(result.bestLeagueName()).isEqualTo("브론즈 3");
                 softly.assertThat(result.seasonHistory()).hasSize(1);
                 softly.assertThat(result.seasonHistory().get(0).seasonKey()).isEqualTo("2025-S2");
+                softly.assertThat(result.seasonHistory().get(0).sortOrder()).isEqualTo(1); // bronze3
+                softly.assertThat(result.seasonHistory().get(0).isCurrent()).isTrue();
             });
         }
 
@@ -95,7 +97,11 @@ class LeagueHistoryServiceTest {
                 softly.assertThat(result.totalSeasonCount()).isEqualTo(2);
                 softly.assertThat(result.seasonHistory()).hasSize(2);
                 softly.assertThat(result.seasonHistory().get(0).seasonKey()).isEqualTo("2025-S1");
+                softly.assertThat(result.seasonHistory().get(0).sortOrder()).isEqualTo(4); // silver3
+                softly.assertThat(result.seasonHistory().get(0).isCurrent()).isFalse();
                 softly.assertThat(result.seasonHistory().get(1).seasonKey()).isEqualTo("2025-S2");
+                softly.assertThat(result.seasonHistory().get(1).sortOrder()).isEqualTo(1); // bronze3
+                softly.assertThat(result.seasonHistory().get(1).isCurrent()).isTrue();
             });
         }
 


### PR DESCRIPTION
### 1. 연관 이슈

---
 - 없음

<br>

### 2. 구현 사항

---
**소셜 피드 메시지에서 닉네임 제거**

프론트엔드 요청에 따라 `SocialFeedResponse`의 `message` 포맷을 변경했습니다.

기존에는 `"{닉네임}님이 자료구조 행성을 정복했어요!"` 형태로 닉네임을 포함하여 메시지를 생성했으나, 프론트엔드에서 닉네임을 별도로 렌더링하기 때문에 메시지에서 닉네임을 제거했습니다.

변경 후 메시지 포맷:
- `PLANET_COMPLETE`: `"{행성명} 행성을 정복했어요!"`
- `STREAK_DAYS`: `"{N}일 연속 학습을 달성했어요!"`
- `TIER_PROMOTION`: `"{티어}로 승급했어요!"`
- `LEVEL_UP`: `"LV.{N}으로 레벨업했어요!"`

관련 테스트(`SocialFeedServiceIntegrationTest`, `SocialFacadeIntegrationTest`) 및 Swagger 예시도 동일하게 수정했습니다.