### PR TITLE
fix: RecommendUserResponse Swagger 스키마 배열 타입으로 수정

### DIFF
--- a/src/main/java/gravit/code/social/controller/docs/SocialControllerDocs.java
+++ b/src/main/java/gravit/code/social/controller/docs/SocialControllerDocs.java
@@ -8,6 +8,7 @@ import gravit.code.social.dto.response.SocialFeedResponse;
 import gravit.code.social.dto.response.SocialFeedSliceResponse;
 import io.swagger.v3.oas.annotations.Operation;
 import io.swagger.v3.oas.annotations.Parameter;
+import io.swagger.v3.oas.annotations.media.ArraySchema;
 import io.swagger.v3.oas.annotations.media.Content;
 import io.swagger.v3.oas.annotations.media.ExampleObject;
 import io.swagger.v3.oas.annotations.media.Schema;
@@ -43,7 +44,7 @@ public interface SocialControllerDocs {
                     description = "✅ 추천 친구 목록 조회 성공",
                     content = @Content(
                             mediaType = MediaType.APPLICATION_JSON_VALUE,
-                            schema = @Schema(implementation = RecommendUserResponse.class),
+                            array = @ArraySchema(schema = @Schema(implementation = RecommendUserResponse.class)),
                             examples = @ExampleObject(
                                     name = "추천 친구 목록 조회 성공 예시",
                                     value = """


### PR DESCRIPTION
### 1. 연관 이슈

---
없음

<br>

### 2. 구현 사항

---
**Swagger 추천 친구 목록 응답 스키마 배열 타입 수정**

`GET /api/v1/social/recommend` 엔드포인트의 Swagger 응답 명세가 `RecommendUserResponse` 단일 객체로 표시되던 문제를 수정했습니다.

실제 반환 타입은 `ResponseEntity<List<RecommendUserResponse>>`이지만, `@Schema(implementation = RecommendUserResponse.class)`를 사용하면 springdoc이 단일 객체 스키마로 렌더링합니다. 이를 `@ArraySchema(schema = @Schema(implementation = RecommendUserResponse.class))`로 변경하여 Swagger UI에서 배열로 올바르게 표시되도록 수정했습니다.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * 소셜 API 문서의 응답 스키마 정의를 개선하여 API 명세의 정확성을 향상시켰습니다. 사용자에게 제공되는 기능이나 API 동작에는 변화가 없습니다.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->