### PR TITLE
fix: boolean isXxx 직렬화 버그 및 Swagger 응답 명세 개선

### DIFF
--- a/src/main/java/gravit/code/admin/controller/docs/AdminNoticeQueryControllerDocs.java
+++ b/src/main/java/gravit/code/admin/controller/docs/AdminNoticeQueryControllerDocs.java
@@ -1,6 +1,7 @@
 package gravit.code.admin.controller.docs;
 
 import gravit.code.admin.dto.response.AdminNoticeDetailResponse;
+import gravit.code.admin.dto.response.AdminNoticeSummaryPageResponse;
 import gravit.code.admin.dto.response.AdminNoticeSummaryResponse;
 import gravit.code.auth.domain.LoginUser;
 import gravit.code.global.dto.response.PageResponse;
@@ -105,7 +106,7 @@ public interface AdminNoticeQueryControllerDocs {
                     description = "✅ 목록 조회 성공",
                     content = @Content(
                             mediaType = MediaType.APPLICATION_JSON_VALUE,
-                            schema = @Schema(implementation = PageResponse.class),
+                            schema = @Schema(implementation = AdminNoticeSummaryPageResponse.class),
                             examples = @ExampleObject(name = "성공 예시", value = """
                     {
                       "page": 0,

--- a/src/main/java/gravit/code/admin/dto/response/AdminNoticeSummaryPageResponse.java
+++ b/src/main/java/gravit/code/admin/dto/response/AdminNoticeSummaryPageResponse.java
@@ -1,0 +1,21 @@
+package gravit.code.admin.dto.response;
+
+import io.swagger.v3.oas.annotations.media.Schema;
+
+import java.util.List;
+
+@Schema(description = "어드민 공지 요약 페이지 응답")
+public class AdminNoticeSummaryPageResponse {
+
+    @Schema(description = "현재 페이지 번호", example = "0")
+    public int page;
+
+    @Schema(description = "전체 페이지 수", example = "3")
+    public int totalPages;
+
+    @Schema(description = "다음 페이지 존재 여부", example = "true")
+    public boolean hasNext;
+
+    @Schema(description = "공지 요약 목록")
+    public List<AdminNoticeSummaryResponse> contents;
+}

--- a/src/main/java/gravit/code/admin/dto/response/ReportDetailResponse.java
+++ b/src/main/java/gravit/code/admin/dto/response/ReportDetailResponse.java
@@ -1,5 +1,6 @@
 package gravit.code.admin.dto.response;
 
+import com.fasterxml.jackson.annotation.JsonProperty;
 import gravit.code.report.domain.ReportType;
 import io.swagger.v3.oas.annotations.media.Schema;
 import jakarta.validation.constraints.NotNull;
@@ -38,6 +39,7 @@ public record ReportDetailResponse(
                 description = "해결 여부",
                 example = "false"
         )
+        @JsonProperty("isResolved")
         boolean isResolved,
 
         @Schema(

--- a/src/main/java/gravit/code/admin/dto/response/ReportSummaryResponse.java
+++ b/src/main/java/gravit/code/admin/dto/response/ReportSummaryResponse.java
@@ -1,5 +1,6 @@
 package gravit.code.admin.dto.response;
 
+import com.fasterxml.jackson.annotation.JsonProperty;
 import gravit.code.report.domain.ReportType;
 import io.swagger.v3.oas.annotations.media.Schema;
 import jakarta.validation.constraints.NotNull;
@@ -31,6 +32,7 @@ public record ReportSummaryResponse(
                 description = "해결 여부",
                 example = "false"
         )
+        @JsonProperty("isResolved")
         boolean isResolved,
 
         @Schema(

--- a/src/main/java/gravit/code/auth/dto/response/LoginResponse.java
+++ b/src/main/java/gravit/code/auth/dto/response/LoginResponse.java
@@ -1,5 +1,6 @@
 package gravit.code.auth.dto.response;
 
+import com.fasterxml.jackson.annotation.JsonProperty;
 import gravit.code.auth.domain.AccessToken;
 import gravit.code.auth.domain.RefreshToken;
 import jakarta.validation.constraints.NotNull;
@@ -10,6 +11,7 @@ public record LoginResponse(
         String accessToken,
         @NotNull
         String refreshToken,
+        @JsonProperty("isOnboarded")
         boolean isOnboarded
 ) {
     public static LoginResponse of(

--- a/src/main/java/gravit/code/friend/controller/docs/FriendControllerDocs.java
+++ b/src/main/java/gravit/code/friend/controller/docs/FriendControllerDocs.java
@@ -4,7 +4,9 @@ import gravit.code.auth.domain.LoginUser;
 import gravit.code.friend.dto.internal.SearchUserDto;
 import gravit.code.friend.dto.response.FollowCountsResponse;
 import gravit.code.friend.dto.response.FollowerResponse;
+import gravit.code.friend.dto.response.FollowerSliceResponse;
 import gravit.code.friend.dto.response.FollowingResponse;
+import gravit.code.friend.dto.response.SearchUserSliceResponse;
 import gravit.code.friend.dto.response.FriendResponse;
 import gravit.code.global.dto.response.SliceResponse;
 import gravit.code.global.exception.domain.ErrorResponse;
@@ -150,7 +152,9 @@ public interface FriendControllerDocs {
     )
     @ApiResponses({
             @ApiResponse(responseCode = "200", description = "✅ 팔로워 목록 조회 성공",
-                    content = @Content(mediaType = MediaType.APPLICATION_JSON_VALUE,
+                    content = @Content(
+                            mediaType = MediaType.APPLICATION_JSON_VALUE,
+                            schema = @Schema(implementation = FollowerSliceResponse.class),
                             examples = @ExampleObject(
                                     name = "성공 예시",
                                     value = """
@@ -174,7 +178,7 @@ public interface FriendControllerDocs {
                                               ]
                                             }
                                             """
-                            )
+                                    )
                     )
             ),
             @ApiResponse(responseCode = "500", description = "🚨 예기치 못한 예외 발생",
@@ -311,7 +315,7 @@ public interface FriendControllerDocs {
                     description = "✅ 검색 성공",
                     content = @Content(
                             mediaType = MediaType.APPLICATION_JSON_VALUE,
-                            schema = @Schema(implementation = SliceResponse.class),
+                            schema = @Schema(implementation = SearchUserSliceResponse.class),
                             examples = @ExampleObject(
                                     name = "검색 결과 예시",
                                     value = """

--- a/src/main/java/gravit/code/friend/dto/internal/SearchUserDto.java
+++ b/src/main/java/gravit/code/friend/dto/internal/SearchUserDto.java
@@ -1,10 +1,13 @@
 package gravit.code.friend.dto.internal;
 
+import com.fasterxml.jackson.annotation.JsonProperty;
+
 public record SearchUserDto(
         long userId,
         int profileImgNumber,
         String nickname,
         String handle,
+        @JsonProperty("isFollowing")
         boolean isFollowing
 ) {
 }

--- a/src/main/java/gravit/code/friend/dto/response/FollowerResponse.java
+++ b/src/main/java/gravit/code/friend/dto/response/FollowerResponse.java
@@ -1,17 +1,17 @@
 package gravit.code.friend.dto.response;
 
 import com.fasterxml.jackson.annotation.JsonProperty;
+import io.swagger.v3.oas.annotations.media.Schema;
 import jakarta.validation.constraints.NotNull;
 
 public record FollowerResponse(
 
-        long id,
-        @NotNull
-        String nickname,
-        int profileImgNumber,
-        @NotNull
-        String handle,
+        @Schema(example = "1") long id,
+        @NotNull @Schema(example = "김나영") String nickname,
+        @Schema(example = "2") int profileImgNumber,
+        @NotNull @Schema(example = "@1235cws") String handle,
         @JsonProperty("isFollowing")
+        @Schema(name = "isFollowing", description = "내가 해당 팔로워를 팔로우 중인지 여부", example = "false")
         boolean isFollowing
 ) {
 }

--- a/src/main/java/gravit/code/friend/dto/response/FollowerSliceResponse.java
+++ b/src/main/java/gravit/code/friend/dto/response/FollowerSliceResponse.java
@@ -1,0 +1,15 @@
+package gravit.code.friend.dto.response;
+
+import io.swagger.v3.oas.annotations.media.Schema;
+
+import java.util.List;
+
+@Schema(description = "팔로워 목록 슬라이스 응답")
+public class FollowerSliceResponse {
+
+    @Schema(description = "다음 페이지 존재 여부", example = "false")
+    public boolean hasNextPage;
+
+    @Schema(description = "팔로워 목록")
+    public List<FollowerResponse> contents;
+}

--- a/src/main/java/gravit/code/friend/dto/response/SearchUserSliceResponse.java
+++ b/src/main/java/gravit/code/friend/dto/response/SearchUserSliceResponse.java
@@ -1,0 +1,16 @@
+package gravit.code.friend.dto.response;
+
+import gravit.code.friend.dto.internal.SearchUserDto;
+import io.swagger.v3.oas.annotations.media.Schema;
+
+import java.util.List;
+
+@Schema(description = "사용자 검색 슬라이스 응답")
+public class SearchUserSliceResponse {
+
+    @Schema(description = "다음 페이지 존재 여부", example = "false")
+    public boolean hasNextPage;
+
+    @Schema(description = "검색 결과 목록")
+    public List<SearchUserDto> contents;
+}

--- a/src/main/java/gravit/code/league/dto/response/LeagueHistoryResponse.java
+++ b/src/main/java/gravit/code/league/dto/response/LeagueHistoryResponse.java
@@ -1,5 +1,6 @@
 package gravit.code.league.dto.response;
 
+import com.fasterxml.jackson.annotation.JsonProperty;
 import lombok.AccessLevel;
 import lombok.Builder;
 
@@ -17,6 +18,7 @@ public record LeagueHistoryResponse(
             String seasonKey,
             String leagueName,
             int sortOrder,
+            @JsonProperty("isCurrent")
             boolean isCurrent
     ) {}
 

--- a/src/main/java/gravit/code/lesson/dto/response/LessonProgressSummaryResponse.java
+++ b/src/main/java/gravit/code/lesson/dto/response/LessonProgressSummaryResponse.java
@@ -1,5 +1,6 @@
 package gravit.code.lesson.dto.response;
 
+import com.fasterxml.jackson.annotation.JsonProperty;
 import io.swagger.v3.oas.annotations.media.Schema;
 import jakarta.validation.constraints.NotNull;
 import lombok.AccessLevel;
@@ -26,6 +27,7 @@ public record LessonProgressSummaryResponse(
                 description = "레슨 완료 여부",
                 example = "true"
         )
+        @JsonProperty("isCompleted")
         boolean isCompleted
 ) {
         public static LessonProgressSummaryResponse create(

--- a/src/main/java/gravit/code/lesson/dto/response/LessonSummaryResponse.java
+++ b/src/main/java/gravit/code/lesson/dto/response/LessonSummaryResponse.java
@@ -1,5 +1,6 @@
 package gravit.code.lesson.dto.response;
 
+import com.fasterxml.jackson.annotation.JsonProperty;
 import io.swagger.v3.oas.annotations.media.Schema;
 import jakarta.validation.constraints.NotNull;
 
@@ -28,6 +29,7 @@ public record LessonSummaryResponse(
                 description = "해결 여부",
                 example = "true"
         )
+        @JsonProperty("isSolved")
         boolean isSolved
 ) {
 }

--- a/src/main/java/gravit/code/mission/dto/response/MissionDetailResponse.java
+++ b/src/main/java/gravit/code/mission/dto/response/MissionDetailResponse.java
@@ -1,5 +1,6 @@
 package gravit.code.mission.dto.response;
 
+import com.fasterxml.jackson.annotation.JsonProperty;
 import gravit.code.mission.domain.Mission;
 import lombok.AccessLevel;
 import lombok.Builder;
@@ -10,6 +11,7 @@ public record MissionDetailResponse(
         String missionDescription,
         int awardXp,
         double progressRate,
+        @JsonProperty("isCompleted")
         boolean isCompleted
 ) {
     public static MissionDetailResponse from(Mission mission) {

--- a/src/main/java/gravit/code/mission/dto/response/MissionSummaryResponse.java
+++ b/src/main/java/gravit/code/mission/dto/response/MissionSummaryResponse.java
@@ -1,5 +1,6 @@
 package gravit.code.mission.dto.response;
 
+import com.fasterxml.jackson.annotation.JsonProperty;
 import gravit.code.mission.domain.MissionType;
 import jakarta.validation.constraints.NotNull;
 
@@ -7,6 +8,7 @@ public record MissionSummaryResponse(
 
         @NotNull
         MissionType missionType,
+        @JsonProperty("isCompleted")
         boolean isCompleted
 ) {
 }

--- a/src/main/java/gravit/code/notice/controller/docs/NoticeQueryControllerDocs.java
+++ b/src/main/java/gravit/code/notice/controller/docs/NoticeQueryControllerDocs.java
@@ -2,8 +2,8 @@ package gravit.code.notice.controller.docs;
 
 
 import gravit.code.global.dto.response.PageResponse;
-import gravit.code.global.dto.response.SliceResponse;
 import gravit.code.notice.dto.response.NoticeDetailResponse;
+import gravit.code.notice.dto.response.NoticeSummaryPageResponse;
 import gravit.code.notice.dto.response.NoticeSummaryResponse;
 import io.swagger.v3.oas.annotations.Operation;
 import io.swagger.v3.oas.annotations.Parameter;
@@ -30,7 +30,7 @@ public interface NoticeQueryControllerDocs {
             @ApiResponse(responseCode = "200", description = "✅ 조회 성공",
                     content = @Content(
                             mediaType = "application/json",
-                            schema = @Schema(implementation = SliceResponse.class),
+                            schema = @Schema(implementation = NoticeSummaryPageResponse.class),
                             examples = @ExampleObject(
                                     name = "notice-summaries",
                                     value = """

--- a/src/main/java/gravit/code/notice/controller/docs/NoticeQueryControllerDocs.java
+++ b/src/main/java/gravit/code/notice/controller/docs/NoticeQueryControllerDocs.java
@@ -35,8 +35,10 @@ public interface NoticeQueryControllerDocs {
                                     name = "notice-summaries",
                                     value = """
                                     {
+                                      "page": 1,
+                                      "totalPages": 5,
                                       "hasNext": true,
-                                      "content": [
+                                      "contents": [
                                         {
                                           "id": 123,
                                           "title": "9월 정기 점검 안내",

--- a/src/main/java/gravit/code/notice/dto/response/NoticeSummaryPageResponse.java
+++ b/src/main/java/gravit/code/notice/dto/response/NoticeSummaryPageResponse.java
@@ -1,0 +1,21 @@
+package gravit.code.notice.dto.response;
+
+import io.swagger.v3.oas.annotations.media.Schema;
+
+import java.util.List;
+
+@Schema(description = "공지 요약 페이지 응답")
+public class NoticeSummaryPageResponse {
+
+    @Schema(description = "현재 페이지 번호", example = "1")
+    public int page;
+
+    @Schema(description = "전체 페이지 수", example = "5")
+    public int totalPages;
+
+    @Schema(description = "다음 페이지 존재 여부", example = "true")
+    public boolean hasNext;
+
+    @Schema(description = "공지 요약 목록")
+    public List<NoticeSummaryResponse> contents;
+}

--- a/src/main/java/gravit/code/option/dto/response/OptionResponse.java
+++ b/src/main/java/gravit/code/option/dto/response/OptionResponse.java
@@ -1,5 +1,6 @@
 package gravit.code.option.dto.response;
 
+import com.fasterxml.jackson.annotation.JsonProperty;
 import gravit.code.option.domain.Option;
 import io.swagger.v3.oas.annotations.media.Schema;
 import jakarta.validation.constraints.NotNull;
@@ -34,6 +35,7 @@ public record OptionResponse(
                 description = "정답 여부",
                 example = "true"
         )
+        @JsonProperty("isAnswer")
         boolean isAnswer,
 
         @Schema(

--- a/src/main/java/gravit/code/problem/dto/response/ProblemDetailResponse.java
+++ b/src/main/java/gravit/code/problem/dto/response/ProblemDetailResponse.java
@@ -1,5 +1,6 @@
 package gravit.code.problem.dto.response;
 
+import com.fasterxml.jackson.annotation.JsonProperty;
 import gravit.code.problem.domain.ProblemType;
 import jakarta.validation.constraints.NotNull;
 
@@ -12,6 +13,7 @@ public record ProblemDetailResponse(
         String instruction,
         @NotNull
         String content,
+        @JsonProperty("isBookmarked")
         boolean isBookmarked
 ) {
 }

--- a/src/main/java/gravit/code/problem/dto/response/ProblemResponse.java
+++ b/src/main/java/gravit/code/problem/dto/response/ProblemResponse.java
@@ -1,6 +1,7 @@
 package gravit.code.problem.dto.response;
 
 import com.fasterxml.jackson.annotation.JsonInclude;
+import com.fasterxml.jackson.annotation.JsonProperty;
 import gravit.code.answer.domain.Answer;
 import gravit.code.answer.dto.response.AnswerResponse;
 import gravit.code.option.dto.response.OptionResponse;
@@ -60,6 +61,7 @@ public record ProblemResponse(
                 description = "북마크 여부",
                 example = "true"
         )
+        @JsonProperty("isBookmarked")
         boolean isBookmarked
 
 ) {

--- a/src/main/java/gravit/code/social/controller/docs/SocialControllerDocs.java
+++ b/src/main/java/gravit/code/social/controller/docs/SocialControllerDocs.java
@@ -5,6 +5,7 @@ import gravit.code.global.dto.response.SliceResponse;
 import gravit.code.global.exception.domain.ErrorResponse;
 import gravit.code.social.dto.response.RecommendUserResponse;
 import gravit.code.social.dto.response.SocialFeedResponse;
+import gravit.code.social.dto.response.SocialFeedSliceResponse;
 import io.swagger.v3.oas.annotations.Operation;
 import io.swagger.v3.oas.annotations.Parameter;
 import io.swagger.v3.oas.annotations.media.Content;
@@ -132,7 +133,7 @@ public interface SocialControllerDocs {
                     description = "✅ 피드 조회 성공",
                     content = @Content(
                             mediaType = MediaType.APPLICATION_JSON_VALUE,
-                            schema = @Schema(implementation = SliceResponse.class),
+                            schema = @Schema(implementation = SocialFeedSliceResponse.class),
                             examples = @ExampleObject(
                                     name = "피드 조회 성공 예시",
                                     value = """

--- a/src/main/java/gravit/code/social/dto/response/SocialFeedSliceResponse.java
+++ b/src/main/java/gravit/code/social/dto/response/SocialFeedSliceResponse.java
@@ -1,0 +1,15 @@
+package gravit.code.social.dto.response;
+
+import io.swagger.v3.oas.annotations.media.Schema;
+
+import java.util.List;
+
+@Schema(description = "피드 슬라이스 응답")
+public class SocialFeedSliceResponse {
+
+    @Schema(description = "다음 페이지 존재 여부", example = "false")
+    public boolean hasNextPage;
+
+    @Schema(description = "피드 목록")
+    public List<SocialFeedResponse> contents;
+}

--- a/src/main/java/gravit/code/unit/dto/response/UnitProgressSummaryResponse.java
+++ b/src/main/java/gravit/code/unit/dto/response/UnitProgressSummaryResponse.java
@@ -1,5 +1,6 @@
 package gravit.code.unit.dto.response;
 
+import com.fasterxml.jackson.annotation.JsonProperty;
 import lombok.Builder;
 
 import static lombok.AccessLevel.PRIVATE;
@@ -8,6 +9,7 @@ import static lombok.AccessLevel.PRIVATE;
 public record UnitProgressSummaryResponse(
         long unitId,
         String title,
+        @JsonProperty("isCompleted")
         boolean isCompleted
 ) {
     public static UnitProgressSummaryResponse of(


### PR DESCRIPTION
### 1. 연관 이슈

---
없음

<br>

### 2. 구현 사항

---
**boolean isXxx 필드 JSON 직렬화 버그 수정**

Java record에서 `boolean isXxx` 컴포넌트를 선언하면 접근자 메서드가 `isXxx()`로 생성되는데, Jackson이 이를 일반 boolean getter로 인식해 `is` prefix를 제거하고 `xxx`로 직렬화하는 버그가 있었습니다. `FollowerResponse.isFollowing`에서 동일한 이유로 버그가 발생했고 `@JsonProperty`로 수정한 것과 같이, Response DTO 전체에서 누락된 필드들을 일괄 수정했습니다.

수정 대상: `isOnboarded`, `isCurrent`, `isBookmarked`, `isSolved`, `isCompleted`, `isAnswer`, `isResolved`, `isFollowing`(SearchUserDto) 등 13개 파일

**Swagger 응답 명세 제네릭 타입 구체화**

`@ApiResponse`의 `@Content`에 `schema = @Schema(implementation = SliceResponse.class)`처럼 raw 타입을 참조하면 Swagger UI에서 `contents` 배열 아이템이 `Object`로 표시되는 문제가 있었습니다. 각 제네릭 타입에 대한 구체 wrapper 클래스를 생성하고 Docs에 적용했습니다.

- `FollowerSliceResponse` → `SliceResponse<FollowerResponse>` (getFollowers)
- `SearchUserSliceResponse` → `SliceResponse<SearchUserDto>` (search)
- `SocialFeedSliceResponse` → `SliceResponse<SocialFeedResponse>` (getFeed)
- `NoticeSummaryPageResponse` → `PageResponse<NoticeSummaryResponse>` (getNoticeSummaries)
- `AdminNoticeSummaryPageResponse` → `PageResponse<AdminNoticeSummaryResponse>` (getNoticeSummaryByAdmin)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## 릴리스 노트

* **Bug Fixes**
  * 여러 API 응답의 boolean 필드 JSON 직렬화 속성명을 명시적으로 고정하여 일관성 확보

* **New Features**
  * 공지사항, 팔로워, 소셜 피드 목록 조회를 위한 새로운 페이지/슬라이스 응답 구조 추가
  * API 응답 문서의 스키마 타입을 보다 명확하게 정의

<!-- end of auto-generated comment: release notes by coderabbit.ai -->