### PR TITLE
hotfix: 공지 상세 응답 OpenAPI 스키마 충돌 수정(#386)

### DIFF
--- a/src/main/java/gravit/code/admin/dto/response/NoticeDetailResponse.java
+++ b/src/main/java/gravit/code/admin/dto/response/NoticeDetailResponse.java
@@ -2,11 +2,13 @@ package gravit.code.admin.dto.response;
 
 import gravit.code.notice.domain.Notice;
 import gravit.code.notice.domain.NoticeStatus;
+import io.swagger.v3.oas.annotations.media.Schema;
 import lombok.AccessLevel;
 import lombok.Builder;
 
 import java.time.LocalDateTime;
 
+@Schema(name = "AdminNoticeDetailResponse")
 @Builder(access = AccessLevel.PRIVATE)
 public record NoticeDetailResponse(
 


### PR DESCRIPTION
### 1. 연관 이슈

---
 - close #386

<br>

### 2. 구현 사항

---
**Admin 공지 상세 응답 DTO의 OpenAPI 스키마 이름 충돌 해소**

`admin.dto.response.NoticeDetailResponse`(admin 공지 상세)와 `notice.dto.response.NoticeDetailResponse`(사용자앱 공지 상세)가 **simple name이 동일**(`NoticeDetailResponse`)했습니다. springdoc은 기본적으로 simple name을 스키마 키로 사용하는데, `@Schema(name=...)` 구분도 `springdoc.use-fqn` 설정도 없어 OpenAPI `components.schemas`에서 **두 DTO의 스키마 키가 충돌**했습니다.

**조치**: admin DTO에 `@Schema(name = "AdminNoticeDetailResponse")`를 부여해 OpenAPI에서 두 DTO를 별도 키로 분리 등록했습니다.

- admin DTO → `AdminNoticeDetailResponse`
- 사용자앱 DTO → `NoticeDetailResponse`

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## 릴리스 노트

* **Documentation**
  * API 문서화를 위한 Swagger/OpenAPI 스키마 애너테이션이 추가되어 API 명세가 더욱 명확해졌습니다.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->