### PR TITLE
feat: 소셜 피드 message에서 닉네임 제거

### DIFF
--- a/src/main/java/gravit/code/social/controller/docs/SocialControllerDocs.java
+++ b/src/main/java/gravit/code/social/controller/docs/SocialControllerDocs.java
@@ -145,7 +145,7 @@ public interface SocialControllerDocs {
                                                   "actorNickname": "테스터",
                                                   "actorProfileImgNumber": 3,
                                                   "actorHandle": "@tester01",
-                                                  "message": "테스터님이 지구 행성을 정복했어요!",
+                                                  "message": "지구 행성을 정복했어요!",
                                                   "createdAt": "2026-05-22T10:00:00"
                                                 }
                                               ]

--- a/src/main/java/gravit/code/social/dto/response/SocialFeedResponse.java
+++ b/src/main/java/gravit/code/social/dto/response/SocialFeedResponse.java
@@ -28,7 +28,7 @@ public record SocialFeedResponse(
                 projection.actorNickname(),
                 projection.actorProfileImgNumber(),
                 projection.actorHandle(),
-                generateMessage(projection.eventType(), projection.actorNickname(), projection.eventValue()),
+                generateMessage(projection.eventType(), projection.eventValue()),
                 computeTimeAgo(projection.createdAt()),
                 canCongratulate,
                 projection.createdAt()
@@ -37,14 +37,13 @@ public record SocialFeedResponse(
 
     private static String generateMessage(
             FeedEventType eventType,
-            String nickname,
             String eventValue
     ) {
         return switch (eventType) {
-            case PLANET_COMPLETE -> nickname + "님이 " + eventValue + " 행성을 정복했어요!";
-            case STREAK_DAYS -> nickname + "님이 " + eventValue + "일 연속 학습을 달성했어요!";
-            case TIER_PROMOTION -> nickname + "님이 " + eventValue + "로 승급했어요!";
-            case LEVEL_UP -> nickname + "님이 LV." + eventValue + "로 레벨업했어요!";
+            case PLANET_COMPLETE -> eventValue + " 행성을 정복했어요!";
+            case STREAK_DAYS -> eventValue + "일 연속 학습을 달성했어요!";
+            case TIER_PROMOTION -> eventValue + "로 승급했어요!";
+            case LEVEL_UP -> "LV." + eventValue + "로 레벨업했어요!";
         };
     }
 

--- a/src/test/java/gravit/code/social/facade/SocialFacadeIntegrationTest.java
+++ b/src/test/java/gravit/code/social/facade/SocialFacadeIntegrationTest.java
@@ -100,7 +100,7 @@ class SocialFacadeIntegrationTest {
                 softly.assertThat(response.actorNickname()).isEqualTo("유저2");
                 softly.assertThat(response.actorHandle()).isEqualTo("h2");
                 softly.assertThat(response.actorProfileImgNumber()).isEqualTo(1);
-                softly.assertThat(response.message()).isEqualTo("유저2님이 LV.5로 레벨업했어요!");
+                softly.assertThat(response.message()).isEqualTo("LV.5로 레벨업했어요!");
                 softly.assertThat(response.timeAgo()).isNotNull();
                 softly.assertThat(response.canCongratulate()).isTrue();
                 softly.assertThat(response.createdAt()).isNotNull();

--- a/src/test/java/gravit/code/social/service/SocialFeedServiceIntegrationTest.java
+++ b/src/test/java/gravit/code/social/service/SocialFeedServiceIntegrationTest.java
@@ -195,7 +195,7 @@ class SocialFeedServiceIntegrationTest {
             SliceResponse<SocialFeedResponse> result = socialFeedService.getFeed(requester.getId(), 0);
 
             // then
-            assertThat(result.contents().get(0).message()).isEqualTo("유저2님이 LV.5로 레벨업했어요!");
+            assertThat(result.contents().get(0).message()).isEqualTo("LV.5로 레벨업했어요!");
         }
 
         @Test
@@ -210,7 +210,7 @@ class SocialFeedServiceIntegrationTest {
             SliceResponse<SocialFeedResponse> result = socialFeedService.getFeed(requester.getId(), 0);
 
             // then
-            assertThat(result.contents().get(0).message()).isEqualTo("유저2님이 30일 연속 학습을 달성했어요!");
+            assertThat(result.contents().get(0).message()).isEqualTo("30일 연속 학습을 달성했어요!");
         }
 
         @Test
@@ -225,7 +225,7 @@ class SocialFeedServiceIntegrationTest {
             SliceResponse<SocialFeedResponse> result = socialFeedService.getFeed(requester.getId(), 0);
 
             // then
-            assertThat(result.contents().get(0).message()).isEqualTo("유저2님이 골드로 승급했어요!");
+            assertThat(result.contents().get(0).message()).isEqualTo("골드로 승급했어요!");
         }
 
         @Test
@@ -240,7 +240,7 @@ class SocialFeedServiceIntegrationTest {
             SliceResponse<SocialFeedResponse> result = socialFeedService.getFeed(requester.getId(), 0);
 
             // then
-            assertThat(result.contents().get(0).message()).isEqualTo("유저2님이 지구 행성을 정복했어요!");
+            assertThat(result.contents().get(0).message()).isEqualTo("지구 행성을 정복했어요!");
         }
     }
 }


### PR DESCRIPTION
### 1. 연관 이슈

---
 - 없음

<br>

### 2. 구현 사항

---
**소셜 피드 메시지에서 닉네임 제거**

프론트엔드 요청에 따라 `SocialFeedResponse`의 `message` 포맷을 변경했습니다.

기존에는 닉네임을 포함한 `"{닉네임}님이 자료구조 행성을 정복했어요!"` 형태로 메시지를 생성했으나, 프론트엔드에서 닉네임을 별도로 렌더링하기 때문에 message 필드에서 닉네임을 제거했습니다.

변경 후 메시지 포맷:
- `PLANET_COMPLETE`: `"{행성명} 행성을 정복했어요!"`
- `STREAK_DAYS`: `"{N}일 연속 학습을 달성했어요!"`
- `TIER_PROMOTION`: `"{티어}로 승급했어요!"`
- `LEVEL_UP`: `"LV.{N}으로 레벨업했어요!"`

관련 테스트(`SocialFeedServiceIntegrationTest`, `SocialFacadeIntegrationTest`) 및 Swagger 예시도 동일하게 수정했습니다.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **소셜 피드**
  * 피드 메시지 형식이 개선되었습니다. 메시지에서 사용자 닉네임 접두어가 제거되어 "LV.5로 레벨업했어요!" 같은 더욱 간결한 형태로 표시됩니다.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/Team-Gravit/gravit-server/pull/364?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->