### PR TITLE
docs: 리드미 추가 및 미사용 코드 정리(#393)

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,0 +1,88 @@
+## Gravit Server
+
+CS(Computer Science) 학습 보조 서비스의 백엔드 서버입니다.
+
+IT 취준생이 CS 핵심 개념을 반복 학습할 수 있도록 돕는 플랫폼을 지향합니다.
+
+<br>
+
+## 기술 스택
+
+| 분류 | 기술 |
+|------|------|
+| Language | Java 21 |
+| Framework | Spring Boot 3.5.11 |
+| Build | Gradle 8.14.2 |
+| Database | PostgreSQL, JPA, Flyway |
+| Cache | Redis |
+| Security | Spring Security, OAuth2 (Google / Kakao / Naver), JWT |
+| Notification | Firebase Cloud Messaging (FCM), Spring Mail |
+| API Docs | springdoc-openapi (Swagger UI) |
+| Test | JUnit 5, AssertJ, Testcontainers, H2 |
+| Monitoring | Actuator, Micrometer, Prometheus |
+| Etc | Spring Retry, Lombok |
+
+<br>
+
+## 빌드 & 실행
+
+```bash
+./gradlew build      # 빌드 (Flyway validate 포함)
+./gradlew test       # 테스트
+./gradlew bootRun    # 로컬 실행 (Docker Compose 로 PostgreSQL, Redis 필요)
+```
+
+<br>
+
+## 디렉토리 구조
+
+각 도메인은 `Controller → (Facade) → Service → Repository` 레이어 구조를 따릅니다.
+
+```
+gravit/code
+│
+├── global              # 공통 설정, 예외, 필터, 이벤트
+├── security            # Spring Security 설정, JWT 필터
+├── auth                # OAuth 인증, 토큰 발급
+│
+├── user                # 사용자 관리
+├── friend              # 팔로우 / 팔로잉
+├── social              # 소셜 피드, 유저 추천
+│
+├── chapter             # 챕터 (최상위 학습 단위)
+├── unit                # 유닛 (챕터 하위 학습 단위)
+├── lesson              # 레슨 (유닛 하위 학습 단위)
+├── problem             # 문제
+├── option              # 객관식 선택지
+├── answer              # 주관식 정답
+├── csnote              # CS 개념 노트
+│
+├── learning            # 학습 진행도, 연속 학습
+├── dailyLearningRecord # 일별 / 주간 학습 기록
+├── bookmark            # 문제 북마크
+├── wrongAnsweredNote   # 오답 노트
+├── mission             # 미션
+├── badge               # 뱃지
+│
+├── league              # 리그
+├── userLeague          # 사용자별 리그 정보
+├── userLeagueHistory   # 리그 이력
+├── season              # 시즌 관리, 배치
+│
+├── notification        # 알림 발송, 알림 인박스
+├── fcm                 # FCM 푸시 토큰 관리
+├── notice              # 공지사항
+├── report              # 신고
+│
+├── admin               # 관리자 기능
+├── version             # 클라이언트 앱 버전 관리
+└── test                # QA 용 테스트 데이터 초기화
+```
+
+<br/>
+
+## Team
+
+| <img src="https://avatars.githubusercontent.com/u/146558936?v=4" width="130" height="130"> | <img src="https://avatars.githubusercontent.com/u/115551339?v=4" width="130" height="130"> |
+| :---: | :---: |
+| [xunxxoie](https://github.com/xunxxoie) | [sukangpunch](https://github.com/sukangpunch) |

--- a/src/main/java/gravit/code/notice/domain/Notice.java
+++ b/src/main/java/gravit/code/notice/domain/Notice.java
@@ -25,9 +25,7 @@ import org.hibernate.annotations.SQLRestriction;
 import java.time.LocalDateTime;
 import java.time.ZoneId;
 
-import static gravit.code.notice.domain.NoticeStatus.ARCHIVED;
-import static gravit.code.notice.domain.NoticeStatus.DRAFT;
-import static gravit.code.notice.domain.NoticeStatus.PUBLISHED;
+import static gravit.code.notice.domain.NoticeStatus.*;
 import static java.time.temporal.ChronoUnit.MICROS;
 
 @Entity

--- a/src/main/java/gravit/code/notification/facade/NotificationFacade.java
+++ b/src/main/java/gravit/code/notification/facade/NotificationFacade.java
@@ -12,6 +12,8 @@ import gravit.code.notification.service.NotificationService;
 import gravit.code.notification.support.NotificationMessageProvider;
 import gravit.code.season.service.SeasonService;
 import gravit.code.user.service.UserAccessService;
+import lombok.RequiredArgsConstructor;
+
 import java.time.Clock;
 import java.time.LocalDate;
 import java.time.LocalDateTime;
@@ -20,7 +22,6 @@ import java.util.List;
 import java.util.Map;
 import java.util.Optional;
 import java.util.function.Supplier;
-import lombok.RequiredArgsConstructor;
 
 @Facade
 @RequiredArgsConstructor

--- a/src/main/java/gravit/code/problem/dto/response/ProblemResponse.java
+++ b/src/main/java/gravit/code/problem/dto/response/ProblemResponse.java
@@ -2,10 +2,8 @@ package gravit.code.problem.dto.response;
 
 import com.fasterxml.jackson.annotation.JsonInclude;
 import com.fasterxml.jackson.annotation.JsonProperty;
-import gravit.code.answer.domain.Answer;
 import gravit.code.answer.dto.response.AnswerResponse;
 import gravit.code.option.dto.response.OptionResponse;
-import gravit.code.problem.domain.Problem;
 import gravit.code.problem.domain.ProblemType;
 import io.swagger.v3.oas.annotations.media.Schema;
 import lombok.AccessLevel;
@@ -93,36 +91,6 @@ public record ProblemResponse(
                         .answerResponse(null)
                         .options(options)
                         .isBookmarked(problemDetailResponse.isBookmarked())
-                        .build();
-        }
-
-        public static ProblemResponse createSubjectiveProblemForAdmin(
-                Problem problem,
-                Answer answer
-        ){
-                return ProblemResponse.builder()
-                        .problemId(problem.getId())
-                        .problemType(problem.getProblemType())
-                        .instruction(problem.getInstruction())
-                        .content(problem.getContent())
-                        .answerResponse(AnswerResponse.from(answer))
-                        .options(null)
-                        .isBookmarked(false)
-                        .build();
-        }
-
-        public static ProblemResponse createObjectiveProblemForAdmin(
-                Problem problem,
-                List<OptionResponse> options
-        ){
-                return ProblemResponse.builder()
-                        .problemId(problem.getId())
-                        .problemType(problem.getProblemType())
-                        .instruction(problem.getInstruction())
-                        .content(problem.getContent())
-                        .answerResponse(null)
-                        .options(options)
-                        .isBookmarked(false)
                         .build();
         }
 }

--- a/src/main/java/gravit/code/season/batch/SeasonBatchService.java
+++ b/src/main/java/gravit/code/season/batch/SeasonBatchService.java
@@ -1,5 +1,6 @@
 package gravit.code.season.batch;
 
+import gravit.code.global.event.SeasonRolledOverEvent;
 import gravit.code.global.exception.domain.CustomErrorCode;
 import gravit.code.global.exception.domain.RestApiException;
 import gravit.code.season.calendar.SeasonCalendar;
@@ -8,7 +9,6 @@ import gravit.code.season.repository.SeasonRepository;
 import gravit.code.season.service.port.SeasonClosedCache;
 import gravit.code.userLeague.repository.UserLeagueRepository;
 import gravit.code.userLeagueHistory.repository.UserLeagueHistoryRepository;
-import gravit.code.global.event.SeasonRolledOverEvent;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.context.ApplicationEventPublisher;

--- a/src/main/java/gravit/code/season/service/SeasonService.java
+++ b/src/main/java/gravit/code/season/service/SeasonService.java
@@ -7,13 +7,13 @@ import gravit.code.season.calendar.dto.SeasonDto;
 import gravit.code.season.domain.Season;
 import gravit.code.season.domain.SeasonStatus;
 import gravit.code.season.repository.SeasonRepository;
-import java.time.LocalDateTime;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.dao.DataIntegrityViolationException;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
+import java.time.LocalDateTime;
 import java.util.Optional;
 
 @Service

--- a/src/test/java/gravit/code/admin/service/AdminProblemServiceIntegrationTest.java
+++ b/src/test/java/gravit/code/admin/service/AdminProblemServiceIntegrationTest.java
@@ -21,7 +21,6 @@ import org.springframework.beans.factory.annotation.Autowired;
 
 import java.util.List;
 
-import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
 import static org.assertj.core.api.SoftAssertions.assertSoftly;
 

--- a/src/test/java/gravit/code/admin/service/AdminStagingServiceIntegrationTest.java
+++ b/src/test/java/gravit/code/admin/service/AdminStagingServiceIntegrationTest.java
@@ -19,10 +19,10 @@ import gravit.code.global.dto.response.PageResponse;
 import gravit.code.global.exception.domain.CustomErrorCode;
 import gravit.code.global.exception.domain.RestApiException;
 import gravit.code.problem.domain.ProblemType;
+import gravit.code.support.TCSpringBootTest;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
-import gravit.code.support.TCSpringBootTest;
 
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;

--- a/src/test/java/gravit/code/answer/service/AnswerQueryServiceIntegrationTest.java
+++ b/src/test/java/gravit/code/answer/service/AnswerQueryServiceIntegrationTest.java
@@ -1,20 +1,21 @@
 package gravit.code.answer.service;
 
-import static org.assertj.core.api.Assertions.assertThat;
-import static org.assertj.core.api.SoftAssertions.assertSoftly;
-
 import gravit.code.answer.domain.Answer;
 import gravit.code.answer.dto.response.AnswerResponse;
 import gravit.code.answer.repository.AnswerRepository;
 import gravit.code.problem.domain.ProblemType;
 import gravit.code.problem.dto.response.ProblemDetailResponse;
 import gravit.code.support.TCSpringBootTest;
-import java.util.List;
-import java.util.Map;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Nested;
 import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
+
+import java.util.List;
+import java.util.Map;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.SoftAssertions.assertSoftly;
 
 @TCSpringBootTest
 class AnswerQueryServiceIntegrationTest {

--- a/src/test/java/gravit/code/bookmark/service/BookmarkServiceUnitTest.java
+++ b/src/test/java/gravit/code/bookmark/service/BookmarkServiceUnitTest.java
@@ -23,7 +23,8 @@ import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
 import static org.assertj.core.api.SoftAssertions.assertSoftly;
 import static org.mockito.ArgumentMatchers.any;
-import static org.mockito.Mockito.*;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
 
 @ExtendWith(MockitoExtension.class)
 class BookmarkServiceUnitTest {

--- a/src/test/java/gravit/code/friend/service/FriendServiceTest.java
+++ b/src/test/java/gravit/code/friend/service/FriendServiceTest.java
@@ -1,8 +1,5 @@
 package gravit.code.friend.service;
 
-import static org.assertj.core.api.Assertions.assertThat;
-import static org.assertj.core.api.Assertions.assertThatThrownBy;
-
 import gravit.code.friend.dto.response.FollowerResponse;
 import gravit.code.friend.fixture.FriendFixture;
 import gravit.code.global.dto.response.SliceResponse;
@@ -10,9 +7,13 @@ import gravit.code.global.exception.domain.RestApiException;
 import gravit.code.support.TCSpringBootTest;
 import gravit.code.user.domain.User;
 import gravit.code.user.fixture.UserFixture;
-import java.util.List;
 import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
+
+import java.util.List;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
 
 @TCSpringBootTest
 class FriendServiceTest {

--- a/src/test/java/gravit/code/league/service/LeagueServiceTest.java
+++ b/src/test/java/gravit/code/league/service/LeagueServiceTest.java
@@ -1,8 +1,5 @@
 package gravit.code.league.service;
 
-import static org.assertj.core.api.Assertions.assertThat;
-import static org.assertj.core.api.SoftAssertions.assertSoftly;
-
 import gravit.code.league.domain.League;
 import gravit.code.league.dto.response.LeagueHomeResponse;
 import gravit.code.league.fixture.LeagueFixture;
@@ -19,6 +16,9 @@ import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Nested;
 import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.SoftAssertions.assertSoftly;
 
 
 @TCSpringBootTest

--- a/src/test/java/gravit/code/lesson/facade/LessonFacadeUnitTest.java
+++ b/src/test/java/gravit/code/lesson/facade/LessonFacadeUnitTest.java
@@ -1,6 +1,7 @@
 package gravit.code.lesson.facade;
 
 import gravit.code.bookmark.service.BookmarkService;
+import gravit.code.global.event.LessonCompletedEvent;
 import gravit.code.learning.dto.internal.ConsecutiveSolvedDto;
 import gravit.code.learning.dto.internal.LearningIdsDto;
 import gravit.code.learning.dto.request.LearningSubmissionSaveRequest;
@@ -33,9 +34,8 @@ import java.util.List;
 
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.SoftAssertions.assertSoftly;
-import gravit.code.global.event.LessonCompletedEvent;
-
-import static org.mockito.ArgumentMatchers.*;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.eq;
 import static org.mockito.Mockito.*;
 
 @ExtendWith(MockitoExtension.class)

--- a/src/test/java/gravit/code/notification/facade/NotificationFacadeIntegrationTest.java
+++ b/src/test/java/gravit/code/notification/facade/NotificationFacadeIntegrationTest.java
@@ -28,9 +28,7 @@ import java.util.List;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.SoftAssertions.assertSoftly;
 import static org.mockito.ArgumentMatchers.anyList;
-import static org.mockito.Mockito.never;
-import static org.mockito.Mockito.timeout;
-import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.*;
 
 @TCSpringBootTest
 class NotificationFacadeIntegrationTest {

--- a/src/test/java/gravit/code/notification/listener/NotificationEventListenerIntegrationTest.java
+++ b/src/test/java/gravit/code/notification/listener/NotificationEventListenerIntegrationTest.java
@@ -12,9 +12,7 @@ import org.springframework.test.context.bean.override.mockito.MockitoBean;
 import org.springframework.test.context.transaction.TestTransaction;
 import org.springframework.transaction.annotation.Transactional;
 
-import static org.mockito.Mockito.after;
-import static org.mockito.Mockito.timeout;
-import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.*;
 
 @TCSpringBootTest
 class NotificationEventListenerIntegrationTest {

--- a/src/test/java/gravit/code/problem/facade/ProblemFacadeTest.java
+++ b/src/test/java/gravit/code/problem/facade/ProblemFacadeTest.java
@@ -1,7 +1,5 @@
 package gravit.code.problem.facade;
 
-import static org.junit.jupiter.api.Assertions.*;
-
 class ProblemFacadeTest {
 
 }

--- a/src/test/java/gravit/code/season/batch/SeasonBatchSchedulerTest.java
+++ b/src/test/java/gravit/code/season/batch/SeasonBatchSchedulerTest.java
@@ -14,13 +14,8 @@ import org.springframework.scheduling.support.CronExpression;
 
 import java.time.LocalDateTime;
 
-import static org.assertj.core.api.Assertions.assertThat;
-import static org.assertj.core.api.Assertions.assertThatNoException;
-import static org.assertj.core.api.Assertions.assertThatThrownBy;
-import static org.mockito.Mockito.doNothing;
-import static org.mockito.Mockito.doThrow;
-import static org.mockito.Mockito.times;
-import static org.mockito.Mockito.verify;
+import static org.assertj.core.api.Assertions.*;
+import static org.mockito.Mockito.*;
 
 @ExtendWith(MockitoExtension.class)
 class SeasonBatchSchedulerTest {

--- a/src/test/java/gravit/code/season/batch/SeasonBatchServiceTest.java
+++ b/src/test/java/gravit/code/season/batch/SeasonBatchServiceTest.java
@@ -1,9 +1,5 @@
 package gravit.code.season.batch;
 
-import static org.assertj.core.api.Assertions.assertThat;
-import static org.assertj.core.api.Assertions.assertThatThrownBy;
-import static org.assertj.core.api.SoftAssertions.assertSoftly;
-
 import gravit.code.global.event.SeasonRolledOverEvent;
 import gravit.code.global.exception.domain.RestApiException;
 import gravit.code.league.domain.League;
@@ -28,6 +24,10 @@ import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.test.context.event.ApplicationEvents;
 import org.springframework.test.context.event.RecordApplicationEvents;
 import org.springframework.transaction.support.TransactionTemplate;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static org.assertj.core.api.SoftAssertions.assertSoftly;
 
 
 @TCSpringBootTest

--- a/src/test/java/gravit/code/season/calendar/SeasonCalendarTest.java
+++ b/src/test/java/gravit/code/season/calendar/SeasonCalendarTest.java
@@ -1,15 +1,16 @@
 package gravit.code.season.calendar;
 
-import static org.assertj.core.api.SoftAssertions.assertSoftly;
-
 import gravit.code.season.calendar.dto.SeasonDto;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Nested;
+import org.junit.jupiter.api.Test;
+
 import java.time.Clock;
 import java.time.LocalDate;
 import java.time.LocalDateTime;
 import java.time.ZoneId;
-import org.junit.jupiter.api.DisplayName;
-import org.junit.jupiter.api.Nested;
-import org.junit.jupiter.api.Test;
+
+import static org.assertj.core.api.SoftAssertions.assertSoftly;
 
 class SeasonCalendarTest {
 

--- a/src/test/java/gravit/code/season/fixture/SeasonFixture.java
+++ b/src/test/java/gravit/code/season/fixture/SeasonFixture.java
@@ -1,9 +1,10 @@
 package gravit.code.season.fixture;
 
 import gravit.code.season.domain.Season;
-import java.time.LocalDateTime;
 import lombok.RequiredArgsConstructor;
 import org.springframework.boot.test.context.TestComponent;
+
+import java.time.LocalDateTime;
 
 @TestComponent
 @RequiredArgsConstructor

--- a/src/test/java/gravit/code/season/fixture/SeasonFixtureBuilder.java
+++ b/src/test/java/gravit/code/season/fixture/SeasonFixtureBuilder.java
@@ -2,9 +2,10 @@ package gravit.code.season.fixture;
 
 import gravit.code.season.domain.Season;
 import gravit.code.season.repository.SeasonRepository;
-import java.time.LocalDateTime;
 import lombok.RequiredArgsConstructor;
 import org.springframework.boot.test.context.TestComponent;
+
+import java.time.LocalDateTime;
 
 @TestComponent
 @RequiredArgsConstructor

--- a/src/test/java/gravit/code/season/service/SeasonServiceTest.java
+++ b/src/test/java/gravit/code/season/service/SeasonServiceTest.java
@@ -1,16 +1,17 @@
 package gravit.code.season.service;
 
-import static org.assertj.core.api.Assertions.assertThat;
-import static org.assertj.core.api.SoftAssertions.assertSoftly;
-
 import gravit.code.season.domain.Season;
 import gravit.code.season.domain.SeasonStatus;
 import gravit.code.season.fixture.SeasonFixture;
 import gravit.code.support.TCSpringBootTest;
-import java.time.LocalDateTime;
-import java.util.Optional;
 import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
+
+import java.time.LocalDateTime;
+import java.util.Optional;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.SoftAssertions.assertSoftly;
 
 
 @TCSpringBootTest

--- a/src/test/java/gravit/code/social/facade/SocialFacadeIntegrationTest.java
+++ b/src/test/java/gravit/code/social/facade/SocialFacadeIntegrationTest.java
@@ -1,13 +1,6 @@
 package gravit.code.social.facade;
 
-import static gravit.code.global.exception.domain.CustomErrorCode.CANNOT_CONGRATULATE_OWN_FEED;
-import static gravit.code.global.exception.domain.CustomErrorCode.CONGRATULATE_LIMIT_EXCEEDED;
-import static org.assertj.core.api.Assertions.assertThat;
-import static org.assertj.core.api.Assertions.assertThatThrownBy;
-import static org.assertj.core.api.SoftAssertions.assertSoftly;
-
 import gravit.code.friend.fixture.FriendFixture;
-import gravit.code.social.domain.FeedEventType;
 import gravit.code.global.dto.response.SliceResponse;
 import gravit.code.global.exception.domain.RestApiException;
 import gravit.code.league.domain.League;
@@ -17,6 +10,7 @@ import gravit.code.notification.domain.NotificationType;
 import gravit.code.notification.repository.NotificationRepository;
 import gravit.code.season.domain.Season;
 import gravit.code.season.fixture.SeasonFixture;
+import gravit.code.social.domain.FeedEventType;
 import gravit.code.social.domain.SocialFeed;
 import gravit.code.social.dto.response.RecommendUserResponse;
 import gravit.code.social.dto.response.SocialFeedResponse;
@@ -27,11 +21,18 @@ import gravit.code.user.fixture.UserFixture;
 import gravit.code.userLeague.domain.UserLeague;
 import gravit.code.userLeague.fixture.UserLeagueFixture;
 import gravit.code.userLeague.repository.UserLeagueRepository;
-import java.util.List;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Nested;
 import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
+
+import java.util.List;
+
+import static gravit.code.global.exception.domain.CustomErrorCode.CANNOT_CONGRATULATE_OWN_FEED;
+import static gravit.code.global.exception.domain.CustomErrorCode.CONGRATULATE_LIMIT_EXCEEDED;
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static org.assertj.core.api.SoftAssertions.assertSoftly;
 
 @TCSpringBootTest
 class SocialFacadeIntegrationTest {

--- a/src/test/java/gravit/code/social/listener/SocialFeedEventListenerIntegrationTest.java
+++ b/src/test/java/gravit/code/social/listener/SocialFeedEventListenerIntegrationTest.java
@@ -1,14 +1,5 @@
 package gravit.code.social.listener;
 
-import static java.util.concurrent.TimeUnit.SECONDS;
-import static org.assertj.core.api.Assertions.assertThat;
-import static org.awaitility.Awaitility.await;
-import static org.mockito.ArgumentMatchers.any;
-import static org.mockito.ArgumentMatchers.anyLong;
-import static org.mockito.Mockito.after;
-import static org.mockito.Mockito.timeout;
-import static org.mockito.Mockito.verify;
-
 import gravit.code.dailyLearningRecord.service.DailyLearningRecordService;
 import gravit.code.global.event.LessonCompletedEvent;
 import gravit.code.global.event.LevelUpFeedEvent;
@@ -28,6 +19,13 @@ import org.springframework.test.context.bean.override.mockito.MockitoBean;
 import org.springframework.test.context.bean.override.mockito.MockitoSpyBean;
 import org.springframework.test.context.transaction.TestTransaction;
 import org.springframework.transaction.annotation.Transactional;
+
+import static java.util.concurrent.TimeUnit.SECONDS;
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.awaitility.Awaitility.await;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.anyLong;
+import static org.mockito.Mockito.*;
 
 @TCSpringBootTest
 class SocialFeedEventListenerIntegrationTest {

--- a/src/test/java/gravit/code/social/service/CongratulationServiceIntegrationTest.java
+++ b/src/test/java/gravit/code/social/service/CongratulationServiceIntegrationTest.java
@@ -1,19 +1,20 @@
 package gravit.code.social.service;
 
-import static gravit.code.global.exception.domain.CustomErrorCode.ALREADY_CONGRATULATED;
-import static gravit.code.global.exception.domain.CustomErrorCode.CONGRATULATE_LIMIT_EXCEEDED;
-import static org.assertj.core.api.Assertions.assertThat;
-import static org.assertj.core.api.Assertions.assertThatThrownBy;
-
 import gravit.code.global.exception.domain.RestApiException;
 import gravit.code.social.domain.Congratulation;
 import gravit.code.social.repository.CongratulationRepository;
 import gravit.code.support.TCSpringBootTest;
-import java.util.List;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Nested;
 import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
+
+import java.util.List;
+
+import static gravit.code.global.exception.domain.CustomErrorCode.ALREADY_CONGRATULATED;
+import static gravit.code.global.exception.domain.CustomErrorCode.CONGRATULATE_LIMIT_EXCEEDED;
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
 
 @TCSpringBootTest
 class CongratulationServiceIntegrationTest {

--- a/src/test/java/gravit/code/social/service/SocialFeedServiceIntegrationTest.java
+++ b/src/test/java/gravit/code/social/service/SocialFeedServiceIntegrationTest.java
@@ -1,8 +1,5 @@
 package gravit.code.social.service;
 
-import static org.assertj.core.api.Assertions.assertThat;
-import static org.assertj.core.api.SoftAssertions.assertSoftly;
-
 import gravit.code.friend.fixture.FriendFixture;
 import gravit.code.global.dto.response.SliceResponse;
 import gravit.code.social.domain.FeedEventType;
@@ -13,11 +10,15 @@ import gravit.code.social.repository.SocialFeedRepository;
 import gravit.code.support.TCSpringBootTest;
 import gravit.code.user.domain.User;
 import gravit.code.user.fixture.UserFixture;
-import java.util.List;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Nested;
 import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
+
+import java.util.List;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.SoftAssertions.assertSoftly;
 
 @TCSpringBootTest
 class SocialFeedServiceIntegrationTest {

--- a/src/test/java/gravit/code/social/service/UserFeedServiceIntegrationTest.java
+++ b/src/test/java/gravit/code/social/service/UserFeedServiceIntegrationTest.java
@@ -1,20 +1,21 @@
 package gravit.code.social.service;
 
-import static gravit.code.global.exception.domain.CustomErrorCode.USER_FEED_NOT_FOUND;
-import static org.assertj.core.api.Assertions.assertThat;
-import static org.assertj.core.api.Assertions.assertThatThrownBy;
-import static org.assertj.core.api.SoftAssertions.assertSoftly;
-
 import gravit.code.global.exception.domain.RestApiException;
 import gravit.code.social.domain.UserFeed;
 import gravit.code.social.fixture.UserFeedFixture;
 import gravit.code.social.repository.UserFeedRepository;
 import gravit.code.support.TCSpringBootTest;
-import java.util.List;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Nested;
 import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
+
+import java.util.List;
+
+import static gravit.code.global.exception.domain.CustomErrorCode.USER_FEED_NOT_FOUND;
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static org.assertj.core.api.SoftAssertions.assertSoftly;
 
 @TCSpringBootTest
 class UserFeedServiceIntegrationTest {

--- a/src/test/java/gravit/code/support/FixedClockConfig.java
+++ b/src/test/java/gravit/code/support/FixedClockConfig.java
@@ -1,11 +1,12 @@
 package gravit.code.support;
 
-import java.time.Clock;
-import java.time.OffsetDateTime;
-import java.time.ZoneId;
 import org.springframework.boot.test.context.TestConfiguration;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Primary;
+
+import java.time.Clock;
+import java.time.OffsetDateTime;
+import java.time.ZoneId;
 
 @TestConfiguration
 public class FixedClockConfig {

--- a/src/test/java/gravit/code/support/TCSpringBootTest.java
+++ b/src/test/java/gravit/code/support/TCSpringBootTest.java
@@ -1,9 +1,5 @@
 package gravit.code.support;
 
-import java.lang.annotation.ElementType;
-import java.lang.annotation.Retention;
-import java.lang.annotation.RetentionPolicy;
-import java.lang.annotation.Target;
 import org.junit.jupiter.api.extension.ExtendWith;
 import org.springframework.boot.test.autoconfigure.jdbc.AutoConfigureTestDatabase;
 import org.springframework.boot.test.context.SpringBootTest;
@@ -11,6 +7,11 @@ import org.springframework.context.annotation.ComponentScan;
 import org.springframework.context.annotation.Import;
 import org.springframework.test.context.ActiveProfiles;
 import org.springframework.test.context.ContextConfiguration;
+
+import java.lang.annotation.ElementType;
+import java.lang.annotation.Retention;
+import java.lang.annotation.RetentionPolicy;
+import java.lang.annotation.Target;
 
 @ComponentScan(basePackages = "gravit.code")
 @Target(ElementType.TYPE)

--- a/src/test/java/gravit/code/unit/facade/UnitFacadeUnitTest.java
+++ b/src/test/java/gravit/code/unit/facade/UnitFacadeUnitTest.java
@@ -16,7 +16,6 @@ import org.mockito.junit.jupiter.MockitoExtension;
 
 import java.util.List;
 
-import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.SoftAssertions.assertSoftly;
 import static org.mockito.Mockito.when;
 

--- a/src/test/java/gravit/code/unit/service/UnitQueryServiceIntegrationTest.java
+++ b/src/test/java/gravit/code/unit/service/UnitQueryServiceIntegrationTest.java
@@ -22,9 +22,7 @@ import org.springframework.test.context.jdbc.Sql;
 import java.util.List;
 
 import static gravit.code.global.exception.domain.CustomErrorCode.UNIT_NOT_FOUND;
-import static gravit.code.unit.domain.UnitProgressStatus.COMPLETED;
-import static gravit.code.unit.domain.UnitProgressStatus.IN_PROGRESS;
-import static gravit.code.unit.domain.UnitProgressStatus.NOT_STARTED;
+import static gravit.code.unit.domain.UnitProgressStatus.*;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
 import static org.assertj.core.api.SoftAssertions.assertSoftly;

--- a/src/test/java/gravit/code/user/facade/UserFacadeIntegrationTest.java
+++ b/src/test/java/gravit/code/user/facade/UserFacadeIntegrationTest.java
@@ -39,9 +39,7 @@ import java.time.LocalDate;
 import java.time.LocalDateTime;
 import java.time.ZoneId;
 
-import static gravit.code.global.exception.domain.CustomErrorCode.LEARNING_NOT_FOUND;
-import static gravit.code.global.exception.domain.CustomErrorCode.USER_LEAGUE_NOT_FOUND;
-import static gravit.code.global.exception.domain.CustomErrorCode.USER_NOT_FOUND;
+import static gravit.code.global.exception.domain.CustomErrorCode.*;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
 import static org.assertj.core.api.SoftAssertions.assertSoftly;
 

--- a/src/test/java/gravit/code/user/service/UserDeletionServiceIntegrationTest.java
+++ b/src/test/java/gravit/code/user/service/UserDeletionServiceIntegrationTest.java
@@ -13,12 +13,9 @@ import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.test.context.bean.override.mockito.MockitoBean;
 
-import static gravit.code.global.exception.domain.CustomErrorCode.DEST_NOT_VALID;
-import static gravit.code.global.exception.domain.CustomErrorCode.INVALID_MAIL_AUTH_CODE;
-import static gravit.code.global.exception.domain.CustomErrorCode.USER_NOT_FOUND;
+import static gravit.code.global.exception.domain.CustomErrorCode.*;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
-
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.Mockito.times;
 import static org.mockito.Mockito.verify;

--- a/src/test/java/gravit/code/user/service/UserServiceIntegrationTest.java
+++ b/src/test/java/gravit/code/user/service/UserServiceIntegrationTest.java
@@ -17,12 +17,7 @@ import org.junit.jupiter.api.Nested;
 import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
 
-import static gravit.code.global.exception.domain.CustomErrorCode.ALREADY_ONBOARDING;
-import static gravit.code.global.exception.domain.CustomErrorCode.NICKNAME_LENGTH_INVALID;
-import static gravit.code.global.exception.domain.CustomErrorCode.PROFILE_IMG_NUM_INVALID;
-import static gravit.code.global.exception.domain.CustomErrorCode.USER_NOT_FOUND;
-import static gravit.code.global.exception.domain.CustomErrorCode.USER_PAGE_NOT_FOUND;
-import static gravit.code.global.exception.domain.CustomErrorCode.USER_RESTORE_ONLY_POSSIBLE_DELETED_STATUS_USER;
+import static gravit.code.global.exception.domain.CustomErrorCode.*;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
 import static org.assertj.core.api.SoftAssertions.assertSoftly;

--- a/src/test/java/gravit/code/userLeague/service/UserLeagueServiceIntegrationTest.java
+++ b/src/test/java/gravit/code/userLeague/service/UserLeagueServiceIntegrationTest.java
@@ -24,9 +24,7 @@ import org.springframework.beans.factory.annotation.Autowired;
 import java.time.LocalDateTime;
 import java.time.ZoneId;
 
-import static gravit.code.global.exception.domain.CustomErrorCode.USER_LEAGUE_CONFLICT;
-import static gravit.code.global.exception.domain.CustomErrorCode.USER_LEAGUE_NOT_FOUND;
-import static gravit.code.global.exception.domain.CustomErrorCode.USER_NOT_FOUND;
+import static gravit.code.global.exception.domain.CustomErrorCode.*;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
 import static org.assertj.core.api.SoftAssertions.assertSoftly;

--- a/src/test/java/gravit/code/userLeagueHistory/service/LeagueHistoryServiceTest.java
+++ b/src/test/java/gravit/code/userLeagueHistory/service/LeagueHistoryServiceTest.java
@@ -1,9 +1,5 @@
 package gravit.code.userLeagueHistory.service;
 
-import static org.assertj.core.api.Assertions.assertThat;
-import static org.assertj.core.api.Assertions.assertThatThrownBy;
-import static org.assertj.core.api.SoftAssertions.assertSoftly;
-
 import gravit.code.global.exception.domain.RestApiException;
 import gravit.code.league.domain.League;
 import gravit.code.league.dto.response.LeagueHistoryResponse;
@@ -20,6 +16,10 @@ import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Nested;
 import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static org.assertj.core.api.SoftAssertions.assertSoftly;
 
 @TCSpringBootTest
 class LeagueHistoryServiceTest {


### PR DESCRIPTION
### 1. 연관 이슈

---
 - close #393

<br>

### 2. 구현 사항

---
**README 추가**

프로젝트 소개, 기술 스택, 빌드/실행 방법을 담은 `README.md`를 추가했습니다.

**미사용 코드 정리**

더 이상 참조되지 않는 `ProblemResponse` DTO를 제거하고, 사용하지 않는 import·변수 등 불필요한 코드를 테스트 및 도메인 전반에서 정리했습니다.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

# 릴리스 노트

* **문서**
  * 프로젝트 개요, 기술 스택, 빌드/테스트 방법, 디렉토리 구조, 팀 정보를 포함한 종합 README 추가

* **리팩토링**
  * 코드 정렬 및 임포트 구성 최적화로 코드 가독성 개선
  * 테스트 코드 임포트 정리 및 정규화

<!-- end of auto-generated comment: release notes by coderabbit.ai -->