### PR TITLE
feat: 팔로우 알림에 상대 유저 정보(actor) 추가

### DIFF
--- a/src/main/java/gravit/code/notification/dto/response/NotificationActor.java
+++ b/src/main/java/gravit/code/notification/dto/response/NotificationActor.java
@@ -1,0 +1,28 @@
+package gravit.code.notification.dto.response;
+
+import io.swagger.v3.oas.annotations.media.Schema;
+
+public record NotificationActor(
+
+        @Schema(
+                description = "상대 유저 프로필 ID (= userId)",
+                example = "42",
+                requiredMode = Schema.RequiredMode.REQUIRED
+        )
+        Long profileId,
+
+        @Schema(
+                description = "상대 유저 닉네임",
+                example = "홍길동",
+                requiredMode = Schema.RequiredMode.REQUIRED
+        )
+        String nickname,
+
+        @Schema(
+                description = "상대 유저 프로필 이미지 번호",
+                example = "2",
+                requiredMode = Schema.RequiredMode.REQUIRED
+        )
+        int profileImgNumber
+) {
+}

--- a/src/main/java/gravit/code/notification/dto/response/NotificationResponse.java
+++ b/src/main/java/gravit/code/notification/dto/response/NotificationResponse.java
@@ -42,12 +42,16 @@ public record NotificationResponse(
         boolean read,
 
         @Schema(description = "생성 시각", requiredMode = Schema.RequiredMode.REQUIRED)
-        LocalDateTime createdAt
+        LocalDateTime createdAt,
+
+        @Schema(description = "팔로우 알림의 상대 유저 정보 (FOLLOW 알림이 아니거나 탈퇴한 유저면 null)")
+        NotificationActor actor
 
 ) {
     public static NotificationResponse of(
             Notification notification,
-            NotificationActionType resolvedActionType
+            NotificationActionType resolvedActionType,
+            NotificationActor actor
     ) {
         return NotificationResponse.builder()
                 .id(notification.getId())
@@ -57,6 +61,7 @@ public record NotificationResponse(
                 .targetId(notification.getTargetId())
                 .read(notification.isRead())
                 .createdAt(notification.getCreatedAt())
+                .actor(actor)
                 .build();
     }
 }

--- a/src/main/java/gravit/code/notification/facade/NotificationFacade.java
+++ b/src/main/java/gravit/code/notification/facade/NotificationFacade.java
@@ -12,12 +12,15 @@ import gravit.code.notification.domain.Notification;
 import gravit.code.notification.domain.NotificationActionType;
 import gravit.code.notification.domain.NotificationType;
 import gravit.code.notification.dto.internal.InactivityMilestone;
+import gravit.code.notification.dto.response.NotificationActor;
 import gravit.code.notification.dto.response.NotificationResponse;
 import gravit.code.notification.service.NotificationQueryService;
 import gravit.code.notification.service.NotificationService;
 import gravit.code.notification.support.NotificationMessageProvider;
 import gravit.code.season.service.SeasonService;
+import gravit.code.user.dto.response.UserSummaryResponse;
 import gravit.code.user.service.UserAccessService;
+import gravit.code.user.service.UserService;
 import lombok.RequiredArgsConstructor;
 
 import java.time.Clock;
@@ -46,6 +49,7 @@ public class NotificationFacade {
     private final NotificationQueryService notificationQueryService;
     private final FriendService friendService;
     private final SeasonService seasonService;
+    private final UserService userService;
     private final Clock clock;
 
     public void sendConsecutiveLearningWarnings() {
@@ -202,8 +206,10 @@ public class NotificationFacade {
                 ? Collections.emptySet()
                 : friendService.followingIdsAmong(userId, followTargetIds);
 
+        Map<Long, UserSummaryResponse> actorsByUserId = userService.getUserSummaries(followTargetIds);
+
         List<NotificationResponse> responses = raw.contents().stream()
-                .map(n -> toResponse(n, alreadyFollowing))
+                .map(n -> toResponse(n, alreadyFollowing, actorsByUserId))
                 .toList();
 
         return SliceResponse.of(raw.hasNextPage(), responses);
@@ -211,15 +217,30 @@ public class NotificationFacade {
 
     private NotificationResponse toResponse(
             Notification notification,
-            Set<Long> alreadyFollowing
+            Set<Long> alreadyFollowing,
+            Map<Long, UserSummaryResponse> actorsByUserId
     ) {
-        NotificationActionType actionType = notification.getType() == NotificationType.FOLLOW
-                && notification.getTargetId() != null
+        boolean isFollow = notification.getType() == NotificationType.FOLLOW
+                && notification.getTargetId() != null;
+
+        NotificationActionType actionType = isFollow
                 ? (alreadyFollowing.contains(notification.getTargetId())
                         ? NotificationActionType.UNFOLLOW
                         : NotificationActionType.FOLLOW_BACK)
                 : notification.getType().getActionType();
-        return NotificationResponse.of(notification, actionType);
+
+        NotificationActor actor = isFollow
+                ? toActor(actorsByUserId.get(notification.getTargetId()))
+                : null;
+
+        return NotificationResponse.of(notification, actionType, actor);
+    }
+
+    private NotificationActor toActor(UserSummaryResponse summary) {
+        if (summary == null) {
+            return null;
+        }
+        return new NotificationActor(summary.id(), summary.nickname(), summary.profileImgNumber());
     }
 
     public void sendConsecutiveLearningWarningToUser(

--- a/src/main/java/gravit/code/user/dto/response/UserSummaryResponse.java
+++ b/src/main/java/gravit/code/user/dto/response/UserSummaryResponse.java
@@ -1,0 +1,8 @@
+package gravit.code.user.dto.response;
+
+public record UserSummaryResponse(
+        long id,
+        String nickname,
+        int profileImgNumber
+) {
+}

--- a/src/main/java/gravit/code/user/repository/UserRepository.java
+++ b/src/main/java/gravit/code/user/repository/UserRepository.java
@@ -2,6 +2,7 @@ package gravit.code.user.repository;
 
 import gravit.code.user.domain.User;
 import gravit.code.user.dto.response.MyPageResponse;
+import gravit.code.user.dto.response.UserSummaryResponse;
 import gravit.code.user.repository.custom.UserDeletionRepository;
 import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.data.jpa.repository.Modifying;
@@ -11,6 +12,7 @@ import org.springframework.data.repository.query.Param;
 import java.time.LocalDateTime;
 import java.util.List;
 import java.util.Optional;
+import java.util.Set;
 
 public interface UserRepository extends JpaRepository<User, Long>, UserDeletionRepository {
 
@@ -61,4 +63,12 @@ public interface UserRepository extends JpaRepository<User, Long>, UserDeletionR
             @Param("start") LocalDateTime start,
             @Param("end") LocalDateTime end
     );
+
+    // @SQLRestriction(deleted_at IS NULL)이 적용되어 탈퇴 유저는 결과에서 자동 제외된다
+    @Query("""
+        SELECT new gravit.code.user.dto.response.UserSummaryResponse(u.id, u.nickname, u.profileImgNumber)
+        FROM User u
+        WHERE u.id IN :ids
+    """)
+    List<UserSummaryResponse> findSummariesByIds(@Param("ids") Set<Long> ids);
 }

--- a/src/main/java/gravit/code/user/service/UserService.java
+++ b/src/main/java/gravit/code/user/service/UserService.java
@@ -11,12 +11,19 @@ import gravit.code.user.dto.request.UserProfileUpdateRequest;
 import gravit.code.user.dto.response.MyPageResponse;
 import gravit.code.user.dto.response.UserLevelResponse;
 import gravit.code.user.dto.response.UserResponse;
+import gravit.code.user.dto.response.UserSummaryResponse;
 import gravit.code.user.repository.UserRepository;
 import gravit.code.user.support.RandomHandleGenerator;
 import lombok.RequiredArgsConstructor;
 import org.springframework.context.ApplicationEventPublisher;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
+
+import java.util.Collections;
+import java.util.Map;
+import java.util.Set;
+import java.util.function.Function;
+import java.util.stream.Collectors;
 
 @Service
 @RequiredArgsConstructor
@@ -97,6 +104,17 @@ public class UserService {
     public User getUser(long userId) {
         return userRepository.findById(userId)
                 .orElseThrow(()-> new RestApiException(CustomErrorCode.USER_NOT_FOUND));
+    }
+
+    // 탈퇴 유저는 조회 결과에서 제외되므로 반환 Map에 키가 존재하지 않는다
+    @Transactional(readOnly = true)
+    public Map<Long, UserSummaryResponse> getUserSummaries(Set<Long> userIds) {
+        if (userIds.isEmpty()) {
+            return Collections.emptyMap();
+        }
+
+        return userRepository.findSummariesByIds(userIds).stream()
+                .collect(Collectors.toMap(UserSummaryResponse::id, Function.identity()));
     }
 
     private UserLevelResponse updateUserLevelAndXp(

--- a/src/test/java/gravit/code/notification/facade/NotificationFacadeIntegrationTest.java
+++ b/src/test/java/gravit/code/notification/facade/NotificationFacadeIntegrationTest.java
@@ -9,6 +9,7 @@ import gravit.code.global.dto.response.SliceResponse;
 import gravit.code.notification.domain.Notification;
 import gravit.code.notification.domain.NotificationActionType;
 import gravit.code.notification.domain.NotificationType;
+import gravit.code.notification.dto.response.NotificationActor;
 import gravit.code.notification.dto.response.NotificationResponse;
 import gravit.code.notification.repository.NotificationRepository;
 import gravit.code.notification.support.NotificationMessageProvider;
@@ -17,6 +18,7 @@ import gravit.code.season.fixture.SeasonFixture;
 import gravit.code.support.TCSpringBootTest;
 import gravit.code.user.domain.User;
 import gravit.code.user.fixture.UserFixture;
+import gravit.code.user.repository.UserRepository;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Nested;
 import org.junit.jupiter.api.Test;
@@ -62,6 +64,9 @@ class NotificationFacadeIntegrationTest {
 
     @Autowired
     private NotificationRepository notificationRepository;
+
+    @Autowired
+    private UserRepository userRepository;
 
     // FCM 외부 발송 경계만 격리하고, 토큰 조회·메시지 구성 등 우리 로직은 실제로 동작시킨다
     @MockitoBean
@@ -394,6 +399,63 @@ class NotificationFacadeIntegrationTest {
                 softly.assertThat(result.contents().get(0).actionType()).isEqualTo(NotificationActionType.UNFOLLOW.name());
                 softly.assertThat(result.contents().get(0).targetId()).isEqualTo(follower.getId());
             });
+        }
+
+        @Test
+        void FOLLOW_알림은_상대_유저의_actor_정보를_포함한다() {
+            // given
+            User me = userFixture.일반_유저(1);
+            User follower = userFixture.일반_유저(2);
+            notificationRepository.save(Notification.create(me.getId(), NotificationType.FOLLOW,
+                    "유저2님이 나를 팔로우했어요! 👀", follower.getId()));
+
+            // when
+            SliceResponse<NotificationResponse> result = notificationFacade.getInbox(me.getId(), 0);
+
+            // then
+            NotificationActor actor = result.contents().get(0).actor();
+            assertThat(actor).isNotNull();
+            assertSoftly(softly -> {
+                softly.assertThat(actor.profileId()).isEqualTo(follower.getId());
+                softly.assertThat(actor.nickname()).isEqualTo("유저2");
+                softly.assertThat(actor.profileImgNumber()).isEqualTo(follower.getProfileImgNumber());
+            });
+        }
+
+        @Test
+        void 탈퇴한_유저의_FOLLOW_알림은_actor가_null이다() {
+            // given
+            User me = userFixture.일반_유저(1);
+            User follower = userFixture.일반_유저(2);
+            notificationRepository.save(Notification.create(me.getId(), NotificationType.FOLLOW,
+                    "유저2님이 나를 팔로우했어요! 👀", follower.getId()));
+            // 상대 유저 탈퇴 (soft delete)
+            userRepository.delete(follower);
+
+            // when
+            SliceResponse<NotificationResponse> result = notificationFacade.getInbox(me.getId(), 0);
+
+            // then
+            assertSoftly(softly -> {
+                softly.assertThat(result.contents().get(0).actor()).isNull();
+                // 알림 자체와 액션 정보는 그대로 유지된다
+                softly.assertThat(result.contents().get(0).targetId()).isEqualTo(follower.getId());
+                softly.assertThat(result.contents().get(0).actionType()).isEqualTo(NotificationActionType.FOLLOW_BACK.name());
+            });
+        }
+
+        @Test
+        void FOLLOW가_아닌_알림은_actor가_null이다() {
+            // given
+            User me = userFixture.일반_유저(1);
+            notificationRepository.save(Notification.create(me.getId(), NotificationType.CONGRATULATION,
+                    "유저2님이 축하해줬어요! 🎉"));
+
+            // when
+            SliceResponse<NotificationResponse> result = notificationFacade.getInbox(me.getId(), 0);
+
+            // then
+            assertThat(result.contents().get(0).actor()).isNull();
         }
 
         @Test

--- a/src/test/java/gravit/code/user/service/UserServiceIntegrationTest.java
+++ b/src/test/java/gravit/code/user/service/UserServiceIntegrationTest.java
@@ -10,12 +10,17 @@ import gravit.code.user.dto.request.UserProfileUpdateRequest;
 import gravit.code.user.dto.response.MyPageResponse;
 import gravit.code.user.dto.response.UserLevelResponse;
 import gravit.code.user.dto.response.UserResponse;
+import gravit.code.user.dto.response.UserSummaryResponse;
 import gravit.code.user.fixture.UserFixture;
 import gravit.code.user.repository.UserRepository;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Nested;
 import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
+
+import java.util.Collections;
+import java.util.Map;
+import java.util.Set;
 
 import static gravit.code.global.exception.domain.CustomErrorCode.*;
 import static org.assertj.core.api.Assertions.assertThat;
@@ -298,6 +303,76 @@ class UserServiceIntegrationTest {
                     .isInstanceOf(RestApiException.class)
                     .extracting(e -> ((RestApiException) e).getErrorCode())
                     .isEqualTo(USER_NOT_FOUND);
+        }
+    }
+
+    @Nested
+    @DisplayName("유저 요약 목록을 조회할 때")
+    class GetUserSummaries {
+
+        @Test
+        void 존재하는_유저들의_요약을_Map으로_반환한다() {
+            // given
+            User user1 = userFixture.일반_유저(1);
+            User user2 = userFixture.일반_유저(2);
+
+            // when
+            Map<Long, UserSummaryResponse> result = userService.getUserSummaries(Set.of(user1.getId(), user2.getId()));
+
+            // then
+            assertSoftly(softly -> {
+                softly.assertThat(result).hasSize(2);
+                softly.assertThat(result.get(user1.getId()).nickname()).isEqualTo(user1.getNickname());
+                softly.assertThat(result.get(user1.getId()).profileImgNumber()).isEqualTo(user1.getProfileImgNumber());
+                softly.assertThat(result.get(user2.getId()).nickname()).isEqualTo(user2.getNickname());
+            });
+        }
+
+        @Test
+        void 빈_아이디_집합이면_빈_Map을_반환한다() {
+            // given
+            Set<Long> emptyIds = Collections.emptySet();
+
+            // when
+            Map<Long, UserSummaryResponse> result = userService.getUserSummaries(emptyIds);
+
+            // then
+            assertThat(result).isEmpty();
+        }
+
+        @Test
+        void 탈퇴한_유저는_결과에서_제외된다() {
+            // given
+            User active = userFixture.일반_유저(1);
+            User deleted = userFixture.일반_유저(2);
+            userRepository.deleteById(deleted.getId()); // soft-delete
+
+            // when
+            Map<Long, UserSummaryResponse> result = userService.getUserSummaries(Set.of(active.getId(), deleted.getId()));
+
+            // then
+            assertSoftly(softly -> {
+                softly.assertThat(result).hasSize(1);
+                softly.assertThat(result).containsKey(active.getId());
+                softly.assertThat(result).doesNotContainKey(deleted.getId());
+            });
+        }
+
+        @Test
+        void 존재하지_않는_아이디는_결과에서_제외된다() {
+            // given
+            User user = userFixture.일반_유저(1);
+            long nonExistentUserId = 999L;
+
+            // when
+            Map<Long, UserSummaryResponse> result = userService.getUserSummaries(Set.of(user.getId(), nonExistentUserId));
+
+            // then
+            assertSoftly(softly -> {
+                softly.assertThat(result).hasSize(1);
+                softly.assertThat(result).containsKey(user.getId());
+                softly.assertThat(result).doesNotContainKey(nonExistentUserId);
+            });
         }
     }
 }


### PR DESCRIPTION
### 1. 연관 이슈

---
 - close #401

<br>

### 2. 구현 사항

---
**팔로우 알림에 상대 유저 정보(actor) 포함**

FOLLOW 알림 인박스(`GET inbox`) 조회 시, 상대 유저를 식별·렌더링할 수 있는 정보가 응답에 없어 클라이언트가 별도 조회를 해야 했습니다. 이를 해소하기 위해 상대 유저 정보(`profileId`, `nickname`, `profileImgNumber`)를 **알림 응답에 중첩 객체(`actor`)로 함께 제공**합니다.

- `NotificationResponse`에 nullable `actor` 필드 추가
- FOLLOW 알림이 아니거나 상대 유저가 탈퇴(soft delete)한 경우 `actor`는 `null`
- `actor.profileId`는 자기완결적 식별자로 유지 (다형적인 `targetId` 오버로드에 의존하지 않고 actor 객체만으로 프로필 이동·렌더링 가능)

**유저 정보 배치 조회 (N+1 방지)**

기존 `getInbox`가 FOLLOW targetId를 모아 맞팔 여부를 배치 조회하던 패턴을 그대로 확장했습니다.

- `UserService#getUserSummaries(Set<Long>)` 추가 — userId 집합으로 요약 정보를 **쿼리 1회** 배치 조회 후 `Map<Long, UserSummaryResponse>` 반환 (빈 입력은 쿼리 없이 빈 Map)
- `UserRepository#findSummariesByIds` — `UserSummaryResponse` projection으로 필요한 컬럼만 조회. `User`의 `@SQLRestriction(deleted_at IS NULL)` 덕분에 탈퇴 유저는 결과에서 자동 제외되어 `actor = null`로 자연스럽게 처리됨
- `NotificationFacade#getInbox`에서 조회한 요약 정보를 `NotificationActor`로 매핑

**테스트**

- `NotificationFacadeIntegrationTest`: actor 포함 / 탈퇴 유저 null / 비-FOLLOW null (3건)
- `UserServiceIntegrationTest > GetUserSummaries`: 정상 / 빈 입력 / 탈퇴 제외 / 미존재 제외 (4건)
