### PR TITLE
feat: 알림 기본 엔티티 구현(#367)

### DIFF
--- a/src/main/java/gravit/code/notification/domain/Notification.java
+++ b/src/main/java/gravit/code/notification/domain/Notification.java
@@ -3,6 +3,8 @@ package gravit.code.notification.domain;
 import gravit.code.global.entity.BaseEntity;
 import jakarta.persistence.Column;
 import jakarta.persistence.Entity;
+import jakarta.persistence.EnumType;
+import jakarta.persistence.Enumerated;
 import jakarta.persistence.GeneratedValue;
 import jakarta.persistence.GenerationType;
 import jakarta.persistence.Id;
@@ -25,8 +27,15 @@ public class Notification extends BaseEntity {
     @Column(name = "user_id", nullable = false)
     private long userId;
 
+    @Enumerated(EnumType.STRING)
+    @Column(name = "type", nullable = false)
+    private NotificationType type;
+
     @Column(name = "message", nullable = false)
     private String message;
+
+    @Column(name = "target_id")
+    private Long targetId;
 
     @Column(name = "is_read", nullable = false)
     private boolean read;
@@ -34,20 +43,36 @@ public class Notification extends BaseEntity {
     @Builder(access = AccessLevel.PRIVATE)
     private Notification(
             long userId,
-            String message
+            NotificationType type,
+            String message,
+            Long targetId
     ) {
         this.userId = userId;
+        this.type = type;
         this.message = message;
+        this.targetId = targetId;
         this.read = false;
     }
 
     public static Notification create(
             long userId,
-            String message
+            NotificationType type,
+            String message,
+            Long targetId
     ) {
         return Notification.builder()
                 .userId(userId)
+                .type(type)
                 .message(message)
+                .targetId(targetId)
                 .build();
+    }
+
+    public static Notification create(
+            long userId,
+            NotificationType type,
+            String message
+    ) {
+        return create(userId, type, message, null);
     }
 }

--- a/src/main/java/gravit/code/notification/domain/NotificationActionType.java
+++ b/src/main/java/gravit/code/notification/domain/NotificationActionType.java
@@ -1,0 +1,17 @@
+package gravit.code.notification.domain;
+
+import lombok.Getter;
+import lombok.RequiredArgsConstructor;
+
+@Getter
+@RequiredArgsConstructor
+public enum NotificationActionType {
+
+    NONE("버튼 없음"),                     // 액션 없음 (targetId 없음)
+    GO_TO_LEARNING("학습하러 가기"),         // 학습 메인(targetId 없음) 또는 레슨 딥링크(targetId = unit)
+    GO_TO_NOTICE("공지사항 바로가기"),       // targetId = noticeId
+    FOLLOW_BACK("맞팔로우"),               // targetId = 상대 userId
+    CONGRATULATE("축하하기");              // targetId = feedId
+
+    private final String label;
+}

--- a/src/main/java/gravit/code/notification/domain/NotificationType.java
+++ b/src/main/java/gravit/code/notification/domain/NotificationType.java
@@ -1,0 +1,29 @@
+package gravit.code.notification.domain;
+
+import lombok.Getter;
+import lombok.RequiredArgsConstructor;
+
+import static gravit.code.notification.domain.NotificationActionType.CONGRATULATE;
+import static gravit.code.notification.domain.NotificationActionType.FOLLOW_BACK;
+import static gravit.code.notification.domain.NotificationActionType.GO_TO_LEARNING;
+import static gravit.code.notification.domain.NotificationActionType.GO_TO_NOTICE;
+import static gravit.code.notification.domain.NotificationActionType.NONE;
+
+@Getter
+@RequiredArgsConstructor
+public enum NotificationType {
+
+    STREAK_WARNING(GO_TO_LEARNING),    // 3.1  연속학습 끊길 위기
+    DAILY_INCOMPLETE(GO_TO_LEARNING),  // 3.2  오늘 학습 미완료
+    INACTIVITY(GO_TO_LEARNING),        // 3.3  장기 미접속
+    SEASON_ENDING(GO_TO_LEARNING),     // 3.7  시즌 종료 임박
+    SEASON_RESET(NONE),                // 3.8  시즌 종료 + 새 시즌 시작
+    FOLLOW(FOLLOW_BACK),               // 3.9  팔로우
+    CONGRATULATION(NONE),              // 3.10 축하하기 받음
+    FRIEND_ACTIVITY(CONGRATULATE),     // 3.11 친구 활동
+    NOTICE(GO_TO_NOTICE),              // 3.12 공지사항
+    VERSION(GO_TO_NOTICE),             // 3.13 버전 관리
+    NEW_CONTENT(GO_TO_LEARNING);       // 3.14 새 콘텐츠 업데이트
+
+    private final NotificationActionType actionType;
+}

--- a/src/main/java/gravit/code/notification/service/NotificationService.java
+++ b/src/main/java/gravit/code/notification/service/NotificationService.java
@@ -1,6 +1,7 @@
 package gravit.code.notification.service;
 
 import gravit.code.notification.domain.Notification;
+import gravit.code.notification.domain.NotificationType;
 import gravit.code.notification.repository.NotificationRepository;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
@@ -15,8 +16,19 @@ public class NotificationService {
     @Transactional
     public void notify(
             long userId,
+            NotificationType type,
+            String message,
+            Long targetId
+    ) {
+        notificationRepository.save(Notification.create(userId, type, message, targetId));
+    }
+
+    @Transactional
+    public void notify(
+            long userId,
+            NotificationType type,
             String message
     ) {
-        notificationRepository.save(Notification.create(userId, message));
+        notify(userId, type, message, null);
     }
 }

--- a/src/main/java/gravit/code/social/facade/SocialFacade.java
+++ b/src/main/java/gravit/code/social/facade/SocialFacade.java
@@ -5,6 +5,7 @@ import gravit.code.global.annotation.Facade;
 import gravit.code.global.dto.response.SliceResponse;
 import gravit.code.global.exception.domain.CustomErrorCode;
 import gravit.code.global.exception.domain.RestApiException;
+import gravit.code.notification.domain.NotificationType;
 import gravit.code.notification.service.NotificationService;
 import gravit.code.social.domain.FeedEventType;
 import gravit.code.social.domain.SocialFeed;
@@ -97,6 +98,6 @@ public class SocialFacade {
         userFeedService.congratulateFeed(userId, feedId);
         userLeaguePointService.addLeaguePoints(actorId, CONGRATULATION_LP, FULL_ACCURACY);
         String congratulatorNickname = userService.getUser(userId).getNickname();
-        notificationService.notify(actorId, congratulatorNickname + "님이 축하해줬어요!");
+        notificationService.notify(actorId, NotificationType.CONGRATULATION, congratulatorNickname + "님이 축하해줬어요!");
     }
 }

--- a/src/main/resources/db/migration/V15__add_notification_type_and_target.sql
+++ b/src/main/resources/db/migration/V15__add_notification_type_and_target.sql
@@ -1,0 +1,20 @@
+-- notification에 알림 종류(type)와 액션 라우팅 대상(target_id) 컬럼 추가
+-- type: 알림 종류. 버튼 종류는 type에서 파생되므로 별도 컬럼을 두지 않는다.
+-- target_id: 액션이 이동할 리소스 id. 의미(noticeId/lessonId/userId/feedId)는 type이 결정. 대상 없으면 NULL.
+ALTER TABLE notification ADD COLUMN type      VARCHAR(255);
+ALTER TABLE notification ADD COLUMN target_id BIGINT;
+
+-- 기존 행 백필: V12 이후 생성된 알림은 축하받음(3.10) 알림뿐이므로 CONGRATULATION으로 채운다
+UPDATE notification SET type = 'CONGRATULATION' WHERE type IS NULL;
+
+-- type은 필수값
+ALTER TABLE notification ALTER COLUMN type SET NOT NULL;
+
+-- enum 값 제약
+ALTER TABLE notification ADD CONSTRAINT ck_notification_type CHECK (
+    type IN (
+        'STREAK_WARNING', 'DAILY_INCOMPLETE', 'INACTIVITY', 'SEASON_ENDING',
+        'SEASON_RESET', 'FOLLOW', 'CONGRATULATION', 'FRIEND_ACTIVITY',
+        'NOTICE', 'VERSION', 'NEW_CONTENT'
+    )
+);

--- a/src/test/java/gravit/code/social/facade/SocialFacadeIntegrationTest.java
+++ b/src/test/java/gravit/code/social/facade/SocialFacadeIntegrationTest.java
@@ -12,6 +12,7 @@ import gravit.code.global.exception.domain.RestApiException;
 import gravit.code.league.domain.League;
 import gravit.code.league.fixture.LeagueFixture;
 import gravit.code.notification.domain.Notification;
+import gravit.code.notification.domain.NotificationType;
 import gravit.code.notification.repository.NotificationRepository;
 import gravit.code.season.domain.Season;
 import gravit.code.season.fixture.SeasonFixture;
@@ -222,7 +223,9 @@ class SocialFacadeIntegrationTest {
             assertThat(notifications).hasSize(1);
             assertSoftly(softly -> {
                 softly.assertThat(notifications.get(0).getUserId()).isEqualTo(followee.getId());
+                softly.assertThat(notifications.get(0).getType()).isEqualTo(NotificationType.CONGRATULATION);
                 softly.assertThat(notifications.get(0).getMessage()).isEqualTo("유저1님이 축하해줬어요!");
+                softly.assertThat(notifications.get(0).getTargetId()).isNull();
             });
         }
 


### PR DESCRIPTION
### 1. 연관 이슈

---
 - close #367

<br>

### 2. 구현 사항

---
**알림(Notification) 기본 엔티티 설계 및 14종 알림 타입 수용**

기능 명세서 3.1~3.14의 모든 알림 종류를 하나의 엔티티로 수용하기 위해, 기존 `userId/message/read`만 있던 최소 엔티티를 확장했습니다.

**`NotificationType` enum 신규**
알림 종류 11종(STREAK_WARNING, DAILY_INCOMPLETE, INACTIVITY, SEASON_ENDING, SEASON_RESET, FOLLOW, CONGRATULATION, FRIEND_ACTIVITY, NOTICE, VERSION, NEW_CONTENT)을 정의. 각 타입은 자신의 액션 버튼 종류(`NotificationActionType`)를 고정으로 가집니다. **버튼 종류는 타입에서 파생**되므로 별도 컬럼으로 저장하지 않습니다.


명세 | type | actionType | targetId 성격 | 라우팅 목적지
-- | -- | -- | -- | --
3.1 연속학습 끊길 위기 | STREAK_WARNING | GO_TO_LEARNING | null | 학습 메인
3.2 오늘 학습 미완료 | DAILY_INCOMPLETE | GO_TO_LEARNING | null | 학습 메인
3.3 장기 미접속 | INACTIVITY | GO_TO_LEARNING | null | 학습 메인
3.7 시즌 종료 임박 | SEASON_ENDING | GO_TO_LEARNING | null | 학습 메인
3.8 시즌 종료+새 시즌 | SEASON_RESET | NONE | null | -
3.9 팔로우 | FOLLOW | FOLLOW_BACK | 상대 userId | 맞팔로우/프로필
3.10 축하받음 | CONGRATULATION | NONE | null | -
3.11 친구 활동 | FRIEND_ACTIVITY | CONGRATULATE | feedId | 축하하기 실행
3.12 공지사항 | NOTICE | GO_TO_NOTICE | noticeId | 공지 상세
3.13 버전 관리 | VERSION | GO_TO_NOTICE | noticeId | 공지 상세
3.14 새 콘텐츠 | NEW_CONTENT | GO_TO_LEARNING | unitId | 레슨 딥링크

<br>

**`NotificationActionType` enum 신규**
버튼 종류(NONE / GO_TO_LEARNING / GO_TO_NOTICE / FOLLOW_BACK / CONGRATULATE)와 라벨.


actionType | 버튼 라벨 | 라우팅 | targetId 사용
-- | -- | -- | --
NONE | (버튼 없음) | - | -
GO_TO_LEARNING | 학습하러 가기 | 해당 unit으로 이동 | unitId (nullable)
GO_TO_NOTICE | 공지사항 바로가기 | 공지 상세 | noticeId
FOLLOW_BACK | 맞팔로우 | 맞팔로우 실행 / 상대 프로필 | 상대 userId
CONGRATULATE | 축하하기 | 축하하기 실행 | feedId

<br>

**`Notification` 엔티티 확장**
`type`(NOT NULL)과 `targetId`(nullable) 추가. `targetId`는 액션 버튼이 이동할 리소스 id로, 그 의미(noticeId/lessonId/userId/feedId)는 `type`이 결정합니다. 명세 13/14가 id 1개로 환원되므로 다중 컬럼·JSONB 대신 단일 `targetId`로 단순화했습니다.


**`NotificationService.notify` 시그니처 확장**
(userId, type, message, targetId)` + 호환용 `(userId, type, message)` 오버로드.


**`SocialFacade` 호출부 보정**
 축하받음 알림(3.10)에 `CONGRATULATION` 타입을 전달. 수신자·메시지는 동일하게 유지하여 기존 동작을 보존했습니다.


**DB 마이그레이션 (V15)**
V12 테이블을 수정하지 않고 V15로 `type`, `target_id` 컬럼만 추가. 기존 행은 CONGRATULATION으로 백필한 뒤 `type`에 NOT NULL과 enum CHECK 제약을 부여하여, 운영 데이터가 있어도 제약 위반 없이 적용됩니다.

> 조회 API 응답 DTO 및 조건부 버튼(3.9 맞팔로우 / 3.11 축하하기) 활성 플래그는 본 PR 범위 밖이며, 별도 작업으로 진행합니다.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## 릴리스 노트

* **새로운 기능**
  * 알림 시스템이 확장되어 다양한 알림 유형(스트릭 경고, 불완전한 일일 과제, 비활성화, 시즌 종료/리셋, 팔로우, 축하, 친구 활동, 공지사항, 버전, 새 콘텐츠)을 지원합니다.
  * 알림이 특정 리소스를 가리킬 수 있도록 타겟 식별자 기능을 추가했습니다.
  * 각 알림 유형에 맞는 액션(학습으로 이동, 공지로 이동, 팔로우 응답, 축하)이 자동으로 매핑됩니다.

* **테스트**
  * 축하 알림 관련 테스트를 업데이트했습니다.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->