### PR TITLE
feat: 리텐션, 콘텐츠 알림 및 앱 버전 체크 구현(#368)

### DIFF
--- a/.claude/rules/class-convention.md
+++ b/.claude/rules/class-convention.md
@@ -20,5 +20,21 @@ paths:
 
 - DTO는 `record` 타입으로 선언하라
 - Request에는 `@Schema` + validation 어노테이션을 포함하라
+- Response에는 validation 어노테이션(`@NotNull` 등)을 붙이지 마라. validation은 Request 전용이다
 - Response에는 `@Builder(access = AccessLevel.PRIVATE)` + `static create()` 또는 `static of()` 팩토리 메서드를 사용하라
 - 패키지는 `{domain}/dto/request/`, `{domain}/dto/response/`로 분리하라
+
+### @Schema 포맷 (Response)
+
+- `@Schema` 속성이 2개 이상이면 한 줄에 몰아쓰지 말고 속성당 한 줄로 작성하라
+
+```java
+@Schema(
+        description = "팔로워 목록",
+        requiredMode = Schema.RequiredMode.REQUIRED
+)
+public List<FollowerResponse> contents;
+```
+
+- 속성이 1개면 한 줄로 작성해도 된다 (예: `@Schema(requiredMode = Schema.RequiredMode.REQUIRED)`)
+- record 컴포넌트(필드) 사이는 빈 줄로 구분하라

--- a/src/main/java/gravit/code/admin/dto/response/AdminNoticeDetailResponse.java
+++ b/src/main/java/gravit/code/admin/dto/response/AdminNoticeDetailResponse.java
@@ -2,7 +2,6 @@ package gravit.code.admin.dto.response;
 
 import gravit.code.notice.domain.Notice;
 import io.swagger.v3.oas.annotations.media.Schema;
-import jakarta.validation.constraints.NotNull;
 import lombok.Builder;
 
 import java.time.LocalDateTime;
@@ -12,24 +11,25 @@ public record AdminNoticeDetailResponse(
 
         @Schema(requiredMode = Schema.RequiredMode.REQUIRED)
         long noticeId,
+
         @Schema(requiredMode = Schema.RequiredMode.REQUIRED)
-        @NotNull
         String title,
+
         @Schema(requiredMode = Schema.RequiredMode.REQUIRED)
-        @NotNull
         String contents,
+
         @Schema(requiredMode = Schema.RequiredMode.REQUIRED)
-        @NotNull
         String authorName,
+
         @Schema(requiredMode = Schema.RequiredMode.REQUIRED)
-        @NotNull
         LocalDateTime createdAt,
+
         @Schema(requiredMode = Schema.RequiredMode.REQUIRED)
-        @NotNull
         LocalDateTime updatedAt,
+
         @Schema(requiredMode = Schema.RequiredMode.REQUIRED)
-        @NotNull
         String noticeType,
+
         @Schema(requiredMode = Schema.RequiredMode.REQUIRED)
         boolean pinned,
         LocalDateTime publishedAt

--- a/src/main/java/gravit/code/admin/dto/response/AdminNoticeSummaryPageResponse.java
+++ b/src/main/java/gravit/code/admin/dto/response/AdminNoticeSummaryPageResponse.java
@@ -7,15 +7,30 @@ import java.util.List;
 @Schema(description = "어드민 공지 요약 페이지 응답")
 public class AdminNoticeSummaryPageResponse {
 
-    @Schema(description = "현재 페이지 번호", example = "0", requiredMode = Schema.RequiredMode.REQUIRED)
+    @Schema(
+            description = "현재 페이지 번호",
+            example = "0",
+            requiredMode = Schema.RequiredMode.REQUIRED
+    )
     public int page;
 
-    @Schema(description = "전체 페이지 수", example = "3", requiredMode = Schema.RequiredMode.REQUIRED)
+    @Schema(
+            description = "전체 페이지 수",
+            example = "3",
+            requiredMode = Schema.RequiredMode.REQUIRED
+    )
     public int totalPages;
 
-    @Schema(description = "다음 페이지 존재 여부", example = "true", requiredMode = Schema.RequiredMode.REQUIRED)
+    @Schema(
+            description = "다음 페이지 존재 여부",
+            example = "true",
+            requiredMode = Schema.RequiredMode.REQUIRED
+    )
     public boolean hasNext;
 
-    @Schema(description = "공지 요약 목록", requiredMode = Schema.RequiredMode.REQUIRED)
+    @Schema(
+            description = "공지 요약 목록",
+            requiredMode = Schema.RequiredMode.REQUIRED
+    )
     public List<AdminNoticeSummaryResponse> contents;
 }

--- a/src/main/java/gravit/code/admin/dto/response/AdminNoticeSummaryResponse.java
+++ b/src/main/java/gravit/code/admin/dto/response/AdminNoticeSummaryResponse.java
@@ -1,7 +1,6 @@
 package gravit.code.admin.dto.response;
 
 import io.swagger.v3.oas.annotations.media.Schema;
-import jakarta.validation.constraints.NotNull;
 
 import java.time.LocalDateTime;
 
@@ -9,14 +8,16 @@ public record AdminNoticeSummaryResponse(
 
         @Schema(requiredMode = Schema.RequiredMode.REQUIRED)
         long id,
+
         @Schema(requiredMode = Schema.RequiredMode.REQUIRED)
-        @NotNull
         String title,
+
         @Schema(requiredMode = Schema.RequiredMode.REQUIRED)
-        @NotNull
         String summary,
+
         @Schema(requiredMode = Schema.RequiredMode.REQUIRED)
         boolean pinned,
+
         LocalDateTime publishedAt
 ) {
 }

--- a/src/main/java/gravit/code/admin/dto/response/ReportDetailResponse.java
+++ b/src/main/java/gravit/code/admin/dto/response/ReportDetailResponse.java
@@ -3,7 +3,6 @@ package gravit.code.admin.dto.response;
 import com.fasterxml.jackson.annotation.JsonProperty;
 import gravit.code.report.domain.ReportType;
 import io.swagger.v3.oas.annotations.media.Schema;
-import jakarta.validation.constraints.NotNull;
 
 import java.time.LocalDateTime;
 
@@ -21,7 +20,6 @@ public record ReportDetailResponse(
                 description = "신고 유형",
                 requiredMode = Schema.RequiredMode.REQUIRED
         )
-        @NotNull
         ReportType reportType,
 
         @Schema(
@@ -36,7 +34,6 @@ public record ReportDetailResponse(
                 example = "문제에 오타가 있습니다.",
                 requiredMode = Schema.RequiredMode.REQUIRED
         )
-        @NotNull
         String content,
 
         @Schema(
@@ -51,7 +48,6 @@ public record ReportDetailResponse(
                 description = "신고 접수 시간",
                 requiredMode = Schema.RequiredMode.REQUIRED
         )
-        @NotNull
         LocalDateTime submittedAt
 ) {
 }

--- a/src/main/java/gravit/code/admin/dto/response/ReportSummaryResponse.java
+++ b/src/main/java/gravit/code/admin/dto/response/ReportSummaryResponse.java
@@ -3,7 +3,6 @@ package gravit.code.admin.dto.response;
 import com.fasterxml.jackson.annotation.JsonProperty;
 import gravit.code.report.domain.ReportType;
 import io.swagger.v3.oas.annotations.media.Schema;
-import jakarta.validation.constraints.NotNull;
 
 import java.time.LocalDateTime;
 
@@ -21,7 +20,6 @@ public record ReportSummaryResponse(
                 description = "신고 유형",
                 requiredMode = Schema.RequiredMode.REQUIRED
         )
-        @NotNull
         ReportType reportType,
 
         @Schema(
@@ -43,7 +41,6 @@ public record ReportSummaryResponse(
                 description = "신고 접수 시간",
                 requiredMode = Schema.RequiredMode.REQUIRED
         )
-        @NotNull
         LocalDateTime submittedAt
 ) {
 }

--- a/src/main/java/gravit/code/admin/service/AdminNoticeCommandService.java
+++ b/src/main/java/gravit/code/admin/service/AdminNoticeCommandService.java
@@ -3,6 +3,7 @@ package gravit.code.admin.service;
 import gravit.code.admin.dto.request.NoticeCreateRequest;
 import gravit.code.admin.dto.request.NoticeUpdateRequest;
 import gravit.code.admin.dto.response.AdminNoticeDetailResponse;
+import gravit.code.global.event.NoticeCreatedEvent;
 import gravit.code.global.exception.domain.CustomErrorCode;
 import gravit.code.global.exception.domain.RestApiException;
 import gravit.code.notice.domain.Notice;
@@ -11,12 +12,15 @@ import gravit.code.notice.repository.NoticeRepository;
 import gravit.code.user.domain.User;
 import gravit.code.user.repository.UserRepository;
 import lombok.RequiredArgsConstructor;
+import org.springframework.context.ApplicationEventPublisher;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
 @Service
 @RequiredArgsConstructor
 public class AdminNoticeCommandService {
+
+    private final ApplicationEventPublisher publisher;
 
     private final NoticeRepository noticeRepository;
     private final UserRepository userRepository;
@@ -35,6 +39,10 @@ public class AdminNoticeCommandService {
         Notice notice = Notice.create(title, content, author, status, pinned);
 
         noticeRepository.save(notice);
+
+        if (status == NoticeStatus.PUBLISHED) {
+            publisher.publishEvent(new NoticeCreatedEvent(notice.getId(), title));
+        }
 
         return AdminNoticeDetailResponse.from(notice);
     }

--- a/src/main/java/gravit/code/auth/dto/response/LoginResponse.java
+++ b/src/main/java/gravit/code/auth/dto/response/LoginResponse.java
@@ -4,16 +4,15 @@ import com.fasterxml.jackson.annotation.JsonProperty;
 import gravit.code.auth.domain.AccessToken;
 import gravit.code.auth.domain.RefreshToken;
 import io.swagger.v3.oas.annotations.media.Schema;
-import jakarta.validation.constraints.NotNull;
 
 public record LoginResponse(
 
         @Schema(requiredMode = Schema.RequiredMode.REQUIRED)
-        @NotNull
         String accessToken,
+
         @Schema(requiredMode = Schema.RequiredMode.REQUIRED)
-        @NotNull
         String refreshToken,
+
         @Schema(requiredMode = Schema.RequiredMode.REQUIRED)
         @JsonProperty("isOnboarded")
         boolean isOnboarded

--- a/src/main/java/gravit/code/auth/dto/response/ReissueResponse.java
+++ b/src/main/java/gravit/code/auth/dto/response/ReissueResponse.java
@@ -2,12 +2,10 @@ package gravit.code.auth.dto.response;
 
 import gravit.code.auth.domain.AccessToken;
 import io.swagger.v3.oas.annotations.media.Schema;
-import jakarta.validation.constraints.NotNull;
 
 public record ReissueResponse(
 
         @Schema(requiredMode = Schema.RequiredMode.REQUIRED)
-        @NotNull
         String accessToken
 ) {
     public static ReissueResponse from(AccessToken accessToken) {

--- a/src/main/java/gravit/code/chapter/dto/response/ChapterDetailResponse.java
+++ b/src/main/java/gravit/code/chapter/dto/response/ChapterDetailResponse.java
@@ -1,7 +1,6 @@
 package gravit.code.chapter.dto.response;
 
 import io.swagger.v3.oas.annotations.media.Schema;
-import jakarta.validation.constraints.NotNull;
 import lombok.AccessLevel;
 import lombok.Builder;
 
@@ -13,7 +12,6 @@ public record ChapterDetailResponse(
                 description = "챕터 요약 정보",
                 requiredMode = Schema.RequiredMode.REQUIRED
         )
-        @NotNull
         ChapterSummaryResponse chapterSummaryResponse,
 
         @Schema(

--- a/src/main/java/gravit/code/chapter/dto/response/ChapterSummaryResponse.java
+++ b/src/main/java/gravit/code/chapter/dto/response/ChapterSummaryResponse.java
@@ -1,7 +1,6 @@
 package gravit.code.chapter.dto.response;
 
 import io.swagger.v3.oas.annotations.media.Schema;
-import jakarta.validation.constraints.NotNull;
 import lombok.AccessLevel;
 import lombok.Builder;
 
@@ -20,7 +19,6 @@ public record ChapterSummaryResponse(
                 example = "자료구조",
                 requiredMode = Schema.RequiredMode.REQUIRED
         )
-        @NotNull
         String title,
 
         @Schema(
@@ -28,7 +26,6 @@ public record ChapterSummaryResponse(
                 example = "큐, 스택, 힙과 같은 자료구조에 대해 학습합니다.",
                 requiredMode = Schema.RequiredMode.REQUIRED
         )
-        @NotNull
         String description
 ) {
 }

--- a/src/main/java/gravit/code/dailyLearningRecord/dto/response/DailySolvedCountResponse.java
+++ b/src/main/java/gravit/code/dailyLearningRecord/dto/response/DailySolvedCountResponse.java
@@ -7,6 +7,7 @@ import java.time.LocalDate;
 public record DailySolvedCountResponse(
         @Schema(requiredMode = Schema.RequiredMode.REQUIRED)
         LocalDate date,
+
         @Schema(requiredMode = Schema.RequiredMode.REQUIRED)
         int solvedLessonCount
 ) {

--- a/src/main/java/gravit/code/dailyLearningRecord/dto/response/WeeklyLearningRecordResponse.java
+++ b/src/main/java/gravit/code/dailyLearningRecord/dto/response/WeeklyLearningRecordResponse.java
@@ -5,16 +5,22 @@ import io.swagger.v3.oas.annotations.media.Schema;
 public record WeeklyLearningRecordResponse(
         @Schema(requiredMode = Schema.RequiredMode.REQUIRED)
         boolean MONDAY,
+
         @Schema(requiredMode = Schema.RequiredMode.REQUIRED)
         boolean TUESDAY,
+
         @Schema(requiredMode = Schema.RequiredMode.REQUIRED)
         boolean WEDNESDAY,
+
         @Schema(requiredMode = Schema.RequiredMode.REQUIRED)
         boolean THURSDAY,
+
         @Schema(requiredMode = Schema.RequiredMode.REQUIRED)
         boolean FRIDAY,
+
         @Schema(requiredMode = Schema.RequiredMode.REQUIRED)
         boolean SATURDAY,
+
         @Schema(requiredMode = Schema.RequiredMode.REQUIRED)
         boolean SUNDAY
 ) {

--- a/src/main/java/gravit/code/dailyLearningRecord/dto/response/WeeklyLearningReportResponse.java
+++ b/src/main/java/gravit/code/dailyLearningRecord/dto/response/WeeklyLearningReportResponse.java
@@ -12,20 +12,28 @@ import java.util.Map;
 public record WeeklyLearningReportResponse(
         @Schema(requiredMode = Schema.RequiredMode.REQUIRED)
         int MONDAY,
+
         @Schema(requiredMode = Schema.RequiredMode.REQUIRED)
         int TUESDAY,
+
         @Schema(requiredMode = Schema.RequiredMode.REQUIRED)
         int WEDNESDAY,
+
         @Schema(requiredMode = Schema.RequiredMode.REQUIRED)
         int THURSDAY,
+
         @Schema(requiredMode = Schema.RequiredMode.REQUIRED)
         int FRIDAY,
+
         @Schema(requiredMode = Schema.RequiredMode.REQUIRED)
         int SATURDAY,
+
         @Schema(requiredMode = Schema.RequiredMode.REQUIRED)
         int SUNDAY,
+
         @Schema(requiredMode = Schema.RequiredMode.REQUIRED)
         int thisWeekCompletedLessonCount,
+
         @Schema(requiredMode = Schema.RequiredMode.REQUIRED)
         List<Integer> weekOverWeekDeltas
 ) {

--- a/src/main/java/gravit/code/fcm/dto/internal/PushMessage.java
+++ b/src/main/java/gravit/code/fcm/dto/internal/PushMessage.java
@@ -3,7 +3,6 @@ package gravit.code.fcm.dto.internal;
 import java.util.List;
 import java.util.Map;
 
-// 발송 단위: 한 유저의 토큰 목록 + 제목/본문 + 액션 라우팅용 data payload
 public record PushMessage(
         List<String> tokens,
         String title,

--- a/src/main/java/gravit/code/fcm/dto/internal/PushMessage.java
+++ b/src/main/java/gravit/code/fcm/dto/internal/PushMessage.java
@@ -1,0 +1,29 @@
+package gravit.code.fcm.dto.internal;
+
+import java.util.List;
+import java.util.Map;
+
+// 발송 단위: 한 유저의 토큰 목록 + 제목/본문 + 액션 라우팅용 data payload
+public record PushMessage(
+        List<String> tokens,
+        String title,
+        String body,
+        Map<String, String> data
+) {
+    public static PushMessage of(
+            List<String> tokens,
+            String title,
+            String body,
+            Map<String, String> data
+    ) {
+        return new PushMessage(tokens, title, body, data);
+    }
+
+    public static PushMessage of(
+            List<String> tokens,
+            String title,
+            String body
+    ) {
+        return new PushMessage(tokens, title, body, Map.of());
+    }
+}

--- a/src/main/java/gravit/code/fcm/dto/internal/PushMessage.java
+++ b/src/main/java/gravit/code/fcm/dto/internal/PushMessage.java
@@ -9,6 +9,11 @@ public record PushMessage(
         String body,
         Map<String, String> data
 ) {
+    public PushMessage {
+        tokens = List.copyOf(tokens);
+        data = Map.copyOf(data);
+    }
+
     public static PushMessage of(
             List<String> tokens,
             String title,

--- a/src/main/java/gravit/code/fcm/repository/FcmTokenRepository.java
+++ b/src/main/java/gravit/code/fcm/repository/FcmTokenRepository.java
@@ -2,6 +2,7 @@ package gravit.code.fcm.repository;
 
 import gravit.code.fcm.domain.FcmToken;
 import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Query;
 
 import java.util.List;
 import java.util.Optional;
@@ -15,4 +16,7 @@ public interface FcmTokenRepository extends JpaRepository<FcmToken, Long> {
     );
 
     List<FcmToken> findByUserIdIn(List<Long> userIds);
+
+    @Query("SELECT t.token FROM FcmToken t")
+    List<String> findAllTokens();
 }

--- a/src/main/java/gravit/code/fcm/repository/FcmTokenRepository.java
+++ b/src/main/java/gravit/code/fcm/repository/FcmTokenRepository.java
@@ -3,6 +3,7 @@ package gravit.code.fcm.repository;
 import gravit.code.fcm.domain.FcmToken;
 import org.springframework.data.jpa.repository.JpaRepository;
 
+import java.util.List;
 import java.util.Optional;
 
 public interface FcmTokenRepository extends JpaRepository<FcmToken, Long> {
@@ -12,4 +13,6 @@ public interface FcmTokenRepository extends JpaRepository<FcmToken, Long> {
             long userId,
             String deviceId
     );
+
+    List<FcmToken> findByUserIdIn(List<Long> userIds);
 }

--- a/src/main/java/gravit/code/fcm/service/FcmService.java
+++ b/src/main/java/gravit/code/fcm/service/FcmService.java
@@ -1,0 +1,71 @@
+package gravit.code.fcm.service;
+
+import com.google.firebase.messaging.FirebaseMessaging;
+import com.google.firebase.messaging.FirebaseMessagingException;
+import com.google.firebase.messaging.Message;
+import com.google.firebase.messaging.Notification;
+import gravit.code.fcm.dto.internal.PushMessage;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.log4j.Log4j2;
+import org.springframework.stereotype.Service;
+
+import java.util.List;
+import java.util.Map;
+
+@Log4j2
+@Service
+@RequiredArgsConstructor
+public class FcmService {
+
+    private static final int BATCH_SIZE = 500;
+
+    private final FirebaseMessaging firebaseMessaging;
+
+    public void sendNotifications(List<PushMessage> messages) {
+        List<Message> fcmMessages = messages.stream()
+                .flatMap(message -> message.tokens().stream()
+                        .map(token -> toMessage(token, message.title(), message.body(), message.data())))
+                .toList();
+
+        if (fcmMessages.isEmpty()) {
+            return;
+        }
+
+        for (int start = 0; start < fcmMessages.size(); start += BATCH_SIZE) {
+            int end = Math.min(start + BATCH_SIZE, fcmMessages.size());
+            sendBatch(fcmMessages.subList(start, end));
+        }
+    }
+
+    private Message toMessage(
+            String token,
+            String title,
+            String body,
+            Map<String, String> data
+    ) {
+        Notification.Builder notification = Notification.builder();
+        if (title != null && !title.isBlank()) {
+            notification.setTitle(title);
+        }
+        if (body != null && !body.isBlank()) {
+            notification.setBody(body);
+        }
+
+        Message.Builder message = Message.builder()
+                .setToken(token)
+                .setNotification(notification.build());
+        if (data != null && !data.isEmpty()) {
+            message.putAllData(data);
+        }
+
+        return message.build();
+    }
+
+    private void sendBatch(List<Message> batch) {
+        try {
+            firebaseMessaging.sendEach(batch);
+        } catch (FirebaseMessagingException e) {
+            log.error("FCM 푸시 발송 실패 (배치 {}건)", batch.size(), e);
+        }
+    }
+}

--- a/src/main/java/gravit/code/fcm/service/FcmService.java
+++ b/src/main/java/gravit/code/fcm/service/FcmService.java
@@ -1,5 +1,6 @@
 package gravit.code.fcm.service;
 
+import com.google.firebase.messaging.BatchResponse;
 import com.google.firebase.messaging.FirebaseMessaging;
 import com.google.firebase.messaging.FirebaseMessagingException;
 import com.google.firebase.messaging.Message;
@@ -66,7 +67,10 @@ public class FcmService {
 
     private void sendBatch(List<Message> batch) {
         try {
-            firebaseMessaging.sendEach(batch);
+            BatchResponse response = firebaseMessaging.sendEach(batch);
+            if (response.getFailureCount() > 0) {
+                log.warn("FCM 부분 실패 (성공 {}건 / 실패 {}건)", response.getSuccessCount(), response.getFailureCount());
+            }
         } catch (FirebaseMessagingException e) {
             log.error("FCM 푸시 발송 실패 (배치 {}건)", batch.size(), e);
         }

--- a/src/main/java/gravit/code/fcm/service/FcmService.java
+++ b/src/main/java/gravit/code/fcm/service/FcmService.java
@@ -44,9 +44,11 @@ public class FcmService {
             Map<String, String> data
     ) {
         Notification.Builder notification = Notification.builder();
+
         if (title != null && !title.isBlank()) {
             notification.setTitle(title);
         }
+
         if (body != null && !body.isBlank()) {
             notification.setBody(body);
         }
@@ -54,6 +56,7 @@ public class FcmService {
         Message.Builder message = Message.builder()
                 .setToken(token)
                 .setNotification(notification.build());
+
         if (data != null && !data.isEmpty()) {
             message.putAllData(data);
         }

--- a/src/main/java/gravit/code/fcm/service/FcmTokenQueryService.java
+++ b/src/main/java/gravit/code/fcm/service/FcmTokenQueryService.java
@@ -35,4 +35,10 @@ public class FcmTokenQueryService {
                         Collectors.mapping(FcmToken::getToken, Collectors.toList())
                 ));
     }
+
+    // 전체 유저 브로드캐스트용: 모든 디바이스 토큰
+    @Transactional(readOnly = true)
+    public List<String> getAllTokens() {
+        return fcmTokenRepository.findAllTokens();
+    }
 }

--- a/src/main/java/gravit/code/fcm/service/FcmTokenQueryService.java
+++ b/src/main/java/gravit/code/fcm/service/FcmTokenQueryService.java
@@ -1,10 +1,15 @@
 package gravit.code.fcm.service;
 
+import gravit.code.fcm.domain.FcmToken;
 import gravit.code.fcm.dto.response.FcmTokenExistsResponse;
 import gravit.code.fcm.repository.FcmTokenRepository;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
+
+import java.util.List;
+import java.util.Map;
+import java.util.stream.Collectors;
 
 @Service
 @RequiredArgsConstructor
@@ -20,5 +25,14 @@ public class FcmTokenQueryService {
         boolean registered = fcmTokenRepository.existsByUserIdAndDeviceId(userId, deviceId);
 
         return FcmTokenExistsResponse.create(registered);
+    }
+
+    @Transactional(readOnly = true)
+    public Map<Long, List<String>> getTokensByUserIds(List<Long> userIds) {
+        return fcmTokenRepository.findByUserIdIn(userIds).stream()
+                .collect(Collectors.groupingBy(
+                        FcmToken::getUserId,
+                        Collectors.mapping(FcmToken::getToken, Collectors.toList())
+                ));
     }
 }

--- a/src/main/java/gravit/code/fcm/service/FcmTokenQueryService.java
+++ b/src/main/java/gravit/code/fcm/service/FcmTokenQueryService.java
@@ -36,7 +36,6 @@ public class FcmTokenQueryService {
                 ));
     }
 
-    // 전체 유저 브로드캐스트용: 모든 디바이스 토큰
     @Transactional(readOnly = true)
     public List<String> getAllTokens() {
         return fcmTokenRepository.findAllTokens();

--- a/src/main/java/gravit/code/friend/dto/response/FollowCountsResponse.java
+++ b/src/main/java/gravit/code/friend/dto/response/FollowCountsResponse.java
@@ -6,6 +6,7 @@ public record FollowCountsResponse(
 
         @Schema(requiredMode = Schema.RequiredMode.REQUIRED)
         long followerCount,
+
         @Schema(requiredMode = Schema.RequiredMode.REQUIRED)
         long followingCount
 ) {

--- a/src/main/java/gravit/code/friend/dto/response/FollowerResponse.java
+++ b/src/main/java/gravit/code/friend/dto/response/FollowerResponse.java
@@ -2,16 +2,40 @@ package gravit.code.friend.dto.response;
 
 import com.fasterxml.jackson.annotation.JsonProperty;
 import io.swagger.v3.oas.annotations.media.Schema;
-import jakarta.validation.constraints.NotNull;
 
 public record FollowerResponse(
 
-        @Schema(example = "1", requiredMode = Schema.RequiredMode.REQUIRED) long id,
-        @NotNull @Schema(example = "김나영", requiredMode = Schema.RequiredMode.REQUIRED) String nickname,
-        @Schema(example = "2", requiredMode = Schema.RequiredMode.REQUIRED) int profileImgNumber,
-        @NotNull @Schema(example = "@1235cws", requiredMode = Schema.RequiredMode.REQUIRED) String handle,
+        @Schema(
+                example = "1",
+                requiredMode = Schema.RequiredMode.REQUIRED
+        )
+        long id,
+
+        @Schema(
+                example = "김나영",
+                requiredMode = Schema.RequiredMode.REQUIRED
+        )
+        String nickname,
+
+        @Schema(
+                example = "2",
+                requiredMode = Schema.RequiredMode.REQUIRED
+        )
+        int profileImgNumber,
+
+        @Schema(
+                example = "@1235cws",
+                requiredMode = Schema.RequiredMode.REQUIRED
+        )
+        String handle,
+
         @JsonProperty("isFollowing")
-        @Schema(name = "isFollowing", description = "내가 해당 팔로워를 팔로우 중인지 여부", example = "false", requiredMode = Schema.RequiredMode.REQUIRED)
+        @Schema(
+                name = "isFollowing",
+                description = "내가 해당 팔로워를 팔로우 중인지 여부",
+                example = "false",
+                requiredMode = Schema.RequiredMode.REQUIRED
+        )
         boolean isFollowing
 ) {
 }

--- a/src/main/java/gravit/code/friend/dto/response/FollowerSliceResponse.java
+++ b/src/main/java/gravit/code/friend/dto/response/FollowerSliceResponse.java
@@ -7,9 +7,16 @@ import java.util.List;
 @Schema(description = "팔로워 목록 슬라이스 응답")
 public class FollowerSliceResponse {
 
-    @Schema(description = "다음 페이지 존재 여부", example = "false", requiredMode = Schema.RequiredMode.REQUIRED)
+    @Schema(
+            description = "다음 페이지 존재 여부",
+            example = "false",
+            requiredMode = Schema.RequiredMode.REQUIRED
+    )
     public boolean hasNextPage;
 
-    @Schema(description = "팔로워 목록", requiredMode = Schema.RequiredMode.REQUIRED)
+    @Schema(
+            description = "팔로워 목록",
+            requiredMode = Schema.RequiredMode.REQUIRED
+    )
     public List<FollowerResponse> contents;
 }

--- a/src/main/java/gravit/code/friend/dto/response/FollowingResponse.java
+++ b/src/main/java/gravit/code/friend/dto/response/FollowingResponse.java
@@ -2,18 +2,18 @@ package gravit.code.friend.dto.response;
 
 
 import io.swagger.v3.oas.annotations.media.Schema;
-import jakarta.validation.constraints.NotNull;
 
 public record FollowingResponse(
 
         @Schema(requiredMode = Schema.RequiredMode.REQUIRED)
         long id,
-        @NotNull
+
         @Schema(requiredMode = Schema.RequiredMode.REQUIRED)
         String nickname,
+
         @Schema(requiredMode = Schema.RequiredMode.REQUIRED)
         int profileImgNumber,
-        @NotNull
+
         @Schema(requiredMode = Schema.RequiredMode.REQUIRED)
         String handle
 ){

--- a/src/main/java/gravit/code/friend/dto/response/FriendResponse.java
+++ b/src/main/java/gravit/code/friend/dto/response/FriendResponse.java
@@ -2,16 +2,14 @@ package gravit.code.friend.dto.response;
 
 import gravit.code.friend.domain.Friend;
 import io.swagger.v3.oas.annotations.media.Schema;
-import jakarta.validation.constraints.NotNull;
 import lombok.Builder;
 
 @Builder
 public record FriendResponse(
 
-        @NotNull
         @Schema(requiredMode = Schema.RequiredMode.REQUIRED)
         Long followeeId,
-        @NotNull
+
         @Schema(requiredMode = Schema.RequiredMode.REQUIRED)
         Long followerId
 ) {

--- a/src/main/java/gravit/code/friend/dto/response/SearchUserSliceResponse.java
+++ b/src/main/java/gravit/code/friend/dto/response/SearchUserSliceResponse.java
@@ -8,9 +8,16 @@ import java.util.List;
 @Schema(description = "사용자 검색 슬라이스 응답")
 public class SearchUserSliceResponse {
 
-    @Schema(description = "다음 페이지 존재 여부", example = "false", requiredMode = Schema.RequiredMode.REQUIRED)
+    @Schema(
+            description = "다음 페이지 존재 여부",
+            example = "false",
+            requiredMode = Schema.RequiredMode.REQUIRED
+    )
     public boolean hasNextPage;
 
-    @Schema(description = "검색 결과 목록", requiredMode = Schema.RequiredMode.REQUIRED)
+    @Schema(
+            description = "검색 결과 목록",
+            requiredMode = Schema.RequiredMode.REQUIRED
+    )
     public List<SearchUserDto> contents;
 }

--- a/src/main/java/gravit/code/global/config/WebMvcConfig.java
+++ b/src/main/java/gravit/code/global/config/WebMvcConfig.java
@@ -2,6 +2,7 @@ package gravit.code.global.config;
 
 import gravit.code.global.filter.HttpLoggingFilter;
 import gravit.code.global.interceptor.ApiPerformanceInterceptor;
+import gravit.code.global.interceptor.LastAccessInterceptor;
 import gravit.code.global.interceptor.RequestContextInterceptor;
 import lombok.RequiredArgsConstructor;
 import org.springframework.boot.web.servlet.FilterRegistrationBean;
@@ -17,6 +18,7 @@ public class WebMvcConfig implements WebMvcConfigurer {
 
     private final ApiPerformanceInterceptor apiPerformanceInterceptor;
     private final RequestContextInterceptor requestContextInterceptor;
+    private final LastAccessInterceptor lastAccessInterceptor;
     private final HttpLoggingFilter httpLoggingFilter;
 
     @Override
@@ -26,6 +28,10 @@ public class WebMvcConfig implements WebMvcConfigurer {
                 .excludePathPatterns("/actuator/**", "/swagger-ui/**", "/v3/api-docs/**");
 
         registry.addInterceptor(apiPerformanceInterceptor)
+                .addPathPatterns("/**")
+                .excludePathPatterns("/actuator/**", "/swagger-ui/**", "/v3/api-docs/**");
+
+        registry.addInterceptor(lastAccessInterceptor)
                 .addPathPatterns("/**")
                 .excludePathPatterns("/actuator/**", "/swagger-ui/**", "/v3/api-docs/**");
     }

--- a/src/main/java/gravit/code/global/dto/response/PageResponse.java
+++ b/src/main/java/gravit/code/global/dto/response/PageResponse.java
@@ -8,10 +8,13 @@ import java.util.List;
 public record PageResponse<T>(
         @Schema(requiredMode = Schema.RequiredMode.REQUIRED)
         int page,
+
         @Schema(requiredMode = Schema.RequiredMode.REQUIRED)
         int totalPages,
+
         @Schema(requiredMode = Schema.RequiredMode.REQUIRED)
         boolean hasNext,
+
         @Schema(requiredMode = Schema.RequiredMode.REQUIRED)
         List<T> contents
 ) {

--- a/src/main/java/gravit/code/global/dto/response/SliceResponse.java
+++ b/src/main/java/gravit/code/global/dto/response/SliceResponse.java
@@ -10,6 +10,7 @@ import java.util.List;
 public record SliceResponse<T>(
         @Schema(requiredMode = Schema.RequiredMode.REQUIRED)
         boolean hasNextPage,
+
         @Schema(requiredMode = Schema.RequiredMode.REQUIRED)
         List<T> contents
 ){

--- a/src/main/java/gravit/code/global/event/NoticeCreatedEvent.java
+++ b/src/main/java/gravit/code/global/event/NoticeCreatedEvent.java
@@ -1,0 +1,7 @@
+package gravit.code.global.event;
+
+public record NoticeCreatedEvent(
+        long noticeId,
+        String title
+) {
+}

--- a/src/main/java/gravit/code/global/interceptor/LastAccessInterceptor.java
+++ b/src/main/java/gravit/code/global/interceptor/LastAccessInterceptor.java
@@ -1,0 +1,38 @@
+package gravit.code.global.interceptor;
+
+import gravit.code.auth.domain.LoginUser;
+import gravit.code.user.service.UserAccessService;
+import jakarta.servlet.http.HttpServletRequest;
+import jakarta.servlet.http.HttpServletResponse;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.log4j.Log4j2;
+import org.springframework.security.core.Authentication;
+import org.springframework.security.core.context.SecurityContextHolder;
+import org.springframework.stereotype.Component;
+import org.springframework.web.servlet.HandlerInterceptor;
+
+@Log4j2
+@Component
+@RequiredArgsConstructor
+public class LastAccessInterceptor implements HandlerInterceptor {
+
+    private final UserAccessService userAccessService;
+
+    @Override
+    public boolean preHandle(
+            HttpServletRequest request,
+            HttpServletResponse response,
+            Object handler
+    ) {
+        Authentication authentication = SecurityContextHolder.getContext().getAuthentication();
+        if (authentication != null && authentication.getPrincipal() instanceof LoginUser loginUser) {
+            try {
+                userAccessService.updateLastAccessed(loginUser.getId());
+            } catch (Exception e) {
+                log.warn("lastAccessedAt 갱신 실패 - userId: {}", loginUser.getId(), e);
+            }
+        }
+
+        return true;
+    }
+}

--- a/src/main/java/gravit/code/league/dto/response/LeagueDetailResponse.java
+++ b/src/main/java/gravit/code/league/dto/response/LeagueDetailResponse.java
@@ -9,10 +9,13 @@ import static lombok.AccessLevel.PRIVATE;
 public record LeagueDetailResponse(
         @Schema(requiredMode = Schema.RequiredMode.REQUIRED)
         long leagueId,
+
         @Schema(requiredMode = Schema.RequiredMode.REQUIRED)
         String leagueName,
+
         @Schema(requiredMode = Schema.RequiredMode.REQUIRED)
         int currentLP,
+
         @Schema(requiredMode = Schema.RequiredMode.REQUIRED)
         int maxLP
 ) {

--- a/src/main/java/gravit/code/league/dto/response/LeagueHistoryResponse.java
+++ b/src/main/java/gravit/code/league/dto/response/LeagueHistoryResponse.java
@@ -11,22 +11,29 @@ import java.util.List;
 public record LeagueHistoryResponse(
         @Schema(requiredMode = Schema.RequiredMode.REQUIRED)
         int currentSeasonRank,
+
         @Schema(requiredMode = Schema.RequiredMode.REQUIRED)
         int totalSeasonCount,
+
         @Schema(requiredMode = Schema.RequiredMode.REQUIRED)
         int top3SeasonCount,
+
         @Schema(requiredMode = Schema.RequiredMode.REQUIRED)
         String bestLeagueName,
+
         @Schema(requiredMode = Schema.RequiredMode.REQUIRED)
         List<SeasonHistoryEntry> seasonHistory
 ) {
     public record SeasonHistoryEntry(
             @Schema(requiredMode = Schema.RequiredMode.REQUIRED)
             String seasonKey,
+
             @Schema(requiredMode = Schema.RequiredMode.REQUIRED)
             String leagueName,
+
             @Schema(requiredMode = Schema.RequiredMode.REQUIRED)
             int sortOrder,
+
             @Schema(requiredMode = Schema.RequiredMode.REQUIRED)
             @JsonProperty("isCurrent")
             boolean isCurrent

--- a/src/main/java/gravit/code/league/dto/response/LeagueHomeResponse.java
+++ b/src/main/java/gravit/code/league/dto/response/LeagueHomeResponse.java
@@ -3,15 +3,15 @@ package gravit.code.league.dto.response;
 import gravit.code.league.dto.internal.CurrentSeasonDto;
 import gravit.code.league.dto.internal.LastSeasonPopupDto;
 import io.swagger.v3.oas.annotations.media.Schema;
-import jakarta.validation.constraints.NotNull;
 
 public record LeagueHomeResponse(
 
         @Schema(requiredMode = Schema.RequiredMode.REQUIRED)
         boolean containsPopup,
+
         @Schema(requiredMode = Schema.RequiredMode.REQUIRED)
-        @NotNull
         CurrentSeasonDto currentSeason,
+
         LastSeasonPopupDto lastSeasonPopupDto
 ) {
     public static LeagueHomeResponse normal(

--- a/src/main/java/gravit/code/league/dto/response/LeagueResponse.java
+++ b/src/main/java/gravit/code/league/dto/response/LeagueResponse.java
@@ -2,7 +2,6 @@ package gravit.code.league.dto.response;
 
 import gravit.code.league.domain.League;
 import io.swagger.v3.oas.annotations.media.Schema;
-import jakarta.validation.constraints.NotNull;
 import lombok.Builder;
 
 @Builder
@@ -10,11 +9,13 @@ public record LeagueResponse(
 
         @Schema(requiredMode = Schema.RequiredMode.REQUIRED)
         long leagueId,
+
         @Schema(requiredMode = Schema.RequiredMode.REQUIRED)
-        @NotNull
         String name,
+
         @Schema(requiredMode = Schema.RequiredMode.REQUIRED)
         int minLp,
+
         @Schema(requiredMode = Schema.RequiredMode.REQUIRED)
         int maxLp
 ) {

--- a/src/main/java/gravit/code/learning/batch/LearningScheduler.java
+++ b/src/main/java/gravit/code/learning/batch/LearningScheduler.java
@@ -1,6 +1,6 @@
-package gravit.code.learning.scheduler;
+package gravit.code.learning.batch;
 
-import gravit.code.learning.service.LearningService;
+import gravit.code.learning.service.LearningCommandService;
 import lombok.RequiredArgsConstructor;
 import org.springframework.scheduling.annotation.Scheduled;
 import org.springframework.stereotype.Component;
@@ -9,10 +9,10 @@ import org.springframework.stereotype.Component;
 @RequiredArgsConstructor
 public class LearningScheduler {
 
-    private final LearningService learningService;
+    private final LearningCommandService learningCommandService;
 
     @Scheduled(cron = "0 1 0 * * *", zone = "Asia/Seoul")
     public void updateConsecutiveDays(){
-        learningService.updateConsecutiveDays();
+        learningCommandService.updateConsecutiveDays();
     }
 }

--- a/src/main/java/gravit/code/learning/dto/internal/ConsecutiveAtRiskUser.java
+++ b/src/main/java/gravit/code/learning/dto/internal/ConsecutiveAtRiskUser.java
@@ -1,0 +1,7 @@
+package gravit.code.learning.dto.internal;
+
+public record ConsecutiveAtRiskUser(
+        long userId,
+        int consecutiveSolvedDays
+) {
+}

--- a/src/main/java/gravit/code/learning/dto/response/LearningDetailResponse.java
+++ b/src/main/java/gravit/code/learning/dto/response/LearningDetailResponse.java
@@ -11,12 +11,16 @@ import java.util.List;
 public record LearningDetailResponse(
         @Schema(requiredMode = Schema.RequiredMode.REQUIRED)
         int consecutiveSolvedDays,
+
         @Schema(requiredMode = Schema.RequiredMode.REQUIRED)
         long recentSolvedChapterId,
+
         @Schema(requiredMode = Schema.RequiredMode.REQUIRED)
         String recentSolvedChapterTitle,
+
         @Schema(requiredMode = Schema.RequiredMode.REQUIRED)
         double recentSolvedChapterProgressRate,
+
         @Schema(requiredMode = Schema.RequiredMode.REQUIRED)
         List<UnitProgressSummaryResponse> units
 ) {

--- a/src/main/java/gravit/code/learning/dto/response/LearningHistoryResponse.java
+++ b/src/main/java/gravit/code/learning/dto/response/LearningHistoryResponse.java
@@ -11,6 +11,7 @@ import java.util.List;
 public record LearningHistoryResponse(
         @Schema(requiredMode = Schema.RequiredMode.REQUIRED)
         List<DailySolvedCountResponse> dailySolvedCounts,
+
         @Schema(requiredMode = Schema.RequiredMode.REQUIRED)
         int peakLearningHour
 ) {

--- a/src/main/java/gravit/code/learning/dto/response/LearningSummaryResponse.java
+++ b/src/main/java/gravit/code/learning/dto/response/LearningSummaryResponse.java
@@ -8,12 +8,16 @@ import lombok.Builder;
 public record LearningSummaryResponse(
         @Schema(requiredMode = Schema.RequiredMode.REQUIRED)
         int topPercent,
+
         @Schema(requiredMode = Schema.RequiredMode.REQUIRED)
         int completedLessonCount,
+
         @Schema(requiredMode = Schema.RequiredMode.REQUIRED)
         int totalLessonCount,
+
         @Schema(requiredMode = Schema.RequiredMode.REQUIRED)
         double totalLearningHours,
+
         @Schema(requiredMode = Schema.RequiredMode.REQUIRED)
         int averageAccuracy
 ) {

--- a/src/main/java/gravit/code/learning/dto/response/MyPageLearningResponse.java
+++ b/src/main/java/gravit/code/learning/dto/response/MyPageLearningResponse.java
@@ -12,8 +12,10 @@ import java.util.List;
 public record MyPageLearningResponse(
         @Schema(requiredMode = Schema.RequiredMode.REQUIRED)
         WeeklyLearningReportResponse weeklyReport,
+
         @Schema(requiredMode = Schema.RequiredMode.REQUIRED)
         List<TopChapterResponse> topChapters,
+
         @Schema(requiredMode = Schema.RequiredMode.REQUIRED)
         List<WeakConceptResponse> weakConcepts
 ) {

--- a/src/main/java/gravit/code/learning/dto/response/MyPageSummaryResponse.java
+++ b/src/main/java/gravit/code/learning/dto/response/MyPageSummaryResponse.java
@@ -11,8 +11,10 @@ import static lombok.AccessLevel.PRIVATE;
 public record MyPageSummaryResponse(
         @Schema(requiredMode = Schema.RequiredMode.REQUIRED)
         LearningSummaryResponse learningSummary,
+
         @Schema(requiredMode = Schema.RequiredMode.REQUIRED)
         LearningHistoryResponse learningHistory,
+
         @Schema(requiredMode = Schema.RequiredMode.REQUIRED)
         List<Integer> years
 ) {

--- a/src/main/java/gravit/code/learning/dto/response/WeakConceptResponse.java
+++ b/src/main/java/gravit/code/learning/dto/response/WeakConceptResponse.java
@@ -9,12 +9,16 @@ import lombok.Builder;
 public record WeakConceptResponse(
         @Schema(requiredMode = Schema.RequiredMode.REQUIRED)
         int rank,
+
         @Schema(requiredMode = Schema.RequiredMode.REQUIRED)
         String unitTitle,
+
         @Schema(requiredMode = Schema.RequiredMode.REQUIRED)
         String chapterTitle,
+
         @Schema(requiredMode = Schema.RequiredMode.REQUIRED)
         int wrongAnswerCount,
+
         @Schema(requiredMode = Schema.RequiredMode.REQUIRED)
         int wrongAnswerRate
 ) {

--- a/src/main/java/gravit/code/learning/listener/LearningEventListener.java
+++ b/src/main/java/gravit/code/learning/listener/LearningEventListener.java
@@ -1,7 +1,7 @@
 package gravit.code.learning.listener;
 
 import gravit.code.global.event.OnboardingCompletedEvent;
-import gravit.code.learning.service.LearningService;
+import gravit.code.learning.service.LearningCommandService;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.log4j.Log4j2;
 import org.springframework.stereotype.Component;
@@ -13,12 +13,12 @@ import org.springframework.transaction.event.TransactionalEventListener;
 @RequiredArgsConstructor
 public class LearningEventListener {
 
-    private final LearningService learningService;
+    private final LearningCommandService learningCommandService;
 
     @TransactionalEventListener(phase = TransactionPhase.BEFORE_COMMIT)
     public void createLearning(OnboardingCompletedEvent event){
         try{
-            learningService.createLearning(event.userId());
+            learningCommandService.createLearning(event.userId());
         }catch (Exception e){
             log.error("Exception occurred while creating Learning", e);
         }

--- a/src/main/java/gravit/code/learning/repository/LearningRepository.java
+++ b/src/main/java/gravit/code/learning/repository/LearningRepository.java
@@ -6,7 +6,9 @@ import jakarta.persistence.LockModeType;
 import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.data.jpa.repository.Lock;
 import org.springframework.data.jpa.repository.Query;
+import org.springframework.data.repository.query.Param;
 
+import java.time.LocalDateTime;
 import java.util.List;
 import java.util.Optional;
 
@@ -17,17 +19,21 @@ public interface LearningRepository extends JpaRepository<Learning,Long> {
     @Lock(LockModeType.OPTIMISTIC)
     List<Learning> findAll();
 
+    // 연속학습 위기 대상. 단, 미접속 14일 이상 유저는 장기 미접속 알림으로 대체되므로 제외(activeThreshold 이후 접속자만)
     @Query("""
             SELECT new gravit.code.learning.dto.internal.ConsecutiveAtRiskUser(l.userId, l.consecutiveSolvedDays)
             FROM Learning l
             WHERE l.consecutiveSolvedDays >= 1 AND l.todaySolved = false
+              AND EXISTS (SELECT 1 FROM User u WHERE u.id = l.userId AND u.lastAccessedAt >= :activeThreshold)
     """)
-    List<ConsecutiveAtRiskUser> findConsecutiveAtRiskUsers();
+    List<ConsecutiveAtRiskUser> findConsecutiveAtRiskUsers(@Param("activeThreshold") LocalDateTime activeThreshold);
 
+    // 오늘 미완료 대상. 위와 동일하게 미접속 14일 이상 유저는 제외
     @Query("""
             SELECT l.userId
             FROM Learning l
             WHERE l.consecutiveSolvedDays = 0 AND l.todaySolved = false
+              AND EXISTS (SELECT 1 FROM User u WHERE u.id = l.userId AND u.lastAccessedAt >= :activeThreshold)
     """)
-    List<Long> findDailyIncompleteUserIds();
+    List<Long> findDailyIncompleteUserIds(@Param("activeThreshold") LocalDateTime activeThreshold);
 }

--- a/src/main/java/gravit/code/learning/repository/LearningRepository.java
+++ b/src/main/java/gravit/code/learning/repository/LearningRepository.java
@@ -1,9 +1,11 @@
 package gravit.code.learning.repository;
 
 import gravit.code.learning.domain.Learning;
+import gravit.code.learning.dto.internal.ConsecutiveAtRiskUser;
 import jakarta.persistence.LockModeType;
 import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.data.jpa.repository.Lock;
+import org.springframework.data.jpa.repository.Query;
 
 import java.util.List;
 import java.util.Optional;
@@ -14,4 +16,18 @@ public interface LearningRepository extends JpaRepository<Learning,Long> {
 
     @Lock(LockModeType.OPTIMISTIC)
     List<Learning> findAll();
+
+    @Query("""
+            SELECT new gravit.code.learning.dto.internal.ConsecutiveAtRiskUser(l.userId, l.consecutiveSolvedDays)
+            FROM Learning l
+            WHERE l.consecutiveSolvedDays >= 1 AND l.todaySolved = false
+    """)
+    List<ConsecutiveAtRiskUser> findConsecutiveAtRiskUsers();
+
+    @Query("""
+            SELECT l.userId
+            FROM Learning l
+            WHERE l.consecutiveSolvedDays = 0 AND l.todaySolved = false
+    """)
+    List<Long> findDailyIncompleteUserIds();
 }

--- a/src/main/java/gravit/code/learning/service/LearningCommandService.java
+++ b/src/main/java/gravit/code/learning/service/LearningCommandService.java
@@ -13,7 +13,7 @@ import java.util.List;
 
 @Service
 @RequiredArgsConstructor
-public class LearningService {
+public class LearningCommandService {
 
     private final LearningRepository learningRepository;
     private final LearningProgressRateService learningProgressRateService;
@@ -27,6 +27,12 @@ public class LearningService {
         }
 
         learningRepository.saveAll(learnings);
+    }
+
+    @Transactional
+    public void createLearning(long userId){
+        Learning learning = Learning.create(userId);
+        learningRepository.save(learning);
     }
 
     @Transactional
@@ -44,17 +50,5 @@ public class LearningService {
         learningRepository.save(learning);
 
         return consecutiveSolvedDto;
-    }
-
-    @Transactional
-    public void createLearning(long userId){
-        Learning learning = Learning.create(userId);
-        learningRepository.save(learning);
-    }
-
-    @Transactional(readOnly = true)
-    public Learning getLearning(long userId) {
-        return learningRepository.findByUserId(userId)
-                .orElseThrow(() -> new RestApiException(CustomErrorCode.LEARNING_NOT_FOUND));
     }
 }

--- a/src/main/java/gravit/code/learning/service/LearningQueryService.java
+++ b/src/main/java/gravit/code/learning/service/LearningQueryService.java
@@ -1,0 +1,35 @@
+package gravit.code.learning.service;
+
+import gravit.code.global.exception.domain.CustomErrorCode;
+import gravit.code.global.exception.domain.RestApiException;
+import gravit.code.learning.domain.Learning;
+import gravit.code.learning.dto.internal.ConsecutiveAtRiskUser;
+import gravit.code.learning.repository.LearningRepository;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+import java.util.List;
+
+@Service
+@RequiredArgsConstructor
+public class LearningQueryService {
+
+    private final LearningRepository learningRepository;
+
+    @Transactional(readOnly = true)
+    public Learning getLearning(long userId) {
+        return learningRepository.findByUserId(userId)
+                .orElseThrow(() -> new RestApiException(CustomErrorCode.LEARNING_NOT_FOUND));
+    }
+
+    @Transactional(readOnly = true)
+    public List<ConsecutiveAtRiskUser> getConsecutiveAtRiskUsers() {
+        return learningRepository.findConsecutiveAtRiskUsers();
+    }
+
+    @Transactional(readOnly = true)
+    public List<Long> getDailyIncompleteUserIds() {
+        return learningRepository.findDailyIncompleteUserIds();
+    }
+}

--- a/src/main/java/gravit/code/learning/service/LearningQueryService.java
+++ b/src/main/java/gravit/code/learning/service/LearningQueryService.java
@@ -9,13 +9,20 @@ import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
+import java.time.Clock;
+import java.time.LocalDate;
+import java.time.LocalDateTime;
 import java.util.List;
 
 @Service
 @RequiredArgsConstructor
 public class LearningQueryService {
 
+    // 미접속 7일 미만(=6일 이내 접속)만 일일 알림 대상. 7일 이상은 장기 미접속 알림으로 대체
+    private static final int ACTIVE_THRESHOLD_DAYS = 6;
+
     private final LearningRepository learningRepository;
+    private final Clock clock;
 
     @Transactional(readOnly = true)
     public Learning getLearning(long userId) {
@@ -25,11 +32,15 @@ public class LearningQueryService {
 
     @Transactional(readOnly = true)
     public List<ConsecutiveAtRiskUser> getConsecutiveAtRiskUsers() {
-        return learningRepository.findConsecutiveAtRiskUsers();
+        return learningRepository.findConsecutiveAtRiskUsers(activeThreshold());
     }
 
     @Transactional(readOnly = true)
     public List<Long> getDailyIncompleteUserIds() {
-        return learningRepository.findDailyIncompleteUserIds();
+        return learningRepository.findDailyIncompleteUserIds(activeThreshold());
+    }
+
+    private LocalDateTime activeThreshold() {
+        return LocalDate.now(clock).minusDays(ACTIVE_THRESHOLD_DAYS).atStartOfDay();
     }
 }

--- a/src/main/java/gravit/code/lesson/dto/response/LessonDetailResponse.java
+++ b/src/main/java/gravit/code/lesson/dto/response/LessonDetailResponse.java
@@ -2,7 +2,6 @@ package gravit.code.lesson.dto.response;
 
 import gravit.code.unit.dto.response.UnitSummaryResponse;
 import io.swagger.v3.oas.annotations.media.Schema;
-import jakarta.validation.constraints.NotNull;
 import lombok.AccessLevel;
 import lombok.Builder;
 
@@ -16,7 +15,6 @@ public record LessonDetailResponse(
                 description = "유닛 요약 정보",
                 requiredMode = Schema.RequiredMode.REQUIRED
         )
-        @NotNull
         UnitSummaryResponse unitSummaryResponse,
 
         @Schema(
@@ -24,7 +22,6 @@ public record LessonDetailResponse(
                 example = "true",
                 requiredMode = Schema.RequiredMode.REQUIRED
         )
-        @NotNull
         boolean bookmarkAccessible,
 
         @Schema(
@@ -32,7 +29,6 @@ public record LessonDetailResponse(
                 example = "true",
                 requiredMode = Schema.RequiredMode.REQUIRED
         )
-        @NotNull
         boolean wrongAnsweredNoteAccessible,
 
         @Schema(
@@ -46,7 +42,6 @@ public record LessonDetailResponse(
                 description = "레슨 요약 정보 목록",
                 requiredMode = Schema.RequiredMode.REQUIRED
         )
-        @NotNull
         List<LessonSummaryResponse> lessonSummaries
 ) {
     public static LessonDetailResponse create(

--- a/src/main/java/gravit/code/lesson/dto/response/LessonProgressSummaryResponse.java
+++ b/src/main/java/gravit/code/lesson/dto/response/LessonProgressSummaryResponse.java
@@ -2,7 +2,6 @@ package gravit.code.lesson.dto.response;
 
 import com.fasterxml.jackson.annotation.JsonProperty;
 import io.swagger.v3.oas.annotations.media.Schema;
-import jakarta.validation.constraints.NotNull;
 import lombok.AccessLevel;
 import lombok.Builder;
 
@@ -22,7 +21,6 @@ public record LessonProgressSummaryResponse(
                 example = "스택 1/3",
                 requiredMode = Schema.RequiredMode.REQUIRED
         )
-        @NotNull
         String name,
 
         @Schema(

--- a/src/main/java/gravit/code/lesson/dto/response/LessonResponse.java
+++ b/src/main/java/gravit/code/lesson/dto/response/LessonResponse.java
@@ -3,7 +3,6 @@ package gravit.code.lesson.dto.response;
 import gravit.code.problem.dto.response.ProblemResponse;
 import gravit.code.unit.dto.response.UnitSummaryResponse;
 import io.swagger.v3.oas.annotations.media.Schema;
-import jakarta.validation.constraints.NotNull;
 import lombok.AccessLevel;
 import lombok.Builder;
 
@@ -17,14 +16,12 @@ public record LessonResponse(
                 description = "유닛 요약 정보",
                 requiredMode = Schema.RequiredMode.REQUIRED
         )
-        @NotNull
         UnitSummaryResponse unitSummaryResponse,
 
         @Schema(
                 description = "문제 목록",
                 requiredMode = Schema.RequiredMode.REQUIRED
         )
-        @NotNull
         List<ProblemResponse> problems,
 
         @Schema(

--- a/src/main/java/gravit/code/lesson/dto/response/LessonSubmissionSaveResponse.java
+++ b/src/main/java/gravit/code/lesson/dto/response/LessonSubmissionSaveResponse.java
@@ -3,7 +3,6 @@ package gravit.code.lesson.dto.response;
 import gravit.code.unit.dto.response.UnitSummaryResponse;
 import gravit.code.user.dto.response.UserLevelResponse;
 import io.swagger.v3.oas.annotations.media.Schema;
-import jakarta.validation.constraints.NotNull;
 import lombok.AccessLevel;
 import lombok.Builder;
 
@@ -16,21 +15,18 @@ public record LessonSubmissionSaveResponse(
                 example = "브론즈",
                 requiredMode = Schema.RequiredMode.REQUIRED
         )
-        @NotNull
         String leagueName,
 
         @Schema(
                 description = "유저 레벨 정보",
                 requiredMode = Schema.RequiredMode.REQUIRED
         )
-        @NotNull
         UserLevelResponse userLevelResponse,
 
         @Schema(
                 description = "유닛 요약 정보",
                 requiredMode = Schema.RequiredMode.REQUIRED
         )
-        @NotNull
         UnitSummaryResponse unitSummaryResponse
 ) {
     public static LessonSubmissionSaveResponse create(

--- a/src/main/java/gravit/code/lesson/dto/response/LessonSummaryResponse.java
+++ b/src/main/java/gravit/code/lesson/dto/response/LessonSummaryResponse.java
@@ -2,7 +2,6 @@ package gravit.code.lesson.dto.response;
 
 import com.fasterxml.jackson.annotation.JsonProperty;
 import io.swagger.v3.oas.annotations.media.Schema;
-import jakarta.validation.constraints.NotNull;
 
 @Schema(description = "레슨 요약 정보")
 public record LessonSummaryResponse(
@@ -18,7 +17,6 @@ public record LessonSummaryResponse(
                 example = "스택 1/3",
                 requiredMode = Schema.RequiredMode.REQUIRED
         )
-        @NotNull
         String title,
 
         @Schema(

--- a/src/main/java/gravit/code/lesson/facade/LessonFacade.java
+++ b/src/main/java/gravit/code/lesson/facade/LessonFacade.java
@@ -6,7 +6,7 @@ import gravit.code.global.event.LessonCompletedEvent;
 import gravit.code.learning.dto.internal.ConsecutiveSolvedDto;
 import gravit.code.learning.dto.internal.LearningIdsDto;
 import gravit.code.learning.dto.request.LearningSubmissionSaveRequest;
-import gravit.code.learning.service.LearningService;
+import gravit.code.learning.service.LearningCommandService;
 import gravit.code.lesson.dto.response.LessonDetailResponse;
 import gravit.code.lesson.dto.response.LessonSubmissionSaveResponse;
 import gravit.code.lesson.dto.response.LessonSummaryResponse;
@@ -41,7 +41,7 @@ public class LessonFacade {
     private final WrongAnsweredNoteService wrongAnsweredNoteService;
     private final BookmarkService bookmarkService;
 
-    private final LearningService learningService;
+    private final LearningCommandService learningCommandService;
 
     private final UserService userService;
     private final UserLeagueService userLeagueService;
@@ -89,7 +89,7 @@ public class LessonFacade {
 
         LearningIdsDto learningIdsDto = lessonQueryService.getLearningIdsByLessonId(request.lessonSubmissionSaveRequest().lessonId());
 
-        ConsecutiveSolvedDto consecutiveSolvedDto = learningService.updateLearningStatus(userId, learningIdsDto.chapterId());
+        ConsecutiveSolvedDto consecutiveSolvedDto = learningCommandService.updateLearningStatus(userId, learningIdsDto.chapterId());
         if(isFirstTry){
             publisher.publishEvent(new LessonCompletedEvent(
                     userId,

--- a/src/main/java/gravit/code/mission/dto/response/MissionDetailResponse.java
+++ b/src/main/java/gravit/code/mission/dto/response/MissionDetailResponse.java
@@ -10,12 +10,16 @@ import lombok.Builder;
 public record MissionDetailResponse(
         @Schema(requiredMode = Schema.RequiredMode.REQUIRED)
         String missionType,
+
         @Schema(requiredMode = Schema.RequiredMode.REQUIRED)
         String missionDescription,
+
         @Schema(requiredMode = Schema.RequiredMode.REQUIRED)
         int awardXp,
+
         @Schema(requiredMode = Schema.RequiredMode.REQUIRED)
         double progressRate,
+
         @Schema(requiredMode = Schema.RequiredMode.REQUIRED)
         @JsonProperty("isCompleted")
         boolean isCompleted

--- a/src/main/java/gravit/code/mission/dto/response/MissionSummaryResponse.java
+++ b/src/main/java/gravit/code/mission/dto/response/MissionSummaryResponse.java
@@ -3,13 +3,12 @@ package gravit.code.mission.dto.response;
 import com.fasterxml.jackson.annotation.JsonProperty;
 import gravit.code.mission.domain.MissionType;
 import io.swagger.v3.oas.annotations.media.Schema;
-import jakarta.validation.constraints.NotNull;
 
 public record MissionSummaryResponse(
 
         @Schema(requiredMode = Schema.RequiredMode.REQUIRED)
-        @NotNull
         MissionType missionType,
+
         @Schema(requiredMode = Schema.RequiredMode.REQUIRED)
         @JsonProperty("isCompleted")
         boolean isCompleted

--- a/src/main/java/gravit/code/notice/dto/response/NoticeDetailResponse.java
+++ b/src/main/java/gravit/code/notice/dto/response/NoticeDetailResponse.java
@@ -2,7 +2,6 @@ package gravit.code.notice.dto.response;
 
 import gravit.code.notice.domain.Notice;
 import io.swagger.v3.oas.annotations.media.Schema;
-import jakarta.validation.constraints.NotNull;
 import lombok.Builder;
 
 import java.time.LocalDateTime;
@@ -12,27 +11,28 @@ public record NoticeDetailResponse(
 
         @Schema(requiredMode = Schema.RequiredMode.REQUIRED)
         long id,
-        @NotNull
+
         @Schema(requiredMode = Schema.RequiredMode.REQUIRED)
         String title,
-        @NotNull
+
         @Schema(requiredMode = Schema.RequiredMode.REQUIRED)
         String content,
-        @NotNull
+
         @Schema(requiredMode = Schema.RequiredMode.REQUIRED)
         String authorName,
-        @NotNull
+
         @Schema(requiredMode = Schema.RequiredMode.REQUIRED)
         LocalDateTime createdAt,
-        @NotNull
+
         @Schema(requiredMode = Schema.RequiredMode.REQUIRED)
         LocalDateTime updatedAt,
-        @NotNull
+
         @Schema(requiredMode = Schema.RequiredMode.REQUIRED)
         String status,
+
         @Schema(requiredMode = Schema.RequiredMode.REQUIRED)
         boolean pinned,
-        @NotNull
+
         @Schema(requiredMode = Schema.RequiredMode.REQUIRED)
         LocalDateTime publishedAt
 ) {

--- a/src/main/java/gravit/code/notice/dto/response/NoticeSummaryPageResponse.java
+++ b/src/main/java/gravit/code/notice/dto/response/NoticeSummaryPageResponse.java
@@ -7,15 +7,30 @@ import java.util.List;
 @Schema(description = "공지 요약 페이지 응답")
 public class NoticeSummaryPageResponse {
 
-    @Schema(description = "현재 페이지 번호", example = "1", requiredMode = Schema.RequiredMode.REQUIRED)
+    @Schema(
+            description = "현재 페이지 번호",
+            example = "1",
+            requiredMode = Schema.RequiredMode.REQUIRED
+    )
     public int page;
 
-    @Schema(description = "전체 페이지 수", example = "5", requiredMode = Schema.RequiredMode.REQUIRED)
+    @Schema(
+            description = "전체 페이지 수",
+            example = "5",
+            requiredMode = Schema.RequiredMode.REQUIRED
+    )
     public int totalPages;
 
-    @Schema(description = "다음 페이지 존재 여부", example = "true", requiredMode = Schema.RequiredMode.REQUIRED)
+    @Schema(
+            description = "다음 페이지 존재 여부",
+            example = "true",
+            requiredMode = Schema.RequiredMode.REQUIRED
+    )
     public boolean hasNext;
 
-    @Schema(description = "공지 요약 목록", requiredMode = Schema.RequiredMode.REQUIRED)
+    @Schema(
+            description = "공지 요약 목록",
+            requiredMode = Schema.RequiredMode.REQUIRED
+    )
     public List<NoticeSummaryResponse> contents;
 }

--- a/src/main/java/gravit/code/notice/dto/response/NoticeSummaryResponse.java
+++ b/src/main/java/gravit/code/notice/dto/response/NoticeSummaryResponse.java
@@ -1,7 +1,6 @@
 package gravit.code.notice.dto.response;
 
 import io.swagger.v3.oas.annotations.media.Schema;
-import jakarta.validation.constraints.NotNull;
 
 import java.time.LocalDateTime;
 
@@ -9,15 +8,16 @@ public record NoticeSummaryResponse(
 
         @Schema(requiredMode = Schema.RequiredMode.REQUIRED)
         long id,
-        @NotNull
+
         @Schema(requiredMode = Schema.RequiredMode.REQUIRED)
         String title,
-        @NotNull
+
         @Schema(requiredMode = Schema.RequiredMode.REQUIRED)
         String summary,
+
         @Schema(requiredMode = Schema.RequiredMode.REQUIRED)
         boolean pinned,
-        @NotNull
+
         @Schema(requiredMode = Schema.RequiredMode.REQUIRED)
         LocalDateTime publishedAt
 ) {

--- a/src/main/java/gravit/code/notification/batch/NotificationScheduler.java
+++ b/src/main/java/gravit/code/notification/batch/NotificationScheduler.java
@@ -20,4 +20,9 @@ public class NotificationScheduler {
     public void sendDailyIncompleteReminders(){
         notificationFacade.sendDailyIncompleteReminders();
     }
+
+    @Scheduled(cron = "0 0 21 * * *", zone = "Asia/Seoul")
+    public void sendInactivityReminders(){
+        notificationFacade.sendInactivityReminders();
+    }
 }

--- a/src/main/java/gravit/code/notification/batch/NotificationScheduler.java
+++ b/src/main/java/gravit/code/notification/batch/NotificationScheduler.java
@@ -1,0 +1,23 @@
+package gravit.code.notification.batch;
+
+import gravit.code.notification.facade.NotificationFacade;
+import lombok.RequiredArgsConstructor;
+import org.springframework.scheduling.annotation.Scheduled;
+import org.springframework.stereotype.Component;
+
+@Component
+@RequiredArgsConstructor
+public class NotificationScheduler {
+
+    private final NotificationFacade notificationFacade;
+
+    @Scheduled(cron = "0 0 21 * * *", zone = "Asia/Seoul")
+    public void sendConsecutiveLearningWarnings(){
+        notificationFacade.sendConsecutiveLearningWarnings();
+    }
+
+    @Scheduled(cron = "0 0 21 * * *", zone = "Asia/Seoul")
+    public void sendDailyIncompleteReminders(){
+        notificationFacade.sendDailyIncompleteReminders();
+    }
+}

--- a/src/main/java/gravit/code/notification/domain/NotificationType.java
+++ b/src/main/java/gravit/code/notification/domain/NotificationType.java
@@ -15,7 +15,7 @@ import static gravit.code.notification.domain.NotificationActionType.NONE;
 @RequiredArgsConstructor
 public enum NotificationType {
 
-    STREAK_WARNING(GO_TO_LEARNING),    // 3.1  연속학습 끊길 위기
+    CONSECUTIVE_LEARNING_WARNING(GO_TO_LEARNING),  // 3.1  연속학습 끊길 위기
     DAILY_INCOMPLETE(GO_TO_LEARNING),  // 3.2  오늘 학습 미완료
     INACTIVITY(GO_TO_LEARNING),        // 3.3  장기 미접속
     SEASON_ENDING(GO_TO_LEARNING),     // 3.7  시즌 종료 임박
@@ -34,6 +34,18 @@ public enum NotificationType {
         return Map.of(
                 "type", name(),
                 "actionType", actionType.name()
+        );
+    }
+
+    // 액션 대상이 있는 경우(targetId) deeplink용으로 함께 실어 보낸다
+    public Map<String, String> toPushData(Long targetId) {
+        if (targetId == null) {
+            return toPushData();
+        }
+        return Map.of(
+                "type", name(),
+                "actionType", actionType.name(),
+                "targetId", String.valueOf(targetId)
         );
     }
 }

--- a/src/main/java/gravit/code/notification/domain/NotificationType.java
+++ b/src/main/java/gravit/code/notification/domain/NotificationType.java
@@ -3,6 +3,8 @@ package gravit.code.notification.domain;
 import lombok.Getter;
 import lombok.RequiredArgsConstructor;
 
+import java.util.Map;
+
 import static gravit.code.notification.domain.NotificationActionType.CONGRATULATE;
 import static gravit.code.notification.domain.NotificationActionType.FOLLOW_BACK;
 import static gravit.code.notification.domain.NotificationActionType.GO_TO_LEARNING;
@@ -26,4 +28,12 @@ public enum NotificationType {
     NEW_CONTENT(GO_TO_LEARNING);       // 3.14 새 콘텐츠 업데이트
 
     private final NotificationActionType actionType;
+
+    // 클라이언트 액션 라우팅용 FCM data payload. 키 계약은 프론트와 동일하게 맞춘다
+    public Map<String, String> toPushData() {
+        return Map.of(
+                "type", name(),
+                "actionType", actionType.name()
+        );
+    }
 }

--- a/src/main/java/gravit/code/notification/dto/internal/InactivityMilestone.java
+++ b/src/main/java/gravit/code/notification/dto/internal/InactivityMilestone.java
@@ -1,0 +1,7 @@
+package gravit.code.notification.dto.internal;
+
+public record InactivityMilestone(
+        int days,
+        String message
+) {
+}

--- a/src/main/java/gravit/code/notification/facade/NotificationFacade.java
+++ b/src/main/java/gravit/code/notification/facade/NotificationFacade.java
@@ -1,0 +1,97 @@
+package gravit.code.notification.facade;
+
+import gravit.code.fcm.dto.internal.PushMessage;
+import gravit.code.fcm.service.FcmService;
+import gravit.code.fcm.service.FcmTokenQueryService;
+import gravit.code.global.annotation.Facade;
+import gravit.code.learning.dto.internal.ConsecutiveAtRiskUser;
+import gravit.code.learning.service.LearningQueryService;
+import gravit.code.notification.domain.NotificationType;
+import lombok.RequiredArgsConstructor;
+
+import java.util.List;
+import java.util.Map;
+import java.util.concurrent.ThreadLocalRandom;
+
+@Facade
+@RequiredArgsConstructor
+public class NotificationFacade {
+
+    private static final String CONSECUTIVE_WARNING_MESSAGE = "오늘 학습을 하지 않으면 %d일 연속학습이 끊겨요!";
+
+    private static final List<String> DAILY_INCOMPLETE_MESSAGES = List.of(
+            "오늘 아직 학습을 안 했어요! 10분만 투자해보세요 📚",
+            "오늘 학습을 시작해보세요! 작은 습관이 큰 변화를 만들어요 🌱",
+            "지금 이 시간에도 누군가는 CS를 공부하고 있어요 👀"
+    );
+
+    private final LearningQueryService learningQueryService;
+    private final FcmTokenQueryService fcmTokenQueryService;
+    private final FcmService fcmService;
+
+    public void sendConsecutiveLearningWarnings() {
+
+        List<ConsecutiveAtRiskUser> targets = learningQueryService.getConsecutiveAtRiskUsers();
+
+        if (targets.isEmpty()) {
+            return;
+        }
+
+        List<Long> targetUserIds = targets.stream()
+                .map(ConsecutiveAtRiskUser::userId)
+                .toList();
+
+        Map<Long, List<String>> tokensByUserId = fcmTokenQueryService.getTokensByUserIds(targetUserIds);
+
+        Map<String, String> data = buildActionData(NotificationType.STREAK_WARNING);
+
+        List<PushMessage> messages = targets.stream()
+                .filter(target -> tokensByUserId.containsKey(target.userId()))
+                .map(target -> PushMessage.of(
+                        tokensByUserId.get(target.userId()),
+                        CONSECUTIVE_WARNING_MESSAGE.formatted(target.consecutiveSolvedDays()),
+                        null,
+                        data
+                ))
+                .toList();
+
+        fcmService.sendNotifications(messages);
+    }
+
+    public void sendDailyIncompleteReminders() {
+
+        List<Long> targetUserIds = learningQueryService.getDailyIncompleteUserIds();
+
+        if (targetUserIds.isEmpty()) {
+            return;
+        }
+
+        Map<Long, List<String>> tokensByUserId = fcmTokenQueryService.getTokensByUserIds(targetUserIds);
+
+        Map<String, String> data = buildActionData(NotificationType.DAILY_INCOMPLETE);
+
+        List<PushMessage> messages = targetUserIds.stream()
+                .filter(tokensByUserId::containsKey)
+                .map(userId -> PushMessage.of(
+                        tokensByUserId.get(userId),
+                        randomDailyIncompleteMessage(),
+                        null,
+                        data
+                ))
+                .toList();
+
+        fcmService.sendNotifications(messages);
+    }
+
+    private String randomDailyIncompleteMessage() {
+        int index = ThreadLocalRandom.current().nextInt(DAILY_INCOMPLETE_MESSAGES.size());
+        return DAILY_INCOMPLETE_MESSAGES.get(index);
+    }
+
+    private Map<String, String> buildActionData(NotificationType type) {
+        return Map.of(
+                "type", type.name(),
+                "actionType", type.getActionType().name()
+        );
+    }
+}

--- a/src/main/java/gravit/code/notification/facade/NotificationFacade.java
+++ b/src/main/java/gravit/code/notification/facade/NotificationFacade.java
@@ -7,27 +7,24 @@ import gravit.code.global.annotation.Facade;
 import gravit.code.learning.dto.internal.ConsecutiveAtRiskUser;
 import gravit.code.learning.service.LearningQueryService;
 import gravit.code.notification.domain.NotificationType;
+import gravit.code.notification.dto.internal.InactivityMilestone;
+import gravit.code.notification.support.NotificationMessageProvider;
+import gravit.code.user.service.UserAccessService;
 import lombok.RequiredArgsConstructor;
 
 import java.util.List;
 import java.util.Map;
-import java.util.concurrent.ThreadLocalRandom;
+import java.util.function.Supplier;
 
 @Facade
 @RequiredArgsConstructor
 public class NotificationFacade {
 
-    private static final String CONSECUTIVE_WARNING_MESSAGE = "오늘 학습을 하지 않으면 %d일 연속학습이 끊겨요!";
-
-    private static final List<String> DAILY_INCOMPLETE_MESSAGES = List.of(
-            "오늘 아직 학습을 안 했어요! 10분만 투자해보세요 📚",
-            "오늘 학습을 시작해보세요! 작은 습관이 큰 변화를 만들어요 🌱",
-            "지금 이 시간에도 누군가는 CS를 공부하고 있어요 👀"
-    );
-
     private final LearningQueryService learningQueryService;
+    private final UserAccessService userAccessService;
     private final FcmTokenQueryService fcmTokenQueryService;
     private final FcmService fcmService;
+    private final NotificationMessageProvider messageProvider;
 
     public void sendConsecutiveLearningWarnings() {
 
@@ -43,13 +40,13 @@ public class NotificationFacade {
 
         Map<Long, List<String>> tokensByUserId = fcmTokenQueryService.getTokensByUserIds(targetUserIds);
 
-        Map<String, String> data = buildActionData(NotificationType.STREAK_WARNING);
+        Map<String, String> data = NotificationType.STREAK_WARNING.toPushData();
 
         List<PushMessage> messages = targets.stream()
                 .filter(target -> tokensByUserId.containsKey(target.userId()))
                 .map(target -> PushMessage.of(
                         tokensByUserId.get(target.userId()),
-                        CONSECUTIVE_WARNING_MESSAGE.formatted(target.consecutiveSolvedDays()),
+                        messageProvider.consecutiveWarning(target.consecutiveSolvedDays()),
                         null,
                         data
                 ))
@@ -66,32 +63,41 @@ public class NotificationFacade {
             return;
         }
 
-        Map<Long, List<String>> tokensByUserId = fcmTokenQueryService.getTokensByUserIds(targetUserIds);
+        pushToUsers(targetUserIds, NotificationType.DAILY_INCOMPLETE.toPushData(), messageProvider::randomDailyIncomplete);
+    }
 
-        Map<String, String> data = buildActionData(NotificationType.DAILY_INCOMPLETE);
+    public void sendInactivityReminders() {
 
-        List<PushMessage> messages = targetUserIds.stream()
+        Map<String, String> data = NotificationType.INACTIVITY.toPushData();
+
+        for (InactivityMilestone milestone : messageProvider.inactivityMilestones()) {
+            List<Long> targetUserIds = userAccessService.getUserIdsInactiveForExactly(milestone.days());
+
+            if (targetUserIds.isEmpty()) {
+                continue;
+            }
+
+            pushToUsers(targetUserIds, data, milestone::message);
+        }
+    }
+
+    private void pushToUsers(
+            List<Long> userIds,
+            Map<String, String> data,
+            Supplier<String> messageSupplier
+    ) {
+        Map<Long, List<String>> tokensByUserId = fcmTokenQueryService.getTokensByUserIds(userIds);
+
+        List<PushMessage> messages = userIds.stream()
                 .filter(tokensByUserId::containsKey)
                 .map(userId -> PushMessage.of(
                         tokensByUserId.get(userId),
-                        randomDailyIncompleteMessage(),
+                        messageSupplier.get(),
                         null,
                         data
                 ))
                 .toList();
 
         fcmService.sendNotifications(messages);
-    }
-
-    private String randomDailyIncompleteMessage() {
-        int index = ThreadLocalRandom.current().nextInt(DAILY_INCOMPLETE_MESSAGES.size());
-        return DAILY_INCOMPLETE_MESSAGES.get(index);
-    }
-
-    private Map<String, String> buildActionData(NotificationType type) {
-        return Map.of(
-                "type", type.name(),
-                "actionType", type.getActionType().name()
-        );
     }
 }

--- a/src/main/java/gravit/code/notification/facade/NotificationFacade.java
+++ b/src/main/java/gravit/code/notification/facade/NotificationFacade.java
@@ -40,7 +40,7 @@ public class NotificationFacade {
 
         Map<Long, List<String>> tokensByUserId = fcmTokenQueryService.getTokensByUserIds(targetUserIds);
 
-        Map<String, String> data = NotificationType.STREAK_WARNING.toPushData();
+        Map<String, String> data = NotificationType.CONSECUTIVE_LEARNING_WARNING.toPushData();
 
         List<PushMessage> messages = targets.stream()
                 .filter(target -> tokensByUserId.containsKey(target.userId()))
@@ -79,6 +79,24 @@ public class NotificationFacade {
 
             pushToUsers(targetUserIds, data, milestone::message);
         }
+    }
+
+    public void sendNewContentAlerts(long unitId) {
+
+        List<String> tokens = fcmTokenQueryService.getAllTokens();
+
+        if (tokens.isEmpty()) {
+            return;
+        }
+
+        PushMessage message = PushMessage.of(
+                tokens,
+                messageProvider.newContent(),
+                null,
+                NotificationType.NEW_CONTENT.toPushData(unitId)
+        );
+
+        fcmService.sendNotifications(List.of(message));
     }
 
     private void pushToUsers(

--- a/src/main/java/gravit/code/notification/listener/NotificationEventListener.java
+++ b/src/main/java/gravit/code/notification/listener/NotificationEventListener.java
@@ -1,0 +1,33 @@
+package gravit.code.notification.listener;
+
+import gravit.code.global.event.NoticeCreatedEvent;
+import gravit.code.notification.domain.NotificationType;
+import gravit.code.notification.service.NotificationService;
+import gravit.code.notification.support.NotificationMessageProvider;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.log4j.Log4j2;
+import org.springframework.stereotype.Component;
+import org.springframework.transaction.annotation.Propagation;
+import org.springframework.transaction.annotation.Transactional;
+import org.springframework.transaction.event.TransactionPhase;
+import org.springframework.transaction.event.TransactionalEventListener;
+
+@Log4j2
+@Component
+@RequiredArgsConstructor
+public class NotificationEventListener {
+
+    private final NotificationService notificationService;
+    private final NotificationMessageProvider messageProvider;
+
+    @TransactionalEventListener(phase = TransactionPhase.AFTER_COMMIT)
+    @Transactional(propagation = Propagation.REQUIRES_NEW)
+    public void handleNoticeCreated(NoticeCreatedEvent event) {
+        try {
+            String message = messageProvider.noticePublished(event.title());
+            notificationService.notifyAllUsers(NotificationType.NOTICE, message, event.noticeId());
+        } catch (Exception e) {
+            log.error("공지 알림 적재 실패 - noticeId: {}", event.noticeId(), e);
+        }
+    }
+}

--- a/src/main/java/gravit/code/notification/repository/NotificationRepository.java
+++ b/src/main/java/gravit/code/notification/repository/NotificationRepository.java
@@ -2,6 +2,26 @@ package gravit.code.notification.repository;
 
 import gravit.code.notification.domain.Notification;
 import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Modifying;
+import org.springframework.data.jpa.repository.Query;
+import org.springframework.data.repository.query.Param;
+
+import java.time.LocalDateTime;
 
 public interface NotificationRepository extends JpaRepository<Notification, Long> {
+
+    // 전체 활성 유저에게 동일 알림을 1쿼리로 적재 (공지 등 브로드캐스트용)
+    @Modifying
+    @Query(value = """
+        INSERT INTO notification (user_id, type, message, target_id, is_read, created_at, updated_at)
+        SELECT u.id, :type, :message, :targetId, FALSE, :now, :now
+        FROM users u
+        WHERE u.deleted_at IS NULL
+        """, nativeQuery = true)
+    int insertForAllActiveUsers(
+            @Param("type") String type,
+            @Param("message") String message,
+            @Param("targetId") Long targetId,
+            @Param("now") LocalDateTime now
+    );
 }

--- a/src/main/java/gravit/code/notification/service/NotificationService.java
+++ b/src/main/java/gravit/code/notification/service/NotificationService.java
@@ -7,11 +7,15 @@ import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
+import java.time.Clock;
+import java.time.LocalDateTime;
+
 @Service
 @RequiredArgsConstructor
 public class NotificationService {
 
     private final NotificationRepository notificationRepository;
+    private final Clock clock;
 
     @Transactional
     public void notify(
@@ -30,5 +34,15 @@ public class NotificationService {
             String message
     ) {
         notify(userId, type, message, null);
+    }
+
+    // 전체 활성 유저 알림함에 동일 알림 적재 (공지 등 브로드캐스트)
+    @Transactional
+    public void notifyAllUsers(
+            NotificationType type,
+            String message,
+            Long targetId
+    ) {
+        notificationRepository.insertForAllActiveUsers(type.name(), message, targetId, LocalDateTime.now(clock));
     }
 }

--- a/src/main/java/gravit/code/notification/support/NotificationMessageProvider.java
+++ b/src/main/java/gravit/code/notification/support/NotificationMessageProvider.java
@@ -11,6 +11,8 @@ public class NotificationMessageProvider {
 
     private static final String CONSECUTIVE_WARNING_MESSAGE = "오늘 학습을 하지 않으면 %d일 연속학습이 끊겨요!";
 
+    private static final String NEW_CONTENT_MESSAGE = "새 레슨이 업데이트됐어요! 오늘 학습에 도전해보세요 🔥";
+
     private static final List<String> DAILY_INCOMPLETE_MESSAGES = List.of(
             "오늘 아직 학습을 안 했어요! 10분만 투자해보세요 📚",
             "오늘 학습을 시작해보세요! 작은 습관이 큰 변화를 만들어요 🌱",
@@ -36,5 +38,13 @@ public class NotificationMessageProvider {
 
     public List<InactivityMilestone> inactivityMilestones() {
         return INACTIVITY_MILESTONES;
+    }
+
+    public String noticePublished(String noticeTitle) {
+        return "[공지] " + noticeTitle;
+    }
+
+    public String newContent() {
+        return NEW_CONTENT_MESSAGE;
     }
 }

--- a/src/main/java/gravit/code/notification/support/NotificationMessageProvider.java
+++ b/src/main/java/gravit/code/notification/support/NotificationMessageProvider.java
@@ -1,0 +1,40 @@
+package gravit.code.notification.support;
+
+import gravit.code.notification.dto.internal.InactivityMilestone;
+import org.springframework.stereotype.Component;
+
+import java.util.List;
+import java.util.concurrent.ThreadLocalRandom;
+
+@Component
+public class NotificationMessageProvider {
+
+    private static final String CONSECUTIVE_WARNING_MESSAGE = "오늘 학습을 하지 않으면 %d일 연속학습이 끊겨요!";
+
+    private static final List<String> DAILY_INCOMPLETE_MESSAGES = List.of(
+            "오늘 아직 학습을 안 했어요! 10분만 투자해보세요 📚",
+            "오늘 학습을 시작해보세요! 작은 습관이 큰 변화를 만들어요 🌱",
+            "지금 이 시간에도 누군가는 CS를 공부하고 있어요 👀"
+    );
+
+    private static final List<InactivityMilestone> INACTIVITY_MILESTONES = List.of(
+            new InactivityMilestone(7, "일주일 비웠더니 실력도 쉬는 중... 다시 깨워볼까요?"),
+            new InactivityMilestone(14, "2주.. 슬슬 돌아오실 때가 되었는데요? 👀"),
+            new InactivityMilestone(30, "한 달간 안 까먹었어요. 당신은.. 좀 까먹었을지도?"),
+            new InactivityMilestone(60, "두 달째 그래빗이 우주에서 당신의 신호를 기다리고 있어요 🛜"),
+            new InactivityMilestone(90, "저를 잊으셨나요?")
+    );
+
+    public String consecutiveWarning(int consecutiveDays) {
+        return CONSECUTIVE_WARNING_MESSAGE.formatted(consecutiveDays);
+    }
+
+    public String randomDailyIncomplete() {
+        int index = ThreadLocalRandom.current().nextInt(DAILY_INCOMPLETE_MESSAGES.size());
+        return DAILY_INCOMPLETE_MESSAGES.get(index);
+    }
+
+    public List<InactivityMilestone> inactivityMilestones() {
+        return INACTIVITY_MILESTONES;
+    }
+}

--- a/src/main/java/gravit/code/option/dto/response/OptionResponse.java
+++ b/src/main/java/gravit/code/option/dto/response/OptionResponse.java
@@ -3,7 +3,6 @@ package gravit.code.option.dto.response;
 import com.fasterxml.jackson.annotation.JsonProperty;
 import gravit.code.option.domain.Option;
 import io.swagger.v3.oas.annotations.media.Schema;
-import jakarta.validation.constraints.NotNull;
 import lombok.AccessLevel;
 import lombok.Builder;
 
@@ -23,7 +22,6 @@ public record OptionResponse(
                 example = "tail 포인터가 더 빠른 접근을 제공",
                 requiredMode = Schema.RequiredMode.REQUIRED
         )
-        @NotNull
         String content,
 
         @Schema(
@@ -31,7 +29,6 @@ public record OptionResponse(
                 example = "실제로 tail 포인터를 활용했을 때 속도가 더 빠르다.",
                 requiredMode = Schema.RequiredMode.REQUIRED
         )
-        @NotNull
         String explanation,
 
         @Schema(

--- a/src/main/java/gravit/code/problem/dto/response/BookmarkedProblemResponse.java
+++ b/src/main/java/gravit/code/problem/dto/response/BookmarkedProblemResponse.java
@@ -2,7 +2,6 @@ package gravit.code.problem.dto.response;
 
 import gravit.code.unit.dto.response.UnitSummaryResponse;
 import io.swagger.v3.oas.annotations.media.Schema;
-import jakarta.validation.constraints.NotNull;
 import lombok.AccessLevel;
 import lombok.Builder;
 
@@ -15,14 +14,12 @@ public record BookmarkedProblemResponse(
                 description = "유닛 요약 정보",
                 requiredMode = Schema.RequiredMode.REQUIRED
         )
-        @NotNull
         UnitSummaryResponse unitSummaryResponse,
 
         @Schema(
                 description = "문제 목록",
                 requiredMode = Schema.RequiredMode.REQUIRED
         )
-        @NotNull
         List<ProblemResponse> problems,
 
         @Schema(

--- a/src/main/java/gravit/code/problem/dto/response/ProblemDetailResponse.java
+++ b/src/main/java/gravit/code/problem/dto/response/ProblemDetailResponse.java
@@ -3,21 +3,21 @@ package gravit.code.problem.dto.response;
 import com.fasterxml.jackson.annotation.JsonProperty;
 import gravit.code.problem.domain.ProblemType;
 import io.swagger.v3.oas.annotations.media.Schema;
-import jakarta.validation.constraints.NotNull;
 
 public record ProblemDetailResponse(
 
         @Schema(requiredMode = Schema.RequiredMode.REQUIRED)
         long id,
+
         @Schema(requiredMode = Schema.RequiredMode.REQUIRED)
-        @NotNull
         ProblemType problemType,
+
         @Schema(requiredMode = Schema.RequiredMode.REQUIRED)
-        @NotNull
         String instruction,
+
         @Schema(requiredMode = Schema.RequiredMode.REQUIRED)
-        @NotNull
         String content,
+
         @Schema(requiredMode = Schema.RequiredMode.REQUIRED)
         @JsonProperty("isBookmarked")
         boolean isBookmarked

--- a/src/main/java/gravit/code/problem/dto/response/ProblemResponse.java
+++ b/src/main/java/gravit/code/problem/dto/response/ProblemResponse.java
@@ -8,7 +8,6 @@ import gravit.code.option.dto.response.OptionResponse;
 import gravit.code.problem.domain.Problem;
 import gravit.code.problem.domain.ProblemType;
 import io.swagger.v3.oas.annotations.media.Schema;
-import jakarta.validation.constraints.NotNull;
 import lombok.AccessLevel;
 import lombok.Builder;
 
@@ -30,7 +29,6 @@ public record ProblemResponse(
                 example = "SUBJECTIVE / OBJECTIVE",
                 requiredMode = Schema.RequiredMode.REQUIRED
         )
-        @NotNull
         ProblemType problemType,
 
         @Schema(
@@ -38,7 +36,6 @@ public record ProblemResponse(
                 example = "빈칸에 들어갈 단어를 고르시오.",
                 requiredMode = Schema.RequiredMode.REQUIRED
         )
-        @NotNull
         String instruction,
 
         @Schema(
@@ -46,7 +43,6 @@ public record ProblemResponse(
                 example = "큐에 2, 9, 7, 4를 순차적으로 넣었을 때, 원소 삭제시 반환되는 값은?",
                 requiredMode = Schema.RequiredMode.REQUIRED
         )
-        @NotNull
         String content,
 
         @Schema(

--- a/src/main/java/gravit/code/problem/dto/response/WrongAnsweredProblemsResponse.java
+++ b/src/main/java/gravit/code/problem/dto/response/WrongAnsweredProblemsResponse.java
@@ -2,7 +2,6 @@ package gravit.code.problem.dto.response;
 
 import gravit.code.unit.dto.response.UnitSummaryResponse;
 import io.swagger.v3.oas.annotations.media.Schema;
-import jakarta.validation.constraints.NotNull;
 import lombok.AccessLevel;
 import lombok.Builder;
 
@@ -15,14 +14,12 @@ public record WrongAnsweredProblemsResponse(
                 description = "유닛 요약 정보",
                 requiredMode = Schema.RequiredMode.REQUIRED
         )
-        @NotNull
         UnitSummaryResponse unitSummaryResponse,
 
         @Schema(
                 description = "문제 목록",
                 requiredMode = Schema.RequiredMode.REQUIRED
         )
-        @NotNull
         List<ProblemResponse> problems,
 
         @Schema(

--- a/src/main/java/gravit/code/security/config/SecurityConfig.java
+++ b/src/main/java/gravit/code/security/config/SecurityConfig.java
@@ -8,6 +8,7 @@ import gravit.code.security.filter.JwtAuthFilter;
 import lombok.RequiredArgsConstructor;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
+import org.springframework.http.HttpMethod;
 import org.springframework.security.config.annotation.web.builders.HttpSecurity;
 import org.springframework.security.config.annotation.web.configuration.EnableWebSecurity;
 import org.springframework.security.config.annotation.web.configurers.AbstractHttpConfigurer;
@@ -55,6 +56,7 @@ public class SecurityConfig {
                 .requestMatchers("/api/v1/test/**").permitAll() // 테스트 할때만
                 .requestMatchers("/api/v1/admin/**").hasRole("ADMIN")
                 .requestMatchers("/api/v1/cs-notes/**").permitAll()
+                .requestMatchers(HttpMethod.GET, "/api/v1/version").permitAll() // 앱 버전 체크(로그인 전)
                 .anyRequest().authenticated());
 
         // JwtFilter 추가

--- a/src/main/java/gravit/code/security/filter/JwtAuthFilter.java
+++ b/src/main/java/gravit/code/security/filter/JwtAuthFilter.java
@@ -46,7 +46,10 @@ public class JwtAuthFilter extends OncePerRequestFilter {
             HttpEndpoint.prefix("/actuator", HttpMethod.GET),
 
             /* note */
-            HttpEndpoint.prefix("/api/v1/cs-notes", HttpMethod.GET)
+            HttpEndpoint.prefix("/api/v1/cs-notes", HttpMethod.GET),
+
+            /* app version check */
+            HttpEndpoint.exact("/api/v1/version", HttpMethod.GET)
 
     );
 

--- a/src/main/java/gravit/code/social/dto/response/RecommendUserResponse.java
+++ b/src/main/java/gravit/code/social/dto/response/RecommendUserResponse.java
@@ -9,10 +9,13 @@ import static lombok.AccessLevel.PRIVATE;
 public record RecommendUserResponse(
         @Schema(requiredMode = Schema.RequiredMode.REQUIRED)
         long userId,
+
         @Schema(requiredMode = Schema.RequiredMode.REQUIRED)
         String nickname,
+
         @Schema(requiredMode = Schema.RequiredMode.REQUIRED)
         int profileImgNumber,
+
         @Schema(requiredMode = Schema.RequiredMode.REQUIRED)
         int mutualFollowCount
 ) {

--- a/src/main/java/gravit/code/social/dto/response/SocialFeedResponse.java
+++ b/src/main/java/gravit/code/social/dto/response/SocialFeedResponse.java
@@ -11,20 +11,28 @@ import java.time.temporal.ChronoUnit;
 public record SocialFeedResponse(
         @Schema(requiredMode = Schema.RequiredMode.REQUIRED)
         Long feedId,
+
         @Schema(requiredMode = Schema.RequiredMode.REQUIRED)
         Long actorId,
+
         @Schema(requiredMode = Schema.RequiredMode.REQUIRED)
         String actorNickname,
+
         @Schema(requiredMode = Schema.RequiredMode.REQUIRED)
         int actorProfileImgNumber,
+
         @Schema(requiredMode = Schema.RequiredMode.REQUIRED)
         String actorHandle,
+
         @Schema(requiredMode = Schema.RequiredMode.REQUIRED)
         String message,
+
         @Schema(requiredMode = Schema.RequiredMode.REQUIRED)
         String timeAgo,
+
         @Schema(requiredMode = Schema.RequiredMode.REQUIRED)
         boolean canCongratulate,
+
         @Schema(requiredMode = Schema.RequiredMode.REQUIRED)
         LocalDateTime createdAt
 ) {

--- a/src/main/java/gravit/code/social/dto/response/SocialFeedSliceResponse.java
+++ b/src/main/java/gravit/code/social/dto/response/SocialFeedSliceResponse.java
@@ -7,9 +7,16 @@ import java.util.List;
 @Schema(description = "피드 슬라이스 응답")
 public class SocialFeedSliceResponse {
 
-    @Schema(description = "다음 페이지 존재 여부", example = "false", requiredMode = Schema.RequiredMode.REQUIRED)
+    @Schema(
+            description = "다음 페이지 존재 여부",
+            example = "false",
+            requiredMode = Schema.RequiredMode.REQUIRED
+    )
     public boolean hasNextPage;
 
-    @Schema(description = "피드 목록", requiredMode = Schema.RequiredMode.REQUIRED)
+    @Schema(
+            description = "피드 목록",
+            requiredMode = Schema.RequiredMode.REQUIRED
+    )
     public List<SocialFeedResponse> contents;
 }

--- a/src/main/java/gravit/code/unit/dto/response/UnitPageResponse.java
+++ b/src/main/java/gravit/code/unit/dto/response/UnitPageResponse.java
@@ -2,7 +2,6 @@ package gravit.code.unit.dto.response;
 
 import gravit.code.chapter.dto.response.ChapterSummaryResponse;
 import io.swagger.v3.oas.annotations.media.Schema;
-import jakarta.validation.constraints.NotNull;
 import lombok.AccessLevel;
 import lombok.Builder;
 
@@ -16,14 +15,12 @@ public record UnitPageResponse(
                 description = "챕터 요약 정보",
                 requiredMode = Schema.RequiredMode.REQUIRED
         )
-        @NotNull
         ChapterSummaryResponse chapterSummaryResponse,
 
         @Schema(
                 description = "유닛 상세 정보 목록",
                 requiredMode = Schema.RequiredMode.REQUIRED
         )
-        @NotNull
         List<UnitDetailResponse> unitDetailResponses
 ) {
 

--- a/src/main/java/gravit/code/unit/dto/response/UnitSummaryResponse.java
+++ b/src/main/java/gravit/code/unit/dto/response/UnitSummaryResponse.java
@@ -1,7 +1,6 @@
 package gravit.code.unit.dto.response;
 
 import io.swagger.v3.oas.annotations.media.Schema;
-import jakarta.validation.constraints.NotNull;
 
 public record UnitSummaryResponse(
 
@@ -17,7 +16,6 @@ public record UnitSummaryResponse(
                 example = "Unit01 - 연결리스트",
                 requiredMode = Schema.RequiredMode.REQUIRED
         )
-        @NotNull
         String title,
 
         @Schema(
@@ -25,7 +23,6 @@ public record UnitSummaryResponse(
                 example = "배열과 연결리스트에 대해 학습합니다.",
                 requiredMode = Schema.RequiredMode.REQUIRED
         )
-        @NotNull
         String description
 ) {
 }

--- a/src/main/java/gravit/code/user/domain/User.java
+++ b/src/main/java/gravit/code/user/domain/User.java
@@ -65,6 +65,9 @@ public class User extends BaseEntity {
     @Enumerated(EnumType.STRING)
     private Role role;
 
+    @Column(name = "last_accessed_at")
+    private LocalDateTime lastAccessedAt;
+
     @Builder
     private User(
             String email,

--- a/src/main/java/gravit/code/user/dto/response/MainPageResponse.java
+++ b/src/main/java/gravit/code/user/dto/response/MainPageResponse.java
@@ -15,18 +15,25 @@ import java.util.List;
 public record MainPageResponse(
         @Schema(requiredMode = Schema.RequiredMode.REQUIRED)
         int profileImgNumber,
+
         @Schema(requiredMode = Schema.RequiredMode.REQUIRED)
         String nickname,
+
         @Schema(requiredMode = Schema.RequiredMode.REQUIRED)
         UserLevelDetailResponse userLevelDetailResponse,
+
         @Schema(requiredMode = Schema.RequiredMode.REQUIRED)
         LeagueDetailResponse leagueDetailResponse,
+
         @Schema(requiredMode = Schema.RequiredMode.REQUIRED)
         LearningDetailResponse learningDetailResponse,
+
         @Schema(requiredMode = Schema.RequiredMode.REQUIRED)
         List<RecommendedUnitResponse> recommendedUnitResponses,
+
         @Schema(requiredMode = Schema.RequiredMode.REQUIRED)
         WeeklyLearningRecordResponse weeklyLearningRecordResponse,
+
         @Schema(requiredMode = Schema.RequiredMode.REQUIRED)
         MissionDetailResponse missionDetailResponse
 ) {

--- a/src/main/java/gravit/code/user/dto/response/MyPageBannerResponse.java
+++ b/src/main/java/gravit/code/user/dto/response/MyPageBannerResponse.java
@@ -9,14 +9,19 @@ import static lombok.AccessLevel.PRIVATE;
 public record MyPageBannerResponse(
         @Schema(requiredMode = Schema.RequiredMode.REQUIRED)
         int profileImageNumber,
+
         @Schema(requiredMode = Schema.RequiredMode.REQUIRED)
         String nickname,
+
         @Schema(requiredMode = Schema.RequiredMode.REQUIRED)
         String handle,
+
         @Schema(requiredMode = Schema.RequiredMode.REQUIRED)
         int level,
+
         @Schema(requiredMode = Schema.RequiredMode.REQUIRED)
         String currentLeague,
+
         @Schema(requiredMode = Schema.RequiredMode.REQUIRED)
         int consecutiveSolvedDays
 ) {

--- a/src/main/java/gravit/code/user/dto/response/MyPageResponse.java
+++ b/src/main/java/gravit/code/user/dto/response/MyPageResponse.java
@@ -5,12 +5,16 @@ import io.swagger.v3.oas.annotations.media.Schema;
 public record MyPageResponse(
         @Schema(requiredMode = Schema.RequiredMode.REQUIRED)
         String nickname,
+
         @Schema(requiredMode = Schema.RequiredMode.REQUIRED)
         int profileImgNumber,
+
         @Schema(requiredMode = Schema.RequiredMode.REQUIRED)
         String handle,
+
         @Schema(requiredMode = Schema.RequiredMode.REQUIRED)
         long follower,
+
         @Schema(requiredMode = Schema.RequiredMode.REQUIRED)
         long following
 ) {

--- a/src/main/java/gravit/code/user/dto/response/UserLevelDetailResponse.java
+++ b/src/main/java/gravit/code/user/dto/response/UserLevelDetailResponse.java
@@ -8,10 +8,13 @@ import lombok.Builder;
 public record UserLevelDetailResponse(
         @Schema(requiredMode = Schema.RequiredMode.REQUIRED)
         int level,
+
         @Schema(requiredMode = Schema.RequiredMode.REQUIRED)
         int currentXp,
+
         @Schema(requiredMode = Schema.RequiredMode.REQUIRED)
         int maxXp,
+
         @Schema(requiredMode = Schema.RequiredMode.REQUIRED)
         double levelRate
 ) {

--- a/src/main/java/gravit/code/user/dto/response/UserResponse.java
+++ b/src/main/java/gravit/code/user/dto/response/UserResponse.java
@@ -8,10 +8,13 @@ import lombok.Builder;
 public record UserResponse(
         @Schema(requiredMode = Schema.RequiredMode.REQUIRED)
         long userId,
+
         @Schema(requiredMode = Schema.RequiredMode.REQUIRED)
         int profileImgNumber,
+
         @Schema(requiredMode = Schema.RequiredMode.REQUIRED)
         String nickname,
+
         @Schema(requiredMode = Schema.RequiredMode.REQUIRED)
         String providerId
 ) {

--- a/src/main/java/gravit/code/user/facade/UserFacade.java
+++ b/src/main/java/gravit/code/user/facade/UserFacade.java
@@ -9,7 +9,8 @@ import gravit.code.league.dto.response.LeagueDetailResponse;
 import gravit.code.learning.domain.Learning;
 import gravit.code.learning.dto.response.LearningDetailResponse;
 import gravit.code.learning.service.LearningProgressRateService;
-import gravit.code.learning.service.LearningService;
+import gravit.code.learning.service.LearningQueryService;
+import gravit.code.learning.service.LearningCommandService;
 import gravit.code.mission.dto.response.MissionDetailResponse;
 import gravit.code.mission.service.MissionService;
 import gravit.code.unit.dto.response.RecommendedUnitResponse;
@@ -33,7 +34,8 @@ public class UserFacade {
     private final UserService userService;
     private final UserLeagueService userLeagueService;
     private final UnitQueryService unitQueryService;
-    private final LearningService learningService;
+    private final LearningQueryService learningQueryService;
+    private final LearningCommandService learningCommandService;
     private final ChapterQueryService chapterQueryService;
     private final LearningProgressRateService learningProgressRateService;
     private final MissionService missionService;
@@ -42,7 +44,7 @@ public class UserFacade {
     @Transactional(readOnly = true)
     public MainPageResponse getMainPage(long userId) {
         User user = userService.getUser(userId);
-        Learning learning = learningService.getLearning(userId);
+        Learning learning = learningQueryService.getLearning(userId);
 
         UserLevelDetailResponse userLevelDetailResponse = user.getLevel().getUserLevelDetail();
         LeagueDetailResponse leagueDetailResponse = userLeagueService.getUserLeagueDetail(userId);
@@ -67,7 +69,7 @@ public class UserFacade {
     public MyPageBannerResponse getMyPageBanner(long userId){
         User user = userService.getUser(userId);
         String leagueName = userLeagueService.getUserLeagueName(userId);
-        Learning learning = learningService.getLearning(userId);
+        Learning learning = learningQueryService.getLearning(userId);
 
         return MyPageBannerResponse.of(
                 user.getProfileImgNumber(),

--- a/src/main/java/gravit/code/user/repository/UserRepository.java
+++ b/src/main/java/gravit/code/user/repository/UserRepository.java
@@ -9,6 +9,7 @@ import org.springframework.data.jpa.repository.Query;
 import org.springframework.data.repository.query.Param;
 
 import java.time.LocalDateTime;
+import java.util.List;
 import java.util.Optional;
 
 public interface UserRepository extends JpaRepository<User, Long>, UserDeletionRepository {
@@ -49,5 +50,16 @@ public interface UserRepository extends JpaRepository<User, Long>, UserDeletionR
             @Param("userId") long userId,
             @Param("now") LocalDateTime now,
             @Param("startOfToday") LocalDateTime startOfToday
+    );
+
+    // 마지막 접속이 [start, end) 구간(특정 하루)에 속한 유저 = 정확히 N일째 미접속 유저
+    @Query("""
+        SELECT u.id
+        FROM User u
+        WHERE u.lastAccessedAt >= :start AND u.lastAccessedAt < :end
+    """)
+    List<Long> findUserIdsLastAccessedBetween(
+            @Param("start") LocalDateTime start,
+            @Param("end") LocalDateTime end
     );
 }

--- a/src/main/java/gravit/code/user/repository/UserRepository.java
+++ b/src/main/java/gravit/code/user/repository/UserRepository.java
@@ -39,7 +39,7 @@ public interface UserRepository extends JpaRepository<User, Long>, UserDeletionR
     """)
     Optional<MyPageResponse> findMyPageByUserId(@Param("userId") long userId);
 
-    @Modifying
+    @Modifying(clearAutomatically = true, flushAutomatically = true)
     @Query("""
         UPDATE User u
         SET u.lastAccessedAt = :now
@@ -52,7 +52,6 @@ public interface UserRepository extends JpaRepository<User, Long>, UserDeletionR
             @Param("startOfToday") LocalDateTime startOfToday
     );
 
-    // 마지막 접속이 [start, end) 구간(특정 하루)에 속한 유저 = 정확히 N일째 미접속 유저
     @Query("""
         SELECT u.id
         FROM User u

--- a/src/main/java/gravit/code/user/repository/UserRepository.java
+++ b/src/main/java/gravit/code/user/repository/UserRepository.java
@@ -4,9 +4,11 @@ import gravit.code.user.domain.User;
 import gravit.code.user.dto.response.MyPageResponse;
 import gravit.code.user.repository.custom.UserDeletionRepository;
 import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Modifying;
 import org.springframework.data.jpa.repository.Query;
 import org.springframework.data.repository.query.Param;
 
+import java.time.LocalDateTime;
 import java.util.Optional;
 
 public interface UserRepository extends JpaRepository<User, Long>, UserDeletionRepository {
@@ -35,4 +37,17 @@ public interface UserRepository extends JpaRepository<User, Long>, UserDeletionR
         where u.id = :userId
     """)
     Optional<MyPageResponse> findMyPageByUserId(@Param("userId") long userId);
+
+    @Modifying
+    @Query("""
+        UPDATE User u
+        SET u.lastAccessedAt = :now
+        WHERE u.id = :userId
+          AND (u.lastAccessedAt IS NULL OR u.lastAccessedAt < :startOfToday)
+    """)
+    int updateLastAccessedAt(
+            @Param("userId") long userId,
+            @Param("now") LocalDateTime now,
+            @Param("startOfToday") LocalDateTime startOfToday
+    );
 }

--- a/src/main/java/gravit/code/user/service/UserAccessService.java
+++ b/src/main/java/gravit/code/user/service/UserAccessService.java
@@ -1,0 +1,26 @@
+package gravit.code.user.service;
+
+import gravit.code.user.repository.UserRepository;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+import java.time.Clock;
+import java.time.LocalDate;
+import java.time.LocalDateTime;
+
+@Service
+@RequiredArgsConstructor
+public class UserAccessService {
+
+    private final UserRepository userRepository;
+    private final Clock clock;
+
+    @Transactional
+    public void updateLastAccessed(long userId) {
+        LocalDateTime now = LocalDateTime.now(clock);
+        LocalDateTime startOfToday = LocalDate.now(clock).atStartOfDay();
+
+        userRepository.updateLastAccessedAt(userId, now, startOfToday);
+    }
+}

--- a/src/main/java/gravit/code/user/service/UserAccessService.java
+++ b/src/main/java/gravit/code/user/service/UserAccessService.java
@@ -8,6 +8,7 @@ import org.springframework.transaction.annotation.Transactional;
 import java.time.Clock;
 import java.time.LocalDate;
 import java.time.LocalDateTime;
+import java.util.List;
 
 @Service
 @RequiredArgsConstructor
@@ -22,5 +23,13 @@ public class UserAccessService {
         LocalDateTime startOfToday = LocalDate.now(clock).atStartOfDay();
 
         userRepository.updateLastAccessedAt(userId, now, startOfToday);
+    }
+
+    @Transactional(readOnly = true)
+    public List<Long> getUserIdsInactiveForExactly(int inactiveDays) {
+        LocalDateTime start = LocalDate.now(clock).minusDays(inactiveDays).atStartOfDay();
+        LocalDateTime end = start.plusDays(1);
+
+        return userRepository.findUserIdsLastAccessedBetween(start, end);
     }
 }

--- a/src/main/java/gravit/code/userLeague/dto/response/MyLeagueRankWithProfileResponse.java
+++ b/src/main/java/gravit/code/userLeague/dto/response/MyLeagueRankWithProfileResponse.java
@@ -1,30 +1,36 @@
 package gravit.code.userLeague.dto.response;
 
 import io.swagger.v3.oas.annotations.media.Schema;
-import jakarta.validation.constraints.NotNull;
 
 public record MyLeagueRankWithProfileResponse(
 
         @Schema(requiredMode = Schema.RequiredMode.REQUIRED)
         long leagueId,
+
         @Schema(requiredMode = Schema.RequiredMode.REQUIRED)
-        @NotNull
         String leagueName,
+
         @Schema(requiredMode = Schema.RequiredMode.REQUIRED)
         int rank,
+
         @Schema(requiredMode = Schema.RequiredMode.REQUIRED)
         long userId,
+
         @Schema(requiredMode = Schema.RequiredMode.REQUIRED)
         int lp,
+
         @Schema(requiredMode = Schema.RequiredMode.REQUIRED)
         int maxLp,
+
         @Schema(requiredMode = Schema.RequiredMode.REQUIRED)
-        @NotNull
         String nickname,
+
         @Schema(requiredMode = Schema.RequiredMode.REQUIRED)
         int profileImgNumber,
+
         @Schema(requiredMode = Schema.RequiredMode.REQUIRED)
         int xp,
+
         @Schema(requiredMode = Schema.RequiredMode.REQUIRED)
         int level
 ) {

--- a/src/main/java/gravit/code/version/controller/VersionController.java
+++ b/src/main/java/gravit/code/version/controller/VersionController.java
@@ -1,0 +1,26 @@
+package gravit.code.version.controller;
+
+import gravit.code.version.controller.docs.VersionControllerDocs;
+import gravit.code.version.dto.response.VersionResponse;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+@RestController
+@RequestMapping("/api/v1/version")
+public class VersionController implements VersionControllerDocs {
+
+    private final String appVersion;
+
+    public VersionController(@Value("${app.version}") String appVersion) {
+        this.appVersion = appVersion;
+    }
+
+    @GetMapping
+    public ResponseEntity<VersionResponse> getLatestVersion() {
+        return ResponseEntity.status(HttpStatus.OK).body(VersionResponse.of(appVersion));
+    }
+}

--- a/src/main/java/gravit/code/version/controller/docs/VersionControllerDocs.java
+++ b/src/main/java/gravit/code/version/controller/docs/VersionControllerDocs.java
@@ -1,0 +1,32 @@
+package gravit.code.version.controller.docs;
+
+import gravit.code.version.dto.response.VersionResponse;
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.media.Content;
+import io.swagger.v3.oas.annotations.media.Schema;
+import io.swagger.v3.oas.annotations.responses.ApiResponse;
+import io.swagger.v3.oas.annotations.responses.ApiResponses;
+import io.swagger.v3.oas.annotations.tags.Tag;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.GetMapping;
+
+@Tag(name = "Version API", description = "앱 버전 체크")
+public interface VersionControllerDocs {
+
+    @Operation(
+            summary = "최신 앱 버전 조회",
+            description = "서버가 정의한 최신 앱 버전을 반환합니다. 클라이언트는 자신의 버전과 비교해 일치하지 않으면 강제 업데이트를 유도합니다. (인증 불필요)"
+    )
+    @ApiResponses({
+            @ApiResponse(
+                    responseCode = "200",
+                    description = "✅ 조회 성공",
+                    content = @Content(
+                            mediaType = "application/json",
+                            schema = @Schema(implementation = VersionResponse.class)
+                    )
+            )
+    })
+    @GetMapping
+    ResponseEntity<VersionResponse> getLatestVersion();
+}

--- a/src/main/java/gravit/code/version/dto/response/VersionResponse.java
+++ b/src/main/java/gravit/code/version/dto/response/VersionResponse.java
@@ -1,0 +1,16 @@
+package gravit.code.version.dto.response;
+
+import io.swagger.v3.oas.annotations.media.Schema;
+
+public record VersionResponse(
+        @Schema(
+                description = "서버가 정의한 최신 앱 버전",
+                example = "1.0.0",
+                requiredMode = Schema.RequiredMode.REQUIRED
+        )
+        String version
+) {
+    public static VersionResponse of(String version) {
+        return new VersionResponse(version);
+    }
+}

--- a/src/main/java/gravit/code/wrongAnsweredNote/dto/request/WrongAnsweredNoteDeleteRequest.java
+++ b/src/main/java/gravit/code/wrongAnsweredNote/dto/request/WrongAnsweredNoteDeleteRequest.java
@@ -7,7 +7,8 @@ public record WrongAnsweredNoteDeleteRequest(
 
         @Schema(
                 description = "문제 아이디",
-                example = "1"
+                example = "1",
+                requiredMode = Schema.RequiredMode.REQUIRED
         )
         long problemId
 ) {

--- a/src/main/resources/application-dev.yml
+++ b/src/main/resources/application-dev.yml
@@ -132,3 +132,6 @@ management:
     web:
       exposure:
         include: health, prometheus
+
+app:
+  version: 1.0.0

--- a/src/main/resources/application-prod.yml
+++ b/src/main/resources/application-prod.yml
@@ -136,3 +136,6 @@ management:
     web:
       exposure:
         include: prometheus
+
+app:
+  version: 1.0.0

--- a/src/main/resources/db/migration/V17__add_user_last_accessed_at.sql
+++ b/src/main/resources/db/migration/V17__add_user_last_accessed_at.sql
@@ -1,0 +1,7 @@
+-- V17__add_user_last_accessed_at.sql
+
+ALTER TABLE users ADD COLUMN last_accessed_at TIMESTAMP(6);
+
+UPDATE users SET last_accessed_at = created_at WHERE last_accessed_at IS NULL;
+
+CREATE INDEX IF NOT EXISTS ix_users_last_accessed_at ON users (last_accessed_at);

--- a/src/main/resources/db/migration/V18__rename_notification_type_streak_to_consecutive.sql
+++ b/src/main/resources/db/migration/V18__rename_notification_type_streak_to_consecutive.sql
@@ -1,8 +1,8 @@
 --V18__rename_notification_type_streak_to_consecutive.sql
 
-UPDATE notification SET type = 'CONSECUTIVE_LEARNING_WARNING' WHERE type = 'STREAK_WARNING';
+ALTER TABLE notification DROP CONSTRAINT IF EXISTS ck_notification_type;
 
-ALTER TABLE notification DROP CONSTRAINT ck_notification_type;
+UPDATE notification SET type = 'CONSECUTIVE_LEARNING_WARNING' WHERE type = 'STREAK_WARNING';
 
 ALTER TABLE notification ADD CONSTRAINT ck_notification_type CHECK (
     type IN (

--- a/src/main/resources/db/migration/V18__rename_notification_type_streak_to_consecutive.sql
+++ b/src/main/resources/db/migration/V18__rename_notification_type_streak_to_consecutive.sql
@@ -1,0 +1,13 @@
+--V18__rename_notification_type_streak_to_consecutive.sql
+
+UPDATE notification SET type = 'CONSECUTIVE_LEARNING_WARNING' WHERE type = 'STREAK_WARNING';
+
+ALTER TABLE notification DROP CONSTRAINT ck_notification_type;
+
+ALTER TABLE notification ADD CONSTRAINT ck_notification_type CHECK (
+    type IN (
+        'CONSECUTIVE_LEARNING_WARNING', 'DAILY_INCOMPLETE', 'INACTIVITY', 'SEASON_ENDING',
+        'SEASON_RESET', 'FOLLOW', 'CONGRATULATION', 'FRIEND_ACTIVITY',
+        'NOTICE', 'VERSION', 'NEW_CONTENT'
+    )
+);

--- a/src/test/java/gravit/code/fcm/service/FcmTokenQueryServiceIntegrationTest.java
+++ b/src/test/java/gravit/code/fcm/service/FcmTokenQueryServiceIntegrationTest.java
@@ -10,6 +10,9 @@ import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.transaction.annotation.Transactional;
 
+import java.util.List;
+import java.util.Map;
+
 import static org.assertj.core.api.Assertions.assertThat;
 
 @TCSpringBootTest
@@ -57,6 +60,62 @@ class FcmTokenQueryServiceIntegrationTest extends FcmServiceIntegrationTestBase 
 
             // then
             assertThat(response.registered()).isFalse();
+        }
+    }
+
+    @Nested
+    @DisplayName("userId 목록으로 토큰을 조회할 때")
+    class GetTokensByUserIds {
+
+        @Test
+        void 유저별로_토큰을_묶어_반환하며_멀티_디바이스를_모두_포함한다() {
+            // given
+            fcmTokenRepository.save(FcmToken.create(userId, "device-1", "token-1"));
+            fcmTokenRepository.save(FcmToken.create(userId, "device-2", "token-2"));
+            fcmTokenRepository.save(FcmToken.create(otherUserId, "device-3", "token-3"));
+
+            // when
+            Map<Long, List<String>> result = fcmTokenQueryService.getTokensByUserIds(List.of(userId, otherUserId));
+
+            // then
+            assertThat(result.get(userId)).containsExactlyInAnyOrder("token-1", "token-2");
+            assertThat(result.get(otherUserId)).containsExactly("token-3");
+        }
+
+        @Test
+        void 토큰이_없는_유저는_맵에_포함되지_않는다() {
+            // when
+            Map<Long, List<String>> result = fcmTokenQueryService.getTokensByUserIds(List.of(userId));
+
+            // then
+            assertThat(result).doesNotContainKey(userId);
+        }
+    }
+
+    @Nested
+    @DisplayName("전체 토큰을 조회할 때")
+    class GetAllTokens {
+
+        @Test
+        void 모든_디바이스_토큰을_반환한다() {
+            // given
+            fcmTokenRepository.save(FcmToken.create(userId, "device-1", "token-1"));
+            fcmTokenRepository.save(FcmToken.create(otherUserId, "device-2", "token-2"));
+
+            // when
+            List<String> result = fcmTokenQueryService.getAllTokens();
+
+            // then
+            assertThat(result).containsExactlyInAnyOrder("token-1", "token-2");
+        }
+
+        @Test
+        void 토큰이_없으면_빈_리스트를_반환한다() {
+            // when
+            List<String> result = fcmTokenQueryService.getAllTokens();
+
+            // then
+            assertThat(result).isEmpty();
         }
     }
 }

--- a/src/test/java/gravit/code/learning/service/LearningCommandServiceIntegrationTest.java
+++ b/src/test/java/gravit/code/learning/service/LearningCommandServiceIntegrationTest.java
@@ -14,10 +14,13 @@ import static org.assertj.core.api.Assertions.assertThatThrownBy;
 import static org.assertj.core.api.SoftAssertions.assertSoftly;
 
 @TCSpringBootTest
-class LearningServiceIntegrationTest {
+class LearningCommandServiceIntegrationTest {
 
     @Autowired
-    private LearningService learningService;
+    private LearningCommandService learningCommandService;
+
+    @Autowired
+    private LearningQueryService learningQueryService;
 
     @Autowired
     private LearningRepository learningRepository;
@@ -33,7 +36,7 @@ class LearningServiceIntegrationTest {
             Learning saved = learningRepository.save(Learning.create(userId));
 
             // when
-            Learning result = learningService.getLearning(userId);
+            Learning result = learningQueryService.getLearning(userId);
 
             // then
             assertSoftly(softly -> {
@@ -50,7 +53,7 @@ class LearningServiceIntegrationTest {
             long nonExistentUserId = 999L;
 
             // when & then
-            assertThatThrownBy(() -> learningService.getLearning(nonExistentUserId))
+            assertThatThrownBy(() -> learningQueryService.getLearning(nonExistentUserId))
                     .isInstanceOf(RestApiException.class)
                     .extracting("errorCode")
                     .isEqualTo(LEARNING_NOT_FOUND);

--- a/src/test/java/gravit/code/learning/service/LearningQueryServiceIntegrationTest.java
+++ b/src/test/java/gravit/code/learning/service/LearningQueryServiceIntegrationTest.java
@@ -1,0 +1,109 @@
+package gravit.code.learning.service;
+
+import gravit.code.learning.domain.Learning;
+import gravit.code.learning.dto.internal.ConsecutiveAtRiskUser;
+import gravit.code.learning.repository.LearningRepository;
+import gravit.code.support.TCSpringBootTest;
+import gravit.code.user.domain.Role;
+import gravit.code.user.domain.User;
+import gravit.code.user.repository.UserRepository;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Nested;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.test.util.ReflectionTestUtils;
+
+import java.time.LocalDateTime;
+import java.util.List;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+@TCSpringBootTest
+class LearningQueryServiceIntegrationTest {
+
+    // 고정 시계 기준일 2025-08-05. active 임계값(미접속<7일) = 2025-07-30 00:00 이후 접속
+    private static final LocalDateTime ACTIVE = LocalDateTime.of(2025, 8, 5, 9, 0);    // 오늘 접속
+    private static final LocalDateTime INACTIVE = LocalDateTime.of(2025, 7, 20, 9, 0); // 16일 미접속
+
+    @Autowired
+    private LearningQueryService learningQueryService;
+
+    @Autowired
+    private UserRepository userRepository;
+
+    @Autowired
+    private LearningRepository learningRepository;
+
+    @Nested
+    @DisplayName("연속학습 위기 대상을 조회할 때")
+    class GetConsecutiveAtRiskUsers {
+
+        @Test
+        void 연속1일이상_오늘미완료_최근접속_유저만_반환한다() {
+            // given
+            long target = createUserAndLearning(1, ACTIVE, 3, false);  // 대상
+            createUserAndLearning(2, ACTIVE, 0, false);                // 연속 0 → 제외
+            createUserAndLearning(3, ACTIVE, 3, true);                 // 오늘 완료 → 제외
+            createUserAndLearning(4, INACTIVE, 3, false);              // 미접속 7일↑ → 제외
+
+            // when
+            List<ConsecutiveAtRiskUser> result = learningQueryService.getConsecutiveAtRiskUsers();
+
+            // then
+            assertThat(result).hasSize(1);
+            assertThat(result.get(0).userId()).isEqualTo(target);
+            assertThat(result.get(0).consecutiveSolvedDays()).isEqualTo(3);
+        }
+
+        @Test
+        void 대상이_없으면_빈_리스트를_반환한다() {
+            // given
+            createUserAndLearning(1, ACTIVE, 0, false);
+
+            // when
+            List<ConsecutiveAtRiskUser> result = learningQueryService.getConsecutiveAtRiskUsers();
+
+            // then
+            assertThat(result).isEmpty();
+        }
+    }
+
+    @Nested
+    @DisplayName("오늘 미완료 대상을 조회할 때")
+    class GetDailyIncompleteUserIds {
+
+        @Test
+        void 연속0_오늘미완료_최근접속_유저만_반환한다() {
+            // given
+            long target = createUserAndLearning(1, ACTIVE, 0, false);  // 대상
+            createUserAndLearning(2, ACTIVE, 3, false);                // 연속 1↑ → 제외
+            createUserAndLearning(3, ACTIVE, 0, true);                 // 오늘 완료 → 제외
+            createUserAndLearning(4, INACTIVE, 0, false);              // 미접속 7일↑ → 제외
+
+            // when
+            List<Long> result = learningQueryService.getDailyIncompleteUserIds();
+
+            // then
+            assertThat(result).containsExactly(target);
+        }
+    }
+
+    private long createUserAndLearning(
+            int index,
+            LocalDateTime lastAccessedAt,
+            int consecutiveDays,
+            boolean todaySolved
+    ) {
+        User user = userRepository.save(
+                User.create("e" + index + "@test.com", "p" + index, "유저" + index, "h" + index, 1, Role.USER));
+        ReflectionTestUtils.setField(user, "lastAccessedAt", lastAccessedAt);
+        userRepository.save(user);
+
+        Learning learning = Learning.create(user.getId());
+        ReflectionTestUtils.setField(learning, "consecutiveSolvedDays", consecutiveDays);
+        ReflectionTestUtils.setField(learning, "todaySolved", todaySolved);
+        learningRepository.save(learning);
+
+        return user.getId();
+    }
+}

--- a/src/test/java/gravit/code/lesson/facade/LessonFacadeUnitTest.java
+++ b/src/test/java/gravit/code/lesson/facade/LessonFacadeUnitTest.java
@@ -4,7 +4,7 @@ import gravit.code.bookmark.service.BookmarkService;
 import gravit.code.learning.dto.internal.ConsecutiveSolvedDto;
 import gravit.code.learning.dto.internal.LearningIdsDto;
 import gravit.code.learning.dto.request.LearningSubmissionSaveRequest;
-import gravit.code.learning.service.LearningService;
+import gravit.code.learning.service.LearningCommandService;
 import gravit.code.lesson.dto.request.LessonSubmissionSaveRequest;
 import gravit.code.lesson.dto.response.LessonDetailResponse;
 import gravit.code.lesson.dto.response.LessonSubmissionSaveResponse;
@@ -66,7 +66,7 @@ class LessonFacadeUnitTest {
     private BookmarkService bookmarkService;
 
     @Mock
-    private LearningService learningService;
+    private LearningCommandService learningCommandService;
 
     @Mock
     private UserService userService;
@@ -148,7 +148,7 @@ class LessonFacadeUnitTest {
             when(userService.updateUserLevelByLessonSubmission(eq(userId), eq(lessonRequest), eq(true)))
                     .thenReturn(UserLevelResponse.create(1, 20));
             when(lessonQueryService.getLearningIdsByLessonId(1L)).thenReturn(new LearningIdsDto(1L, 1L, 1L));
-            when(learningService.updateLearningStatus(userId, 1L)).thenReturn(new ConsecutiveSolvedDto(0, 1));
+            when(learningCommandService.updateLearningStatus(userId, 1L)).thenReturn(new ConsecutiveSolvedDto(0, 1));
 
             // when
             LessonSubmissionSaveResponse result = lessonFacade.saveLessonSubmission(userId, request);
@@ -177,7 +177,7 @@ class LessonFacadeUnitTest {
             when(userService.updateUserLevelByLessonSubmission(eq(userId), eq(lessonRequest), eq(false)))
                     .thenReturn(UserLevelResponse.create(1, 0));
             when(lessonQueryService.getLearningIdsByLessonId(1L)).thenReturn(new LearningIdsDto(1L, 1L, 1L));
-            when(learningService.updateLearningStatus(userId, 1L)).thenReturn(new ConsecutiveSolvedDto(1, 1));
+            when(learningCommandService.updateLearningStatus(userId, 1L)).thenReturn(new ConsecutiveSolvedDto(1, 1));
 
             // when
             LessonSubmissionSaveResponse result = lessonFacade.saveLessonSubmission(userId, request);

--- a/src/test/java/gravit/code/notification/service/NotificationServiceIntegrationTest.java
+++ b/src/test/java/gravit/code/notification/service/NotificationServiceIntegrationTest.java
@@ -1,0 +1,68 @@
+package gravit.code.notification.service;
+
+import gravit.code.notification.domain.Notification;
+import gravit.code.notification.domain.NotificationType;
+import gravit.code.notification.repository.NotificationRepository;
+import gravit.code.support.TCSpringBootTest;
+import gravit.code.user.domain.Role;
+import gravit.code.user.domain.User;
+import gravit.code.user.repository.UserRepository;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Nested;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+
+import java.util.List;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+@TCSpringBootTest
+class NotificationServiceIntegrationTest {
+
+    @Autowired
+    private NotificationService notificationService;
+
+    @Autowired
+    private NotificationRepository notificationRepository;
+
+    @Autowired
+    private UserRepository userRepository;
+
+    @Nested
+    @DisplayName("전체 유저에게 알림을 적재할 때")
+    class NotifyAllUsers {
+
+        @Test
+        void 활성_유저_전원에게_적재하고_탈퇴_유저는_제외한다() {
+            // given
+            User user1 = userRepository.save(User.create("a@test.com", "p1", "유저1", "h1", 1, Role.USER));
+            User user2 = userRepository.save(User.create("b@test.com", "p2", "유저2", "h2", 1, Role.USER));
+            User deleted = userRepository.save(User.create("c@test.com", "p3", "유저3", "h3", 1, Role.USER));
+            userRepository.delete(deleted); // soft delete (deleted_at 설정)
+
+            // when
+            notificationService.notifyAllUsers(NotificationType.NOTICE, "[공지] 점검 안내", 99L);
+
+            // then
+            List<Notification> notifications = notificationRepository.findAll();
+            assertThat(notifications)
+                    .extracting(Notification::getUserId)
+                    .containsExactlyInAnyOrder(user1.getId(), user2.getId());
+            assertThat(notifications).allSatisfy(notification -> {
+                assertThat(notification.getType()).isEqualTo(NotificationType.NOTICE);
+                assertThat(notification.getMessage()).isEqualTo("[공지] 점검 안내");
+                assertThat(notification.getTargetId()).isEqualTo(99L);
+                assertThat(notification.isRead()).isFalse();
+            });
+        }
+
+        @Test
+        void 활성_유저가_없으면_아무것도_적재하지_않는다() {
+            // when
+            notificationService.notifyAllUsers(NotificationType.NOTICE, "[공지] 점검 안내", 1L);
+
+            // then
+            assertThat(notificationRepository.findAll()).isEmpty();
+        }
+    }
+}

--- a/src/test/java/gravit/code/support/FcmTestConfig.java
+++ b/src/test/java/gravit/code/support/FcmTestConfig.java
@@ -1,0 +1,17 @@
+package gravit.code.support;
+
+import com.google.firebase.messaging.FirebaseMessaging;
+import org.mockito.Mockito;
+import org.springframework.boot.test.context.TestConfiguration;
+import org.springframework.context.annotation.Bean;
+
+// test 프로파일에서는 FcmConfig(@Profile("!test"))가 비활성화되어 FirebaseMessaging 빈이 없으므로
+// FcmService 주입이 가능하도록 mock 빈을 등록한다
+@TestConfiguration
+public class FcmTestConfig {
+
+    @Bean
+    public FirebaseMessaging firebaseMessaging() {
+        return Mockito.mock(FirebaseMessaging.class);
+    }
+}

--- a/src/test/java/gravit/code/support/TCSpringBootTest.java
+++ b/src/test/java/gravit/code/support/TCSpringBootTest.java
@@ -21,7 +21,8 @@ import org.springframework.test.context.ContextConfiguration;
 @Import({
         PostgreSQLTestContainerConfig.class,
         DatabaseCleaner.class,
-        FixedClockConfig.class
+        FixedClockConfig.class,
+        FcmTestConfig.class
 })
 @AutoConfigureTestDatabase(replace = AutoConfigureTestDatabase.Replace.NONE)
 @ExtendWith(DatabaseClearExtension.class)

--- a/src/test/java/gravit/code/user/service/UserAccessServiceIntegrationTest.java
+++ b/src/test/java/gravit/code/user/service/UserAccessServiceIntegrationTest.java
@@ -1,0 +1,121 @@
+package gravit.code.user.service;
+
+import gravit.code.support.TCSpringBootTest;
+import gravit.code.user.domain.Role;
+import gravit.code.user.domain.User;
+import gravit.code.user.repository.UserRepository;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Nested;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.test.util.ReflectionTestUtils;
+
+import java.time.LocalDateTime;
+import java.util.List;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+// 고정 시계 기준 now = 2025-08-05T12:00 (Asia/Seoul)
+@TCSpringBootTest
+class UserAccessServiceIntegrationTest {
+
+    private static final LocalDateTime NOW = LocalDateTime.of(2025, 8, 5, 12, 0);
+
+    @Autowired
+    private UserAccessService userAccessService;
+
+    @Autowired
+    private UserRepository userRepository;
+
+    @Nested
+    @DisplayName("접속 시각을 갱신할 때")
+    class UpdateLastAccessed {
+
+        @Test
+        void 오늘자_기록이_없으면_현재_시각으로_갱신한다() {
+            // given
+            User user = createUser(1, LocalDateTime.of(2025, 8, 4, 9, 0)); // 어제 접속
+
+            // when
+            userAccessService.updateLastAccessed(user.getId());
+
+            // then
+            assertThat(findById(user.getId()).getLastAccessedAt()).isEqualTo(NOW);
+        }
+
+        @Test
+        void lastAccessedAt이_null이면_현재_시각으로_갱신한다() {
+            // given
+            User user = createUser(1, null);
+
+            // when
+            userAccessService.updateLastAccessed(user.getId());
+
+            // then
+            assertThat(findById(user.getId()).getLastAccessedAt()).isEqualTo(NOW);
+        }
+
+        @Test
+        void 오늘_이미_기록이_있으면_갱신하지_않는다() {
+            // given
+            LocalDateTime todayMorning = LocalDateTime.of(2025, 8, 5, 9, 0);
+            User user = createUser(1, todayMorning);
+
+            // when
+            userAccessService.updateLastAccessed(user.getId());
+
+            // then
+            assertThat(findById(user.getId()).getLastAccessedAt()).isEqualTo(todayMorning);
+        }
+    }
+
+    @Nested
+    @DisplayName("정확히 N일 미접속 유저를 조회할 때")
+    class GetUserIdsInactiveForExactly {
+
+        @Test
+        void 마지막_접속이_정확히_N일_전인_유저만_반환한다() {
+            // given (today 2025-08-05 기준 7일 전 = 2025-07-29)
+            long target = createUser(1, LocalDateTime.of(2025, 7, 29, 10, 0)).getId();
+            createUser(2, LocalDateTime.of(2025, 7, 30, 10, 0)); // 6일 전 → 제외
+            createUser(3, LocalDateTime.of(2025, 7, 28, 10, 0)); // 8일 전 → 제외
+
+            // when
+            List<Long> result = userAccessService.getUserIdsInactiveForExactly(7);
+
+            // then
+            assertThat(result).containsExactly(target);
+        }
+
+        @Test
+        void 해당_날짜의_경계_시각을_포함한다() {
+            // given (2025-07-29 하루 구간: 00:00 포함 ~ 07-30 00:00 미포함)
+            long start = createUser(1, LocalDateTime.of(2025, 7, 29, 0, 0)).getId();
+            long end = createUser(2, LocalDateTime.of(2025, 7, 29, 23, 59, 59)).getId();
+            createUser(3, LocalDateTime.of(2025, 7, 30, 0, 0)); // 경계 밖 → 제외
+
+            // when
+            List<Long> result = userAccessService.getUserIdsInactiveForExactly(7);
+
+            // then
+            assertThat(result).containsExactlyInAnyOrder(start, end);
+        }
+    }
+
+    private User createUser(
+            int index,
+            LocalDateTime lastAccessedAt
+    ) {
+        User user = userRepository.save(
+                User.create("e" + index + "@test.com", "p" + index, "유저" + index, "h" + index, 1, Role.USER));
+        if (lastAccessedAt != null) {
+            ReflectionTestUtils.setField(user, "lastAccessedAt", lastAccessedAt);
+            userRepository.save(user);
+        }
+        return user;
+    }
+
+    private User findById(long userId) {
+        return userRepository.findById(userId).orElseThrow();
+    }
+}

--- a/src/test/resources/application-test.yml
+++ b/src/test/resources/application-test.yml
@@ -82,6 +82,9 @@ spring:
             authorization-grant-type: authorization_code
             scope: name,email
 
+app:
+  version: 1.0.0
+
 jwt:
   secret: testtesttesttesttesttesttesttesttesttesttest
 


### PR DESCRIPTION
### 1. 연관 이슈

---
- close #368

<br>

### 2. 구현 사항

---
**리텐션·콘텐츠 알림**

알림 종류별 발송 방식을 아래와 같이 구분해 구현했습니다.

| 알림 | 발송 방식 | 트리거 | 대상 / 비고 |
|---|---|---|---|
| 연속학습 끊길 위기 | FCM 푸시 | 매일 21시 | 연속 1일↑ & 오늘 미완료, 유저별 "N일" 문구 |
| 오늘 학습 미완료 | FCM 푸시 | 매일 21시 | 연속 0일 & 오늘 미완료, 랜덤 문구 |
| 장기 미접속 | FCM 푸시 | 7·14·30·60·90일 당일 1회 | 1~6일은 위 일일 알림으로 처리 |
| 새 콘텐츠 | FCM 푸시 (전체 브로드캐스트) | 새 레슨 추가 시 | 트리거는 추후 연결, 발송 메서드만 준비 |
| 공지사항 | 알림함(DB) 적재 | PUBLISHED 공지 등록 | 푸시 없음, 전체 유저 bulk insert |
| 앱 버전 체크 | 조회 API | 클라이언트 폴링 | `GET /api/v1/version`, 인증 불필요 |

> 버전 관리 푸시 알림은 이번 범위에서 제외했습니다.

<br>

**접속시각 추적 (장기 미접속 판정용)**

- 인증 요청마다 인터셉터에서 `User.lastAccessedAt`를 **하루 1회**만 조건부 갱신
- `V17` 마이그레이션으로 컬럼 추가 + 기존 유저 백필

<br>

**기타**

- 알림 타입 `STREAK_WARNING` → `CONSECUTIVE_LEARNING_WARNING` 리네임 (`V18`)
  - ⚠️ 프론트: 연속학습 위기 알림 data payload `type` 값이 위 명칭으로 변경됨
- 위 알림 서비스 메서드 통합테스트 추가
- 응답 DTO `@Schema` 포맷 통일 · `@NotNull` 정리 포함 (#370)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * FCM 푸시 알림 시스템 도입: 연속 학습 경고, 일일 미완료 리마인더, 비활동 알림, 새 콘텐츠 알림 및 관련 스케줄러/디스패처 추가
  * 앱 버전 조회 API 추가

* **Refactor**
  * 학습 서비스 구조 개선(CQRS 분리: 조회/명령 서비스 분리)
  * 사용자 마지막 접속 시간 추적 기능 추가(엔티티·업데이트·조회 흐름)

* **Chores**
  * 응답 DTO 스키마/어노테이션 및 문서화 형식 정리
<!-- end of auto-generated comment: release notes by coderabbit.ai -->