### PR TITLE
feat: 관리자 본인 프로필 조회 API 추가(#390)

### DIFF
--- a/src/main/java/gravit/code/admin/controller/AdminMeController.java
+++ b/src/main/java/gravit/code/admin/controller/AdminMeController.java
@@ -1,0 +1,25 @@
+package gravit.code.admin.controller;
+
+import gravit.code.admin.controller.docs.AdminMeControllerDocs;
+import gravit.code.admin.dto.response.AdminMeResponse;
+import gravit.code.admin.service.AdminMeService;
+import gravit.code.auth.domain.LoginUser;
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.ResponseEntity;
+import org.springframework.security.core.annotation.AuthenticationPrincipal;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+@RestController
+@RequiredArgsConstructor
+@RequestMapping("/api/v1/admin/me")
+public class AdminMeController implements AdminMeControllerDocs {
+
+    private final AdminMeService adminMeService;
+
+    @GetMapping
+    public ResponseEntity<AdminMeResponse> getMe(@AuthenticationPrincipal LoginUser loginUser) {
+        return ResponseEntity.ok(adminMeService.getMe(loginUser.getId()));
+    }
+}

--- a/src/main/java/gravit/code/admin/controller/docs/AdminMeControllerDocs.java
+++ b/src/main/java/gravit/code/admin/controller/docs/AdminMeControllerDocs.java
@@ -1,0 +1,21 @@
+package gravit.code.admin.controller.docs;
+
+import gravit.code.admin.dto.response.AdminMeResponse;
+import gravit.code.auth.domain.LoginUser;
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.responses.ApiResponse;
+import io.swagger.v3.oas.annotations.responses.ApiResponses;
+import io.swagger.v3.oas.annotations.tags.Tag;
+import org.springframework.http.ResponseEntity;
+
+@Tag(name = "Admin Me API", description = "현재 로그인한 운영자 본인 프로필")
+public interface AdminMeControllerDocs {
+
+    @Operation(summary = "현재 운영자 프로필", description = "인증된 운영자 본인의 adminId·nickname·email·profileImgNumber 조회. 백오피스 사이드바 표시용.")
+    @ApiResponses({
+            @ApiResponse(responseCode = "200", description = "조회 성공"),
+            @ApiResponse(responseCode = "401", description = "미인증(토큰 없음/무효)"),
+            @ApiResponse(responseCode = "404", description = "존재하지 않는 유저")
+    })
+    ResponseEntity<AdminMeResponse> getMe(LoginUser loginUser);
+}

--- a/src/main/java/gravit/code/admin/dto/response/AdminMeResponse.java
+++ b/src/main/java/gravit/code/admin/dto/response/AdminMeResponse.java
@@ -1,0 +1,26 @@
+package gravit.code.admin.dto.response;
+
+import gravit.code.user.domain.User;
+import lombok.AccessLevel;
+import lombok.Builder;
+
+@Builder(access = AccessLevel.PRIVATE)
+public record AdminMeResponse(
+
+        long adminId,
+
+        String nickname,
+
+        String email,
+
+        int profileImgNumber
+) {
+    public static AdminMeResponse from(User user) {
+        return AdminMeResponse.builder()
+                .adminId(user.getId())
+                .nickname(user.getNickname())
+                .email(user.getEmail())
+                .profileImgNumber(user.getProfileImgNumber())
+                .build();
+    }
+}

--- a/src/main/java/gravit/code/admin/service/AdminMeService.java
+++ b/src/main/java/gravit/code/admin/service/AdminMeService.java
@@ -1,0 +1,25 @@
+package gravit.code.admin.service;
+
+import gravit.code.admin.dto.response.AdminMeResponse;
+import gravit.code.global.exception.domain.CustomErrorCode;
+import gravit.code.global.exception.domain.RestApiException;
+import gravit.code.user.domain.User;
+import gravit.code.user.repository.UserRepository;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+@Service
+@RequiredArgsConstructor
+public class AdminMeService {
+
+    private final UserRepository userRepository;
+
+    @Transactional(readOnly = true)
+    public AdminMeResponse getMe(long adminId) {
+        User admin = userRepository.findById(adminId)
+                .orElseThrow(() -> new RestApiException(CustomErrorCode.USER_NOT_FOUND));
+
+        return AdminMeResponse.from(admin);
+    }
+}

--- a/src/test/java/gravit/code/admin/service/AdminMeServiceIntegrationTest.java
+++ b/src/test/java/gravit/code/admin/service/AdminMeServiceIntegrationTest.java
@@ -1,0 +1,67 @@
+package gravit.code.admin.service;
+
+import gravit.code.admin.dto.response.AdminMeResponse;
+import gravit.code.global.exception.domain.RestApiException;
+import gravit.code.support.TCSpringBootTest;
+import gravit.code.user.domain.User;
+import gravit.code.user.fixture.UserFixtureBuilder;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Nested;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+
+import static gravit.code.global.exception.domain.CustomErrorCode.USER_NOT_FOUND;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static org.assertj.core.api.SoftAssertions.assertSoftly;
+
+@TCSpringBootTest
+class AdminMeServiceIntegrationTest {
+
+    @Autowired
+    private AdminMeService adminMeService;
+
+    @Autowired
+    private UserFixtureBuilder userFixtureBuilder;
+
+    @Nested
+    @DisplayName("현재 운영자 프로필을 조회할 때")
+    class GetMe {
+
+        @Test
+        @DisplayName("본인 정보가 AdminMeResponse 로 매핑되어 반환된다")
+        void 본인_프로필_조회에_성공한다() {
+            // given
+            User admin = userFixtureBuilder.user()
+                    .email("admin@gravit.com")
+                    .providerId("admin_provider")
+                    .nickname("운영자")
+                    .handle("admin_handle")
+                    .level(3) // UserFixtureBuilder 의 level 필드는 profileImgNumber 로 매핑된다
+                    .create();
+
+            // when
+            AdminMeResponse response = adminMeService.getMe(admin.getId());
+
+            // then
+            assertSoftly(softly -> {
+                softly.assertThat(response.adminId()).isEqualTo(admin.getId());
+                softly.assertThat(response.nickname()).isEqualTo("운영자");
+                softly.assertThat(response.email()).isEqualTo("admin@gravit.com");
+                softly.assertThat(response.profileImgNumber()).isEqualTo(3);
+            });
+        }
+
+        @Test
+        @DisplayName("존재하지 않는 유저면 USER_NOT_FOUND 예외가 발생한다")
+        void 존재하지_않는_유저면_예외가_발생한다() {
+            // given
+            long notExistUserId = 99999L;
+
+            // when & then
+            assertThatThrownBy(() -> adminMeService.getMe(notExistUserId))
+                    .isInstanceOf(RestApiException.class)
+                    .extracting(e -> ((RestApiException) e).getErrorCode())
+                    .isEqualTo(USER_NOT_FOUND);
+        }
+    }
+}


### PR DESCRIPTION
### 1. 연관 이슈

---
 - close #390

<br>

### 2. 구현 사항

---
**`GET /api/v1/admin/me` — 현재 운영자 본인 프로필 조회**

- 인증된 운영자 본인 프로필을 반환하는 엔드포인트 추가(백오피스 사이드바 표시용)
- 응답: `{ adminId, nickname, email, profileImgNumber }` — raw DTO(전역 `{success,data}` 래퍼 없음, camelCase)
- `@AuthenticationPrincipal`의 userId → `UserRepository.findById` 조회 후 `AdminMeResponse` 매핑
- 기존 `User` 엔티티·리포지토리 재사용(신규 테이블·마이그레이션·도메인 없음), 조회 전용이라 감사 로그 비대상
- 미존재 시 방어적으로 404 `USER_NOT_FOUND`(기존 `/api/v1/admin/**` → `hasRole("ADMIN")` 게이트 그대로)
- 서비스 통합 테스트 추가(정상 매핑 / `USER_NOT_FOUND`)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## 릴리스 노트

* **새로운 기능**
  * 관리자가 자신의 프로필 정보(관리자 ID, 닉네임, 이메일, 프로필 이미지 번호)를 조회하는 기능 추가

* **테스트**
  * 관리자 정보 조회 기능 통합 테스트 추가

<!-- end of auto-generated comment: release notes by coderabbit.ai -->