### PR TITLE
feat: 알림 인박스 조회 API 구현 및 팔로우 알림 개선

### DIFF
--- a/src/main/java/gravit/code/friend/repository/FriendRepository.java
+++ b/src/main/java/gravit/code/friend/repository/FriendRepository.java
@@ -12,6 +12,7 @@ import org.springframework.data.repository.query.Param;
 
 import java.util.List;
 import java.util.Optional;
+import java.util.Set;
 
 public interface FriendRepository extends JpaRepository<Friend, Long>, FriendSearchRepository {
     boolean existsByFollowerIdAndFolloweeId(
@@ -82,4 +83,10 @@ public interface FriendRepository extends JpaRepository<Friend, Long>, FriendSea
 
     @Query("SELECT f.followerId FROM Friend f WHERE f.followeeId = :followeeId")
     List<Long> findFollowerIdsByFolloweeId(@Param("followeeId") long followeeId);
+
+    @Query("SELECT f.followeeId FROM Friend f WHERE f.followerId = :followerId AND f.followeeId IN :followeeIds")
+    Set<Long> findFollowingIdsAmong(
+            @Param("followerId") long followerId,
+            @Param("followeeIds") Set<Long> followeeIds
+    );
 }

--- a/src/main/java/gravit/code/friend/service/FriendService.java
+++ b/src/main/java/gravit/code/friend/service/FriendService.java
@@ -25,6 +25,7 @@ import org.springframework.transaction.annotation.Transactional;
 
 import java.util.List;
 import java.util.Optional;
+import java.util.Set;
 
 
 @Slf4j
@@ -136,6 +137,14 @@ public class FriendService {
     @Transactional(readOnly = true)
     public List<Long> getFollowerIds(long followeeId) {
         return friendRepository.findFollowerIdsByFolloweeId(followeeId);
+    }
+
+    @Transactional(readOnly = true)
+    public Set<Long> followingIdsAmong(
+            long followerId,
+            Set<Long> followeeIds
+    ) {
+        return friendRepository.findFollowingIdsAmong(followerId, followeeIds);
     }
 
     @Transactional(readOnly = true)

--- a/src/main/java/gravit/code/notification/controller/NotificationController.java
+++ b/src/main/java/gravit/code/notification/controller/NotificationController.java
@@ -5,14 +5,17 @@ import gravit.code.global.dto.response.SliceResponse;
 import gravit.code.notification.controller.docs.NotificationDocs;
 import gravit.code.notification.dto.response.NotificationResponse;
 import gravit.code.notification.facade.NotificationFacade;
+import jakarta.validation.constraints.Min;
 import lombok.RequiredArgsConstructor;
 import org.springframework.http.ResponseEntity;
 import org.springframework.security.core.annotation.AuthenticationPrincipal;
+import org.springframework.validation.annotation.Validated;
 import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RequestParam;
 import org.springframework.web.bind.annotation.RestController;
 
+@Validated
 @RestController
 @RequestMapping("/api/v1/notifications")
 @RequiredArgsConstructor
@@ -23,7 +26,7 @@ public class NotificationController implements NotificationDocs {
     @GetMapping
     public ResponseEntity<SliceResponse<NotificationResponse>> getInbox(
             @AuthenticationPrincipal LoginUser loginUser,
-            @RequestParam(defaultValue = "0") int page
+            @RequestParam(defaultValue = "0") @Min(0) int page
     ) {
         SliceResponse<NotificationResponse> inbox = notificationFacade.getInbox(loginUser.getId(), page);
         return ResponseEntity.ok(inbox);

--- a/src/main/java/gravit/code/notification/controller/NotificationController.java
+++ b/src/main/java/gravit/code/notification/controller/NotificationController.java
@@ -1,0 +1,31 @@
+package gravit.code.notification.controller;
+
+import gravit.code.auth.domain.LoginUser;
+import gravit.code.global.dto.response.SliceResponse;
+import gravit.code.notification.controller.docs.NotificationDocs;
+import gravit.code.notification.dto.response.NotificationResponse;
+import gravit.code.notification.facade.NotificationFacade;
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.ResponseEntity;
+import org.springframework.security.core.annotation.AuthenticationPrincipal;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RequestParam;
+import org.springframework.web.bind.annotation.RestController;
+
+@RestController
+@RequestMapping("/api/v1/notifications")
+@RequiredArgsConstructor
+public class NotificationController implements NotificationDocs {
+
+    private final NotificationFacade notificationFacade;
+
+    @GetMapping
+    public ResponseEntity<SliceResponse<NotificationResponse>> getInbox(
+            @AuthenticationPrincipal LoginUser loginUser,
+            @RequestParam(defaultValue = "0") int page
+    ) {
+        SliceResponse<NotificationResponse> inbox = notificationFacade.getInbox(loginUser.getId(), page);
+        return ResponseEntity.ok(inbox);
+    }
+}

--- a/src/main/java/gravit/code/notification/controller/docs/NotificationDocs.java
+++ b/src/main/java/gravit/code/notification/controller/docs/NotificationDocs.java
@@ -1,0 +1,85 @@
+package gravit.code.notification.controller.docs;
+
+import gravit.code.auth.domain.LoginUser;
+import gravit.code.global.dto.response.SliceResponse;
+import gravit.code.notification.dto.response.NotificationResponse;
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.Parameter;
+import io.swagger.v3.oas.annotations.media.Content;
+import io.swagger.v3.oas.annotations.media.ExampleObject;
+import io.swagger.v3.oas.annotations.responses.ApiResponse;
+import io.swagger.v3.oas.annotations.responses.ApiResponses;
+import io.swagger.v3.oas.annotations.tags.Tag;
+import org.springframework.http.ResponseEntity;
+import org.springframework.security.core.annotation.AuthenticationPrincipal;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.RequestParam;
+
+@Tag(name = "Notification API", description = "알림 인박스 조회")
+public interface NotificationDocs {
+
+    @Operation(
+            summary = "알림 인박스 조회",
+            description = """
+                    로그인 유저의 알림 목록을 최신순으로 반환합니다. (20개/페이지)
+
+                    **actionType 결정 규칙:**
+                    - FOLLOW 타입: 현재 팔로우 관계 기준으로 동적 결정
+                      - 상대를 아직 팔로우하지 않음 → `FOLLOW_BACK` (맞팔로우 버튼)
+                      - 상대를 이미 팔로우 중 → `UNFOLLOW` (팔로우 취소 버튼)
+                    - 나머지 타입: 알림 타입에 고정된 actionType 반환
+                    """
+    )
+    @ApiResponses({
+            @ApiResponse(
+                    responseCode = "200",
+                    description = "✅ 조회 성공",
+                    content = @Content(
+                            mediaType = "application/json",
+                            examples = @ExampleObject(
+                                    name = "inbox-sample",
+                                    value = """
+                                            {
+                                              "hasNextPage": true,
+                                              "contents": [
+                                                {
+                                                  "id": 101,
+                                                  "type": "FOLLOW",
+                                                  "message": "홍길동님이 나를 팔로우했어요! 👀",
+                                                  "actionType": "FOLLOW_BACK",
+                                                  "targetId": 42,
+                                                  "read": false,
+                                                  "createdAt": "2025-09-25T10:00:00"
+                                                },
+                                                {
+                                                  "id": 100,
+                                                  "type": "FOLLOW",
+                                                  "message": "김철수님이 나를 팔로우했어요! 👀",
+                                                  "actionType": "UNFOLLOW",
+                                                  "targetId": 37,
+                                                  "read": true,
+                                                  "createdAt": "2025-09-24T08:30:00"
+                                                },
+                                                {
+                                                  "id": 99,
+                                                  "type": "FRIEND_ACTIVITY",
+                                                  "message": "이영희님이 OS행성을 정복했어요! 🌍",
+                                                  "actionType": "CONGRATULATE",
+                                                  "targetId": 55,
+                                                  "read": false,
+                                                  "createdAt": "2025-09-23T20:15:00"
+                                                }
+                                              ]
+                                            }
+                                            """
+                            )
+                    )
+            )
+    })
+    @GetMapping
+    ResponseEntity<SliceResponse<NotificationResponse>> getInbox(
+            @AuthenticationPrincipal LoginUser loginUser,
+            @Parameter(description = "0부터 시작하는 페이지 번호", example = "0")
+            @RequestParam(defaultValue = "0") int page
+    );
+}

--- a/src/main/java/gravit/code/notification/domain/NotificationActionType.java
+++ b/src/main/java/gravit/code/notification/domain/NotificationActionType.java
@@ -11,6 +11,7 @@ public enum NotificationActionType {
     GO_TO_LEARNING("학습하러 가기"),         // 학습 메인(targetId 없음) 또는 레슨 딥링크(targetId = unit)
     GO_TO_NOTICE("공지사항 바로가기"),       // targetId = noticeId
     FOLLOW_BACK("맞팔로우"),               // targetId = 상대 userId
+    UNFOLLOW("팔로우 취소"),               // targetId = 상대 userId (이미 맞팔로우한 경우)
     CONGRATULATE("축하하기");              // targetId = feedId
 
     private final String label;

--- a/src/main/java/gravit/code/notification/dto/response/NotificationResponse.java
+++ b/src/main/java/gravit/code/notification/dto/response/NotificationResponse.java
@@ -1,0 +1,62 @@
+package gravit.code.notification.dto.response;
+
+import gravit.code.notification.domain.Notification;
+import gravit.code.notification.domain.NotificationActionType;
+import io.swagger.v3.oas.annotations.media.Schema;
+import lombok.AccessLevel;
+import lombok.Builder;
+
+import java.time.LocalDateTime;
+
+@Builder(access = AccessLevel.PRIVATE)
+public record NotificationResponse(
+
+        @Schema(description = "알림 ID", requiredMode = Schema.RequiredMode.REQUIRED)
+        Long id,
+
+        @Schema(
+                description = "알림 타입",
+                example = "FOLLOW",
+                requiredMode = Schema.RequiredMode.REQUIRED
+        )
+        String type,
+
+        @Schema(
+                description = "알림 메시지",
+                example = "홍길동님이 나를 팔로우했어요! 👀",
+                requiredMode = Schema.RequiredMode.REQUIRED
+        )
+        String message,
+
+        @Schema(
+                description = "액션 버튼 타입 (NONE/FOLLOW_BACK/UNFOLLOW/CONGRATULATE/GO_TO_LEARNING/GO_TO_NOTICE)",
+                example = "FOLLOW_BACK",
+                requiredMode = Schema.RequiredMode.REQUIRED
+        )
+        String actionType,
+
+        @Schema(description = "액션 대상 ID — actionType에 따라 의미가 다름 (없으면 null)")
+        Long targetId,
+
+        @Schema(description = "읽음 여부", requiredMode = Schema.RequiredMode.REQUIRED)
+        boolean read,
+
+        @Schema(description = "생성 시각", requiredMode = Schema.RequiredMode.REQUIRED)
+        LocalDateTime createdAt
+
+) {
+    public static NotificationResponse of(
+            Notification notification,
+            NotificationActionType resolvedActionType
+    ) {
+        return NotificationResponse.builder()
+                .id(notification.getId())
+                .type(notification.getType().name())
+                .message(notification.getMessage())
+                .actionType(resolvedActionType.name())
+                .targetId(notification.getTargetId())
+                .read(notification.isRead())
+                .createdAt(notification.getCreatedAt())
+                .build();
+    }
+}

--- a/src/main/java/gravit/code/notification/facade/NotificationFacade.java
+++ b/src/main/java/gravit/code/notification/facade/NotificationFacade.java
@@ -31,6 +31,7 @@ import java.util.Optional;
 import java.util.Set;
 import java.util.function.Supplier;
 import java.util.stream.Collectors;
+import org.springframework.transaction.annotation.Transactional;
 
 @Facade
 @RequiredArgsConstructor
@@ -185,7 +186,7 @@ public class NotificationFacade {
         pushToUsers(userIds, type.toPushData(targetId), () -> message);
     }
 
-    @org.springframework.transaction.annotation.Transactional(readOnly = true)
+    @Transactional(readOnly = true)
     public SliceResponse<NotificationResponse> getInbox(
             long userId,
             int page

--- a/src/main/java/gravit/code/notification/facade/NotificationFacade.java
+++ b/src/main/java/gravit/code/notification/facade/NotificationFacade.java
@@ -3,11 +3,17 @@ package gravit.code.notification.facade;
 import gravit.code.fcm.dto.internal.PushMessage;
 import gravit.code.fcm.service.FcmService;
 import gravit.code.fcm.service.FcmTokenQueryService;
+import gravit.code.friend.service.FriendService;
 import gravit.code.global.annotation.Facade;
+import gravit.code.global.dto.response.SliceResponse;
 import gravit.code.learning.dto.internal.ConsecutiveAtRiskUser;
 import gravit.code.learning.service.LearningQueryService;
+import gravit.code.notification.domain.Notification;
+import gravit.code.notification.domain.NotificationActionType;
 import gravit.code.notification.domain.NotificationType;
 import gravit.code.notification.dto.internal.InactivityMilestone;
+import gravit.code.notification.dto.response.NotificationResponse;
+import gravit.code.notification.service.NotificationQueryService;
 import gravit.code.notification.service.NotificationService;
 import gravit.code.notification.support.NotificationMessageProvider;
 import gravit.code.season.service.SeasonService;
@@ -18,10 +24,13 @@ import java.time.Clock;
 import java.time.LocalDate;
 import java.time.LocalDateTime;
 import java.time.temporal.ChronoUnit;
+import java.util.Collections;
 import java.util.List;
 import java.util.Map;
 import java.util.Optional;
+import java.util.Set;
 import java.util.function.Supplier;
+import java.util.stream.Collectors;
 
 @Facade
 @RequiredArgsConstructor
@@ -33,6 +42,8 @@ public class NotificationFacade {
     private final FcmService fcmService;
     private final NotificationMessageProvider messageProvider;
     private final NotificationService notificationService;
+    private final NotificationQueryService notificationQueryService;
+    private final FriendService friendService;
     private final SeasonService seasonService;
     private final Clock clock;
 
@@ -142,8 +153,17 @@ public class NotificationFacade {
             NotificationType type,
             String message
     ) {
-        notificationService.notify(userId, type, message);
-        pushToUser(userId, type.toPushData(), message);
+        notifyUser(userId, type, message, null);
+    }
+
+    public void notifyUser(
+            long userId,
+            NotificationType type,
+            String message,
+            Long targetId
+    ) {
+        notificationService.notify(userId, type, message, targetId);
+        pushToUser(userId, type.toPushData(targetId), message);
     }
 
     // 여러 유저에게 인앱 알림 저장 + FCM 푸시 발송
@@ -152,8 +172,53 @@ public class NotificationFacade {
             NotificationType type,
             String message
     ) {
-        notificationService.notifyUsers(userIds, type, message);
-        pushToUsers(userIds, type.toPushData(), () -> message);
+        notifyUsers(userIds, type, message, null);
+    }
+
+    public void notifyUsers(
+            List<Long> userIds,
+            NotificationType type,
+            String message,
+            Long targetId
+    ) {
+        notificationService.notifyUsers(userIds, type, message, targetId);
+        pushToUsers(userIds, type.toPushData(targetId), () -> message);
+    }
+
+    @org.springframework.transaction.annotation.Transactional(readOnly = true)
+    public SliceResponse<NotificationResponse> getInbox(
+            long userId,
+            int page
+    ) {
+        SliceResponse<Notification> raw = notificationQueryService.getNotifications(userId, page);
+
+        Set<Long> followTargetIds = raw.contents().stream()
+                .filter(n -> n.getType() == NotificationType.FOLLOW && n.getTargetId() != null)
+                .map(Notification::getTargetId)
+                .collect(Collectors.toSet());
+
+        Set<Long> alreadyFollowing = followTargetIds.isEmpty()
+                ? Collections.emptySet()
+                : friendService.followingIdsAmong(userId, followTargetIds);
+
+        List<NotificationResponse> responses = raw.contents().stream()
+                .map(n -> toResponse(n, alreadyFollowing))
+                .toList();
+
+        return SliceResponse.of(raw.hasNextPage(), responses);
+    }
+
+    private NotificationResponse toResponse(
+            Notification notification,
+            Set<Long> alreadyFollowing
+    ) {
+        NotificationActionType actionType = notification.getType() == NotificationType.FOLLOW
+                && notification.getTargetId() != null
+                ? (alreadyFollowing.contains(notification.getTargetId())
+                        ? NotificationActionType.UNFOLLOW
+                        : NotificationActionType.FOLLOW_BACK)
+                : notification.getType().getActionType();
+        return NotificationResponse.of(notification, actionType);
     }
 
     public void sendConsecutiveLearningWarningToUser(

--- a/src/main/java/gravit/code/notification/repository/NotificationRepository.java
+++ b/src/main/java/gravit/code/notification/repository/NotificationRepository.java
@@ -1,6 +1,8 @@
 package gravit.code.notification.repository;
 
 import gravit.code.notification.domain.Notification;
+import org.springframework.data.domain.Pageable;
+import org.springframework.data.domain.Slice;
 import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.data.jpa.repository.Modifying;
 import org.springframework.data.jpa.repository.Query;
@@ -23,5 +25,11 @@ public interface NotificationRepository extends JpaRepository<Notification, Long
             @Param("message") String message,
             @Param("targetId") Long targetId,
             @Param("now") LocalDateTime now
+    );
+
+    @Query("SELECT n FROM Notification n WHERE n.userId = :userId ORDER BY n.createdAt DESC")
+    Slice<Notification> findByUserIdOrderByCreatedAtDesc(
+            @Param("userId") long userId,
+            Pageable pageable
     );
 }

--- a/src/main/java/gravit/code/notification/repository/NotificationRepository.java
+++ b/src/main/java/gravit/code/notification/repository/NotificationRepository.java
@@ -27,7 +27,7 @@ public interface NotificationRepository extends JpaRepository<Notification, Long
             @Param("now") LocalDateTime now
     );
 
-    @Query("SELECT n FROM Notification n WHERE n.userId = :userId ORDER BY n.createdAt DESC")
+    @Query("SELECT n FROM Notification n WHERE n.userId = :userId ORDER BY n.createdAt DESC, n.id DESC")
     Slice<Notification> findByUserIdOrderByCreatedAtDesc(
             @Param("userId") long userId,
             Pageable pageable

--- a/src/main/java/gravit/code/notification/service/NotificationQueryService.java
+++ b/src/main/java/gravit/code/notification/service/NotificationQueryService.java
@@ -1,0 +1,31 @@
+package gravit.code.notification.service;
+
+import gravit.code.global.dto.response.SliceResponse;
+import gravit.code.notification.domain.Notification;
+import gravit.code.notification.repository.NotificationRepository;
+import lombok.RequiredArgsConstructor;
+import org.springframework.data.domain.PageRequest;
+import org.springframework.data.domain.Pageable;
+import org.springframework.data.domain.Slice;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+@Service
+@RequiredArgsConstructor
+public class NotificationQueryService {
+
+    private static final int PAGE_SIZE = 20;
+
+    private final NotificationRepository notificationRepository;
+
+    @Transactional(readOnly = true)
+    public SliceResponse<Notification> getNotifications(
+            long userId,
+            int page
+    ) {
+        int safePage = Math.max(0, page);
+        Pageable pageable = PageRequest.of(safePage, PAGE_SIZE);
+        Slice<Notification> result = notificationRepository.findByUserIdOrderByCreatedAtDesc(userId, pageable);
+        return SliceResponse.of(result);
+    }
+}

--- a/src/main/java/gravit/code/notification/service/NotificationService.java
+++ b/src/main/java/gravit/code/notification/service/NotificationService.java
@@ -54,11 +54,21 @@ public class NotificationService {
             NotificationType type,
             String message
     ) {
+        notifyUsers(userIds, type, message, null);
+    }
+
+    @Transactional
+    public void notifyUsers(
+            List<Long> userIds,
+            NotificationType type,
+            String message,
+            Long targetId
+    ) {
         if (userIds.isEmpty()) {
             return;
         }
         List<Notification> notifications = userIds.stream()
-                .map(userId -> Notification.create(userId, type, message))
+                .map(userId -> Notification.create(userId, type, message, targetId))
                 .toList();
         notificationRepository.saveAll(notifications);
     }

--- a/src/main/java/gravit/code/social/facade/SocialFacade.java
+++ b/src/main/java/gravit/code/social/facade/SocialFacade.java
@@ -59,7 +59,7 @@ public class SocialFacade {
     ) {
         friendService.following(userId, targetUserId);
         String followerNickname = userService.getUser(userId).getNickname();
-        notificationFacade.notifyUser(targetUserId, NotificationType.FOLLOW, messageProvider.followReceived(followerNickname));
+        notificationFacade.notifyUser(targetUserId, NotificationType.FOLLOW, messageProvider.followReceived(followerNickname), userId);
     }
 
     @Transactional(readOnly = true)
@@ -82,7 +82,7 @@ public class SocialFacade {
         if (!followerIds.isEmpty()) {
             String actorNickname = userService.getUser(actorId).getNickname();
             String message = messageProvider.friendActivity(actorNickname, eventType, eventValue);
-            notificationFacade.notifyUsers(followerIds, NotificationType.FRIEND_ACTIVITY, message);
+            notificationFacade.notifyUsers(followerIds, NotificationType.FRIEND_ACTIVITY, message, feed.getId());
         }
     }
 

--- a/src/test/java/gravit/code/bookmark/service/BookmarkServiceIntegrationTest.java
+++ b/src/test/java/gravit/code/bookmark/service/BookmarkServiceIntegrationTest.java
@@ -21,7 +21,6 @@ import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Nested;
 import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
-import org.springframework.transaction.annotation.Transactional;
 
 import java.util.List;
 
@@ -32,7 +31,6 @@ import static org.assertj.core.api.Assertions.assertThatThrownBy;
 import static org.assertj.core.api.SoftAssertions.assertSoftly;
 
 @TCSpringBootTest
-@Transactional
 class BookmarkServiceIntegrationTest {
 
     @Autowired

--- a/src/test/java/gravit/code/fcm/service/FcmTokenCommandServiceIntegrationTest.java
+++ b/src/test/java/gravit/code/fcm/service/FcmTokenCommandServiceIntegrationTest.java
@@ -8,7 +8,6 @@ import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Nested;
 import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
-import org.springframework.transaction.annotation.Transactional;
 
 import java.util.List;
 import java.util.Optional;
@@ -17,7 +16,6 @@ import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.SoftAssertions.assertSoftly;
 
 @TCSpringBootTest
-@Transactional
 class FcmTokenCommandServiceIntegrationTest extends FcmServiceIntegrationTestBase {
 
     @Autowired

--- a/src/test/java/gravit/code/fcm/service/FcmTokenQueryServiceIntegrationTest.java
+++ b/src/test/java/gravit/code/fcm/service/FcmTokenQueryServiceIntegrationTest.java
@@ -8,7 +8,6 @@ import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Nested;
 import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
-import org.springframework.transaction.annotation.Transactional;
 
 import java.util.List;
 import java.util.Map;
@@ -16,7 +15,6 @@ import java.util.Map;
 import static org.assertj.core.api.Assertions.assertThat;
 
 @TCSpringBootTest
-@Transactional
 class FcmTokenQueryServiceIntegrationTest extends FcmServiceIntegrationTestBase {
 
     @Autowired

--- a/src/test/java/gravit/code/learning/service/LearningProgressRateServiceIntegrationTest.java
+++ b/src/test/java/gravit/code/learning/service/LearningProgressRateServiceIntegrationTest.java
@@ -16,13 +16,11 @@ import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Nested;
 import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
-import org.springframework.transaction.annotation.Transactional;
 
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.SoftAssertions.assertSoftly;
 
 @TCSpringBootTest
-@Transactional
 class LearningProgressRateServiceIntegrationTest {
 
     @Autowired

--- a/src/test/java/gravit/code/lesson/service/LessonSubmissionCommandServiceIntegrationTest.java
+++ b/src/test/java/gravit/code/lesson/service/LessonSubmissionCommandServiceIntegrationTest.java
@@ -66,14 +66,14 @@ class LessonSubmissionCommandServiceIntegrationTest {
             Chapter chapter = chapterRepository.save(Chapter.create("운영체제", "운영체제 기초 개념"));
             Unit unit = unitRepository.save(Unit.create("프로세스", "프로세스 개념", chapter.getId()));
             Lesson lesson = lessonRepository.save(Lesson.create("레슨1", unit.getId()));
-            lessonSubmissionRepository.save(LessonSubmission.create(120, 80, lesson.getId(), userId));
+            LessonSubmission saved = lessonSubmissionRepository.save(LessonSubmission.create(120, 80, lesson.getId(), userId));
             LessonSubmissionSaveRequest request = new LessonSubmissionSaveRequest(lesson.getId(), 90, 85);
 
             // when
             lessonSubmissionCommandService.saveLessonSubmission(userId, request, false);
 
             // then
-            LessonSubmission updated = lessonSubmissionRepository.findByLessonIdAndUserId(lesson.getId(), userId).get();
+            LessonSubmission updated = lessonSubmissionRepository.findById(saved.getId()).get();
             assertSoftly(softly -> {
                 softly.assertThat(updated.getLearningTime()).isEqualTo(90);
                 softly.assertThat(updated.getTryCount()).isEqualTo(2);

--- a/src/test/java/gravit/code/lesson/service/LessonSubmissionCommandServiceIntegrationTest.java
+++ b/src/test/java/gravit/code/lesson/service/LessonSubmissionCommandServiceIntegrationTest.java
@@ -15,7 +15,6 @@ import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Nested;
 import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
-import org.springframework.transaction.annotation.Transactional;
 
 import static gravit.code.global.exception.domain.CustomErrorCode.LESSON_NOT_FOUND;
 import static org.assertj.core.api.Assertions.assertThat;
@@ -23,7 +22,6 @@ import static org.assertj.core.api.Assertions.assertThatThrownBy;
 import static org.assertj.core.api.SoftAssertions.assertSoftly;
 
 @TCSpringBootTest
-@Transactional
 class LessonSubmissionCommandServiceIntegrationTest {
 
     @Autowired

--- a/src/test/java/gravit/code/mission/service/MissionServiceIntegrationTest.java
+++ b/src/test/java/gravit/code/mission/service/MissionServiceIntegrationTest.java
@@ -17,14 +17,12 @@ import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Nested;
 import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
-import org.springframework.transaction.annotation.Transactional;
 
 import static gravit.code.global.exception.domain.CustomErrorCode.MISSION_NOT_FOUND;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
 
 @TCSpringBootTest
-@Transactional
 class MissionServiceIntegrationTest {
 
     @Autowired

--- a/src/test/java/gravit/code/notification/facade/NotificationFacadeIntegrationTest.java
+++ b/src/test/java/gravit/code/notification/facade/NotificationFacadeIntegrationTest.java
@@ -4,9 +4,12 @@ import gravit.code.fcm.domain.FcmToken;
 import gravit.code.fcm.dto.internal.PushMessage;
 import gravit.code.fcm.repository.FcmTokenRepository;
 import gravit.code.fcm.service.FcmService;
+import gravit.code.friend.fixture.FriendFixture;
+import gravit.code.global.dto.response.SliceResponse;
 import gravit.code.notification.domain.Notification;
 import gravit.code.notification.domain.NotificationActionType;
 import gravit.code.notification.domain.NotificationType;
+import gravit.code.notification.dto.response.NotificationResponse;
 import gravit.code.notification.repository.NotificationRepository;
 import gravit.code.notification.support.NotificationMessageProvider;
 import gravit.code.season.batch.SeasonBatchService;
@@ -50,6 +53,9 @@ class NotificationFacadeIntegrationTest {
 
     @Autowired
     private UserFixture userFixture;
+
+    @Autowired
+    private FriendFixture friendFixture;
 
     @Autowired
     private FcmTokenRepository fcmTokenRepository;
@@ -257,6 +263,23 @@ class NotificationFacadeIntegrationTest {
             // FCM 미발송
             verify(fcmService, never()).sendNotifications(anyList());
         }
+
+        @Test
+        void targetId가_있으면_알림에_함께_저장된다() {
+            // given
+            User receiver = userFixture.일반_유저(1);
+            long followerId = 42L;
+
+            // when
+            notificationFacade.notifyUser(receiver.getId(), NotificationType.FOLLOW, "유저42님이 나를 팔로우했어요! 👀", followerId);
+
+            // then
+            List<Notification> saved = notificationRepository.findAll();
+            assertSoftly(softly -> {
+                softly.assertThat(saved).hasSize(1);
+                softly.assertThat(saved.get(0).getTargetId()).isEqualTo(followerId);
+            });
+        }
     }
 
     @Nested
@@ -289,6 +312,163 @@ class NotificationFacadeIntegrationTest {
             });
             // FCM 발송
             verify(fcmService, timeout(1000)).sendNotifications(anyList());
+        }
+
+        @Test
+        void targetId가_있으면_모든_알림에_저장된다() {
+            // given
+            User user1 = userFixture.일반_유저(1);
+            User user2 = userFixture.일반_유저(2);
+            long feedId = 99L;
+
+            // when
+            notificationFacade.notifyUsers(
+                    List.of(user1.getId(), user2.getId()),
+                    NotificationType.FRIEND_ACTIVITY,
+                    "유저3님이 OS행성을 정복했어요! 🌍",
+                    feedId
+            );
+
+            // then
+            List<Notification> saved = notificationRepository.findAll();
+            assertThat(saved).allMatch(n -> feedId == n.getTargetId());
+        }
+    }
+
+    @Nested
+    @DisplayName("알림 인박스를 조회할 때")
+    class GetInbox {
+
+        @Test
+        void 알림이_없으면_빈_결과를_반환한다() {
+            // given
+            User user = userFixture.일반_유저(1);
+
+            // when
+            SliceResponse<NotificationResponse> result = notificationFacade.getInbox(user.getId(), 0);
+
+            // then
+            assertSoftly(softly -> {
+                softly.assertThat(result.contents()).isEmpty();
+                softly.assertThat(result.hasNextPage()).isFalse();
+            });
+        }
+
+        @Test
+        void FOLLOW_알림에서_상대를_아직_팔로우하지_않았으면_FOLLOW_BACK을_반환한다() {
+            // given
+            User me = userFixture.일반_유저(1);
+            User follower = userFixture.일반_유저(2);
+            // follower가 me를 팔로우했고, me는 아직 맞팔로우 안 함
+            notificationRepository.save(Notification.create(me.getId(), NotificationType.FOLLOW,
+                    "유저2님이 나를 팔로우했어요! 👀", follower.getId()));
+
+            // when
+            SliceResponse<NotificationResponse> result = notificationFacade.getInbox(me.getId(), 0);
+
+            // then
+            assertThat(result.contents()).hasSize(1);
+            assertSoftly(softly -> {
+                softly.assertThat(result.contents().get(0).actionType()).isEqualTo(NotificationActionType.FOLLOW_BACK.name());
+                softly.assertThat(result.contents().get(0).targetId()).isEqualTo(follower.getId());
+            });
+        }
+
+        @Test
+        void FOLLOW_알림에서_상대를_이미_팔로우했으면_UNFOLLOW를_반환한다() {
+            // given
+            User me = userFixture.일반_유저(1);
+            User follower = userFixture.일반_유저(2);
+            // follower가 me를 팔로우했고, me도 follower를 맞팔로우한 상태
+            friendFixture.팔로우(me, follower);
+            notificationRepository.save(Notification.create(me.getId(), NotificationType.FOLLOW,
+                    "유저2님이 나를 팔로우했어요! 👀", follower.getId()));
+
+            // when
+            SliceResponse<NotificationResponse> result = notificationFacade.getInbox(me.getId(), 0);
+
+            // then
+            assertThat(result.contents()).hasSize(1);
+            assertSoftly(softly -> {
+                softly.assertThat(result.contents().get(0).actionType()).isEqualTo(NotificationActionType.UNFOLLOW.name());
+                softly.assertThat(result.contents().get(0).targetId()).isEqualTo(follower.getId());
+            });
+        }
+
+        @Test
+        void CONGRATULATION_알림은_NONE_액션을_반환한다() {
+            // given
+            User me = userFixture.일반_유저(1);
+            notificationRepository.save(Notification.create(me.getId(), NotificationType.CONGRATULATION,
+                    "유저2님이 축하해줬어요! 🎉"));
+
+            // when
+            SliceResponse<NotificationResponse> result = notificationFacade.getInbox(me.getId(), 0);
+
+            // then
+            assertSoftly(softly -> {
+                softly.assertThat(result.contents().get(0).actionType()).isEqualTo(NotificationActionType.NONE.name());
+                softly.assertThat(result.contents().get(0).targetId()).isNull();
+            });
+        }
+
+        @Test
+        void FRIEND_ACTIVITY_알림은_CONGRATULATE_액션과_feedId를_반환한다() {
+            // given
+            User me = userFixture.일반_유저(1);
+            long feedId = 77L;
+            notificationRepository.save(Notification.create(me.getId(), NotificationType.FRIEND_ACTIVITY,
+                    "유저2님이 OS행성을 정복했어요! 🌍", feedId));
+
+            // when
+            SliceResponse<NotificationResponse> result = notificationFacade.getInbox(me.getId(), 0);
+
+            // then
+            assertSoftly(softly -> {
+                softly.assertThat(result.contents().get(0).actionType()).isEqualTo(NotificationActionType.CONGRATULATE.name());
+                softly.assertThat(result.contents().get(0).targetId()).isEqualTo(feedId);
+            });
+        }
+
+        @Test
+        void 여러_타입의_알림이_혼재할_때_각_타입에_맞는_액션을_반환한다() {
+            // given
+            User me = userFixture.일반_유저(1);
+            User followerA = userFixture.일반_유저(2); // 아직 맞팔로우 안 함
+            User followerB = userFixture.일반_유저(3); // 이미 맞팔로우 함
+            friendFixture.팔로우(me, followerB);
+
+            notificationRepository.save(Notification.create(me.getId(), NotificationType.FOLLOW,
+                    "유저2님이 나를 팔로우했어요! 👀", followerA.getId()));
+            notificationRepository.save(Notification.create(me.getId(), NotificationType.FOLLOW,
+                    "유저3님이 나를 팔로우했어요! 👀", followerB.getId()));
+            notificationRepository.save(Notification.create(me.getId(), NotificationType.CONGRATULATION,
+                    "유저2님이 축하해줬어요! 🎉"));
+
+            // when
+            SliceResponse<NotificationResponse> result = notificationFacade.getInbox(me.getId(), 0);
+
+            // then
+            assertThat(result.contents()).hasSize(3);
+            assertThat(result.contents())
+                    .filteredOn(n -> n.type().equals(NotificationType.FOLLOW.name())
+                            && n.targetId().equals(followerA.getId()))
+                    .singleElement()
+                    .extracting(NotificationResponse::actionType)
+                    .isEqualTo(NotificationActionType.FOLLOW_BACK.name());
+
+            assertThat(result.contents())
+                    .filteredOn(n -> n.type().equals(NotificationType.FOLLOW.name())
+                            && n.targetId().equals(followerB.getId()))
+                    .singleElement()
+                    .extracting(NotificationResponse::actionType)
+                    .isEqualTo(NotificationActionType.UNFOLLOW.name());
+
+            assertThat(result.contents())
+                    .filteredOn(n -> n.type().equals(NotificationType.CONGRATULATION.name()))
+                    .singleElement()
+                    .extracting(NotificationResponse::actionType)
+                    .isEqualTo(NotificationActionType.NONE.name());
         }
     }
 }

--- a/src/test/java/gravit/code/notification/facade/NotificationFacadeIntegrationTest.java
+++ b/src/test/java/gravit/code/notification/facade/NotificationFacadeIntegrationTest.java
@@ -331,6 +331,7 @@ class NotificationFacadeIntegrationTest {
 
             // then
             List<Notification> saved = notificationRepository.findAll();
+            assertThat(saved).hasSize(2);
             assertThat(saved).allMatch(n -> feedId == n.getTargetId());
         }
     }

--- a/src/test/java/gravit/code/option/service/OptionQueryServiceIntegrationTest.java
+++ b/src/test/java/gravit/code/option/service/OptionQueryServiceIntegrationTest.java
@@ -10,7 +10,6 @@ import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Nested;
 import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
-import org.springframework.transaction.annotation.Transactional;
 
 import java.util.List;
 import java.util.Map;
@@ -19,7 +18,6 @@ import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.SoftAssertions.assertSoftly;
 
 @TCSpringBootTest
-@Transactional
 class OptionQueryServiceIntegrationTest {
 
     @Autowired

--- a/src/test/java/gravit/code/problem/service/ProblemQueryServiceIntegrationTest.java
+++ b/src/test/java/gravit/code/problem/service/ProblemQueryServiceIntegrationTest.java
@@ -17,7 +17,6 @@ import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Nested;
 import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
-import org.springframework.transaction.annotation.Transactional;
 
 import java.util.List;
 
@@ -25,7 +24,6 @@ import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.SoftAssertions.assertSoftly;
 
 @TCSpringBootTest
-@Transactional
 class ProblemQueryServiceIntegrationTest {
 
     @Autowired

--- a/src/test/java/gravit/code/problem/service/ProblemSubmissionCommandServiceIntegrationTest.java
+++ b/src/test/java/gravit/code/problem/service/ProblemSubmissionCommandServiceIntegrationTest.java
@@ -19,7 +19,6 @@ import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Nested;
 import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
-import org.springframework.transaction.annotation.Transactional;
 
 import java.util.List;
 
@@ -29,7 +28,6 @@ import static org.assertj.core.api.Assertions.assertThatThrownBy;
 import static org.assertj.core.api.SoftAssertions.assertSoftly;
 
 @TCSpringBootTest
-@Transactional
 class ProblemSubmissionCommandServiceIntegrationTest {
 
     @Autowired

--- a/src/test/java/gravit/code/report/service/ReportServiceIntegrationTest.java
+++ b/src/test/java/gravit/code/report/service/ReportServiceIntegrationTest.java
@@ -17,14 +17,12 @@ import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Nested;
 import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
-import org.springframework.transaction.annotation.Transactional;
 
 import static gravit.code.global.exception.domain.CustomErrorCode.PROBLEM_NOT_FOUND;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
 
 @TCSpringBootTest
-@Transactional
 class ReportServiceIntegrationTest {
 
     @Autowired

--- a/src/test/java/gravit/code/social/facade/SocialFacadeIntegrationTest.java
+++ b/src/test/java/gravit/code/social/facade/SocialFacadeIntegrationTest.java
@@ -15,6 +15,7 @@ import gravit.code.social.domain.SocialFeed;
 import gravit.code.social.dto.response.RecommendUserResponse;
 import gravit.code.social.dto.response.SocialFeedResponse;
 import gravit.code.social.fixture.SocialFeedFixture;
+import gravit.code.social.repository.SocialFeedRepository;
 import gravit.code.support.TCSpringBootTest;
 import gravit.code.user.domain.User;
 import gravit.code.user.fixture.UserFixture;
@@ -64,6 +65,9 @@ class SocialFacadeIntegrationTest {
     @Autowired
     private NotificationRepository notificationRepository;
 
+    @Autowired
+    private SocialFeedRepository socialFeedRepository;
+
     @Nested
     @DisplayName("팔로우할 때")
     class Follow {
@@ -85,6 +89,7 @@ class SocialFacadeIntegrationTest {
                 softly.assertThat(notifications.get(0).getType()).isEqualTo(NotificationType.FOLLOW);
                 softly.assertThat(notifications.get(0).getMessage()).isEqualTo("유저1님이 나를 팔로우했어요! 👀");
                 softly.assertThat(notifications.get(0).isRead()).isFalse();
+                softly.assertThat(notifications.get(0).getTargetId()).isEqualTo(follower.getId());
             });
         }
     }
@@ -110,9 +115,11 @@ class SocialFacadeIntegrationTest {
             assertThat(notifications).hasSize(2);
             List<Long> recipientIds = notifications.stream().map(Notification::getUserId).toList();
             assertThat(recipientIds).containsExactlyInAnyOrder(follower1.getId(), follower2.getId());
+            Long feedId = socialFeedRepository.findAll().get(0).getId();
             notifications.forEach(n -> assertSoftly(softly -> {
                 softly.assertThat(n.getType()).isEqualTo(NotificationType.FRIEND_ACTIVITY);
                 softly.assertThat(n.getMessage()).isEqualTo("유저1님이 LV.5이 됐어요! 💪");
+                softly.assertThat(n.getTargetId()).isEqualTo(feedId);
             }));
         }
 

--- a/src/test/java/gravit/code/social/facade/SocialFacadeIntegrationTest.java
+++ b/src/test/java/gravit/code/social/facade/SocialFacadeIntegrationTest.java
@@ -115,7 +115,9 @@ class SocialFacadeIntegrationTest {
             assertThat(notifications).hasSize(2);
             List<Long> recipientIds = notifications.stream().map(Notification::getUserId).toList();
             assertThat(recipientIds).containsExactlyInAnyOrder(follower1.getId(), follower2.getId());
-            Long feedId = socialFeedRepository.findAll().get(0).getId();
+            List<SocialFeed> feeds = socialFeedRepository.findAll();
+            assertThat(feeds).hasSize(1);
+            Long feedId = feeds.get(0).getId();
             notifications.forEach(n -> assertSoftly(softly -> {
                 softly.assertThat(n.getType()).isEqualTo(NotificationType.FRIEND_ACTIVITY);
                 softly.assertThat(n.getMessage()).isEqualTo("유저1님이 LV.5이 됐어요! 💪");

--- a/src/test/java/gravit/code/wrongAnsweredNote/service/WrongAnsweredNoteServiceIntegrationTest.java
+++ b/src/test/java/gravit/code/wrongAnsweredNote/service/WrongAnsweredNoteServiceIntegrationTest.java
@@ -20,7 +20,6 @@ import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Nested;
 import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
-import org.springframework.transaction.annotation.Transactional;
 
 import java.util.List;
 
@@ -28,7 +27,6 @@ import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.SoftAssertions.assertSoftly;
 
 @TCSpringBootTest
-@Transactional
 class WrongAnsweredNoteServiceIntegrationTest {
 
     @Autowired


### PR DESCRIPTION
### 1. 연관 이슈

---
없음

<br>

### 2. 구현 사항

---
**알림 인박스 조회 API 구현 (`GET /api/v1/notifications`)**

알림 목록을 최신순으로 페이지 단위(20개)로 반환하는 API를 추가했습니다.
FOLLOW 타입 알림에 대해 현재 팔로우 관계를 실시간으로 확인해 `actionType`을 동적으로 결정합니다.
- 상대를 아직 팔로우하지 않은 경우 → `FOLLOW_BACK` (맞팔로우 버튼)
- 상대를 이미 팔로우 중인 경우 → `UNFOLLOW` (팔로우 취소 버튼)
- 나머지 타입은 `NotificationType`에 고정된 `actionType`을 그대로 반환합니다.

**팔로우/친구활동 알림의 `targetId` 누락 수정**

기존에 팔로우 알림 발송 시 `targetId`(팔로워 userId)가 저장되지 않아 클라이언트의 맞팔로우 버튼이 동작하지 않았습니다.
- `SocialFacade.follow()`: 팔로워 userId를 `targetId`로 포함하여 발송
- `SocialFacade.publishFeed()`: `feedId`를 `targetId`로 포함하여 발송 (CONGRATULATE 버튼용)
- `NotificationFacade.notifyUser()` / `notifyUsers()`: `targetId` 오버로드 추가

**`NotificationActionType.UNFOLLOW` 추가**

이미 맞팔로우한 경우 알림창에서 팔로우 취소 버튼을 제공하기 위해 `UNFOLLOW` 액션 타입을 추가했습니다.

**`@TCSpringBootTest` 통합 테스트 클래스 레벨 `@Transactional` 제거**

`REQUIRES_NEW` 전파 전략을 사용하는 서비스 메서드(e.g. `handleFollowMission`)를 `@Transactional` 테스트에서 직접 호출하면, 새로운 트랜잭션이 외부 테스트 트랜잭션의 미커밋 데이터를 볼 수 없어 테스트가 정상적으로 동작하지 않는 문제를 수정했습니다.
`DatabaseClearExtension`이 테스트 간 DB 정리를 담당하므로 클래스 레벨 `@Transactional`은 불필요합니다.
대상 파일: `BookmarkServiceIntegrationTest`, `FcmTokenCommandServiceIntegrationTest`, `FcmTokenQueryServiceIntegrationTest`, `LearningProgressRateServiceIntegrationTest`, `LessonSubmissionCommandServiceIntegrationTest`, `MissionServiceIntegrationTest`, `OptionQueryServiceIntegrationTest`, `ProblemQueryServiceIntegrationTest`, `ProblemSubmissionCommandServiceIntegrationTest`, `ReportServiceIntegrationTest`, `WrongAnsweredNoteServiceIntegrationTest`

**`PESSIMISTIC_WRITE` 락 메서드를 `readOnly` 트랜잭션에서 호출하는 문제 수정**

`@Transactional` 제거 후 테스트의 `then` 블록에서 `findByLessonIdAndUserId`(PESSIMISTIC_WRITE)를 호출하면, `SimpleJpaRepository`의 `readOnly=true` 트랜잭션 위에서 실행되어 PostgreSQL이 `SELECT FOR UPDATE`를 거부하는 문제가 발생했습니다.
`then` 블록에서는 setup 시 저장된 엔티티의 ID를 보존해두고 `findById`(일반 SELECT)로 조회하도록 수정했습니다.