### PR TITLE
fix: FollowerResponse isFollowing 필드 Swagger unknown 버그 수정

### DIFF
--- a/src/main/java/gravit/code/friend/dto/response/FollowerResponse.java
+++ b/src/main/java/gravit/code/friend/dto/response/FollowerResponse.java
@@ -1,5 +1,6 @@
 package gravit.code.friend.dto.response;
 
+import com.fasterxml.jackson.annotation.JsonProperty;
 import jakarta.validation.constraints.NotNull;
 
 public record FollowerResponse(
@@ -10,6 +11,7 @@ public record FollowerResponse(
         int profileImgNumber,
         @NotNull
         String handle,
+        @JsonProperty("isFollowing")
         boolean isFollowing
 ) {
 }


### PR DESCRIPTION
### 1. 연관 이슈

---
없음

<br>

### 2. 구현 사항

---
**FollowerResponse isFollowing 필드 Swagger unknown 버그 수정**

Java record 타입에서 `boolean isFollowing` 필드를 선언하면, Jackson이 JavaBeans 규칙에 따라 accessor 메서드 `isFollowing()`을 `following` 프로퍼티로 해석한다. 이로 인해 springdoc-openapi가 실제 필드명 `isFollowing`을 찾지 못해 Swagger UI에서 해당 필드가 `unknown`으로 표시되는 문제가 발생했다.

`@JsonProperty("isFollowing")`을 추가하여 Jackson이 프로퍼티명을 명시적으로 `isFollowing`으로 인식하도록 수정했다.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## 릴리스 노트

* **버그 수정**
  * 팔로워 응답 API의 팔로우 상태 필드 직렬화 문제를 해결했습니다. 이제 API 응답에서 팔로우 상태가 올바르게 표시됩니다.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/Team-Gravit/gravit-server/pull/365?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->