### PR TITLE
fix: 관리자 공지 목록 정렬 기준 수정(#388)

### DIFF
--- a/src/main/java/gravit/code/admin/service/AdminNoticeService.java
+++ b/src/main/java/gravit/code/admin/service/AdminNoticeService.java
@@ -19,15 +19,12 @@ import gravit.code.user.repository.UserRepository;
 import lombok.RequiredArgsConstructor;
 import org.springframework.context.ApplicationEventPublisher;
 import org.springframework.data.domain.Pageable;
-import org.springframework.data.domain.Sort;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
 @Service
 @RequiredArgsConstructor
 public class AdminNoticeService {
-
-    private static final Sort NOTICE_SORT = Sort.by(Sort.Direction.DESC, "id");
 
     private final NoticeRepository noticeRepository;
     private final UserRepository userRepository;
@@ -36,9 +33,9 @@ public class AdminNoticeService {
 
     @Transactional(readOnly = true)
     public PageResponse<NoticeListItemResponse> getNotices(int page) {
-        Pageable pageable = AdminPages.of(page, NOTICE_SORT);
+        Pageable pageable = AdminPages.of(page);
 
-        return PageResponse.from(noticeRepository.findAll(pageable).map(NoticeListItemResponse::from));
+        return PageResponse.from(noticeRepository.findAllForAdmin(pageable).map(NoticeListItemResponse::from));
     }
 
     @Transactional(readOnly = true)

--- a/src/main/java/gravit/code/notice/repository/NoticeRepository.java
+++ b/src/main/java/gravit/code/notice/repository/NoticeRepository.java
@@ -32,6 +32,13 @@ public interface NoticeRepository extends JpaRepository<Notice, Long> {
             Pageable pageable
     );
 
+    @Query("""
+        select n
+        from Notice n
+        order by n.pinned desc, n.publishedAt desc nulls last, n.createdAt desc
+        """)
+    Page<Notice> findAllForAdmin(Pageable pageable);
+
     Optional<Notice> findByIdAndStatus(
             long id,
             NoticeStatus status

--- a/src/test/java/gravit/code/admin/service/AdminNoticeServiceIntegrationTest.java
+++ b/src/test/java/gravit/code/admin/service/AdminNoticeServiceIntegrationTest.java
@@ -16,6 +16,8 @@ import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
 
+import java.util.List;
+
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
 import static org.assertj.core.api.SoftAssertions.assertSoftly;
@@ -164,5 +166,56 @@ class AdminNoticeServiceIntegrationTest {
                 .isInstanceOf(RestApiException.class)
                 .extracting(e -> ((RestApiException) e).getErrorCode())
                 .isEqualTo(CustomErrorCode.NOTICE_NOT_FOUND);
+    }
+
+    @Test
+    @DisplayName("공지 목록 정렬: 핀 최상단(게시일 내림차순) → 비핀 최신순 → 미게시(DRAFT) 최후순, 페이지 경계 적용")
+    void getNotices_ordering() {
+        // 비핀 PUBLISHED 18건: 생성 순서대로 publishedAt 증가 (일반-00 이 가장 오래됨)
+        for (int i = 0; i < 18; i++) {
+            adminNoticeService.createNotice(adminId,
+                    new NoticeCreateRequest("일반-%02d".formatted(i), "요약", "본문", NoticeStatus.PUBLISHED, false));
+        }
+        // 비핀 DRAFT 1건: publishedAt 이 null 이라 NULLS LAST 로 맨 뒤
+        adminNoticeService.createNotice(adminId,
+                new NoticeCreateRequest("드래프트", "요약", "본문", NoticeStatus.DRAFT, false));
+        // 핀 PUBLISHED 3건: 가장 늦게 생성한 핀-2 가 게시일이 가장 최신
+        for (int i = 0; i < 3; i++) {
+            adminNoticeService.createNotice(adminId,
+                    new NoticeCreateRequest("핀-%d".formatted(i), "요약", "본문", NoticeStatus.PUBLISHED, true));
+        }
+
+        // 총 22건 → 1페이지 20건, 2페이지 2건
+        List<NoticeListItemResponse> page1 = adminNoticeService.getNotices(1).contents();
+        List<NoticeListItemResponse> page2 = adminNoticeService.getNotices(2).contents();
+
+        assertSoftly(softly -> {
+            softly.assertThat(page1).hasSize(20);
+            softly.assertThat(page2).hasSize(2);
+
+            // 핀 공지(3건)는 모두 1페이지 최상단
+            softly.assertThat(page1.stream().filter(NoticeListItemResponse::pinned).count()).isEqualTo(3L);
+            softly.assertThat(page1.get(0).pinned()).isTrue();
+            softly.assertThat(page1.get(1).pinned()).isTrue();
+            softly.assertThat(page1.get(2).pinned()).isTrue();
+            softly.assertThat(page1.get(3).pinned()).isFalse();
+
+            // 핀 그룹 내부는 게시일 내림차순 (핀-2 > 핀-1 > 핀-0)
+            softly.assertThat(page1.get(0).title()).isEqualTo("핀-2");
+            softly.assertThat(page1.get(1).title()).isEqualTo("핀-1");
+            softly.assertThat(page1.get(2).title()).isEqualTo("핀-0");
+            softly.assertThat(page1.get(0).publishedAt()).isAfterOrEqualTo(page1.get(1).publishedAt());
+            softly.assertThat(page1.get(1).publishedAt()).isAfterOrEqualTo(page1.get(2).publishedAt());
+
+            // 핀 바로 아래는 비핀 중 가장 최근 게시분(일반-17)
+            softly.assertThat(page1.get(3).title()).isEqualTo("일반-17");
+
+            // 2페이지는 비핀만, 미게시 DRAFT 는 publishedAt null 로 가장 마지막
+            softly.assertThat(page2.stream().anyMatch(NoticeListItemResponse::pinned)).isFalse();
+            softly.assertThat(page2.get(0).title()).isEqualTo("일반-00");
+            softly.assertThat(page2.get(0).publishedAt()).isNotNull();
+            softly.assertThat(page2.get(1).title()).isEqualTo("드래프트");
+            softly.assertThat(page2.get(1).publishedAt()).isNull();
+        });
     }
 }


### PR DESCRIPTION
### 1. 연관 이슈

---
 - close #388

<br>

### 2. 구현 사항

---
**관리자 공지 목록 정렬 변경**

`GET /api/v1/admin/notices` 정렬을 `id DESC` → `pinned DESC, publishedAt DESC NULLS LAST, createdAt DESC`로 변경. 핀 공지가 항상 최상단(게시일 내림차순), 그 아래 비핀 최신순, 미게시(DRAFT)는 맨 뒤로 정렬됩니다.

`findAll(Pageable)`의 Criteria 변환은 NULLS LAST를 지원하지 않아, `NoticeRepository.findAllForAdmin`에 ORDER BY를 명시한 `@Query`로 처리했습니다. 쿼리 레벨 정렬이라 페이지 경계에서도 정렬이 유지되며, soft-delete 제외(`@SQLRestriction`)도 그대로 적용됩니다. 응답 DTO·엔드포인트·page size(20)는 변경 없습니다.

페이지 경계(22건, 20+2)에 걸친 정렬 순서 통합 테스트를 추가했습니다.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## 릴리스 노트

* **새로운 기능**
  * 관리자 공지사항 목록의 정렬 로직을 개선했습니다. 고정된 공지사항이 우선 표시되며, 그 다음 게시된 공지사항(게시일순), 임시글 순으로 정렬됩니다.

* **테스트**
  * 공지사항 목록 조회의 정렬 및 페이지 처리 동작을 검증하는 통합 테스트를 추가했습니다.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->