### PR TITLE
fix: 메인페이지 리그 정보 응답 스펙 수정(#399)

### DIFF
--- a/src/main/java/gravit/code/league/dto/response/LeagueDetailResponse.java
+++ b/src/main/java/gravit/code/league/dto/response/LeagueDetailResponse.java
@@ -17,18 +17,23 @@ public record LeagueDetailResponse(
         int currentLP,
 
         @Schema(requiredMode = Schema.RequiredMode.REQUIRED)
+        int minLP,
+
+        @Schema(requiredMode = Schema.RequiredMode.REQUIRED)
         int maxLP
 ) {
     public static LeagueDetailResponse of(
             long leagueId,
             String leagueName,
             int currentLP,
+            int minLP,
             int maxLP
     ){
         return  LeagueDetailResponse.builder()
                 .leagueId(leagueId)
                 .leagueName(leagueName)
                 .currentLP(currentLP)
+                .minLP(minLP)
                 .maxLP(maxLP)
                 .build();
     }

--- a/src/main/java/gravit/code/userLeague/service/UserLeagueService.java
+++ b/src/main/java/gravit/code/userLeague/service/UserLeagueService.java
@@ -44,6 +44,7 @@ public class UserLeagueService {
                 userLeague.getLeague().getId(),
                 userLeague.getLeague().getName(),
                 userLeague.getLp(),
+                userLeague.getLeague().getMinLp(),
                 userLeague.getLeague().getMaxLp()
         );
     }

--- a/src/test/java/gravit/code/userLeague/service/UserLeagueServiceIntegrationTest.java
+++ b/src/test/java/gravit/code/userLeague/service/UserLeagueServiceIntegrationTest.java
@@ -83,6 +83,7 @@ class UserLeagueServiceIntegrationTest {
                 softly.assertThat(result.leagueId()).isEqualTo(league.getId());
                 softly.assertThat(result.leagueName()).isEqualTo("Bronze");
                 softly.assertThat(result.currentLP()).isEqualTo(50);
+                softly.assertThat(result.minLP()).isEqualTo(0);
                 softly.assertThat(result.maxLP()).isEqualTo(100);
             });
         }


### PR DESCRIPTION
### 1. 연관 이슈

---
 - close #399

<br>

### 2. 구현 사항

---
**`LeagueDetailResponse`에 `minLP` 필드 추가**

메인페이지 리그 정보 응답에 리그의 최소 LP 값이 누락되어 있어 클라이언트가 현재 리그 구간을 표현하기 어려웠습니다. 이를 보완하기 위해 `LeagueDetailResponse`에 `minLP` 필드를 추가했습니다.

- `LeagueDetailResponse` record에 `minLP` 필드 및 `@Schema` 추가, `of()` 팩토리 메서드 파라미터와 빌더 매핑 연결 (필드 순서: `currentLP` → `minLP` → `maxLP`)
- `UserLeagueService.getUserLeagueDetail()`에서 `League.getMinLp()` 값을 응답에 매핑
- `UserLeagueServiceIntegrationTest`에 `minLP` 검증 추가

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## 새 기능

* **리그 상세 정보에 최소 LP(Lowest Points) 정보 추가** - 리그 상세 조회 응답에 최소 LP 필드가 포함되어 사용자가 리그의 최소 포인트 기준을 확인할 수 있게 되었습니다.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->