### PR TITLE
feat: 관리자 문의(Inquiry) API 개발(#405)

### DIFF
--- a/src/main/java/gravit/code/admin/controller/AdminInquiryController.java
+++ b/src/main/java/gravit/code/admin/controller/AdminInquiryController.java
@@ -1,0 +1,70 @@
+package gravit.code.admin.controller;
+
+import gravit.code.admin.controller.docs.AdminInquiryControllerDocs;
+import gravit.code.admin.dto.request.InquiryAnswerCreateRequest;
+import gravit.code.admin.dto.request.InquiryAnswerUpdateRequest;
+import gravit.code.admin.dto.response.InquiryDetailResponse;
+import gravit.code.admin.dto.response.InquiryListItemResponse;
+import gravit.code.admin.service.AdminInquiryService;
+import gravit.code.auth.domain.LoginUser;
+import gravit.code.global.dto.response.PageResponse;
+import gravit.code.inquiry.domain.InquiryStatus;
+import jakarta.validation.Valid;
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.ResponseEntity;
+import org.springframework.security.core.annotation.AuthenticationPrincipal;
+import org.springframework.web.bind.annotation.DeleteMapping;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.PathVariable;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.PutMapping;
+import org.springframework.web.bind.annotation.RequestBody;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RequestParam;
+import org.springframework.web.bind.annotation.RestController;
+
+@RestController
+@RequiredArgsConstructor
+@RequestMapping("/api/v1/admin/inquiries")
+public class AdminInquiryController implements AdminInquiryControllerDocs {
+
+    private final AdminInquiryService adminInquiryService;
+
+    @GetMapping
+    public ResponseEntity<PageResponse<InquiryListItemResponse>> getInquiries(
+            @RequestParam(value = "status", required = false) InquiryStatus status,
+            @RequestParam(value = "page", defaultValue = "1") int page
+    ) {
+        return ResponseEntity.ok(adminInquiryService.getInquiries(status, page));
+    }
+
+    @GetMapping("/{inquiryId}")
+    public ResponseEntity<InquiryDetailResponse> getInquiry(@PathVariable("inquiryId") long inquiryId) {
+        return ResponseEntity.ok(adminInquiryService.getInquiry(inquiryId));
+    }
+
+    @PostMapping("/{inquiryId}/answer")
+    public ResponseEntity<InquiryDetailResponse> answerInquiry(
+            @AuthenticationPrincipal LoginUser loginUser,
+            @PathVariable("inquiryId") long inquiryId,
+            @Valid @RequestBody InquiryAnswerCreateRequest request
+    ) {
+        InquiryDetailResponse response = adminInquiryService.answer(loginUser.getId(), inquiryId, request);
+        return ResponseEntity.status(HttpStatus.CREATED).body(response);
+    }
+
+    @PutMapping("/{inquiryId}/answer")
+    public ResponseEntity<InquiryDetailResponse> updateAnswer(
+            @PathVariable("inquiryId") long inquiryId,
+            @Valid @RequestBody InquiryAnswerUpdateRequest request
+    ) {
+        return ResponseEntity.ok(adminInquiryService.updateAnswer(inquiryId, request));
+    }
+
+    @DeleteMapping("/{inquiryId}/answer")
+    public ResponseEntity<Void> deleteAnswer(@PathVariable("inquiryId") long inquiryId) {
+        adminInquiryService.deleteAnswer(inquiryId);
+        return ResponseEntity.noContent().build();
+    }
+}

--- a/src/main/java/gravit/code/admin/controller/docs/AdminInquiryControllerDocs.java
+++ b/src/main/java/gravit/code/admin/controller/docs/AdminInquiryControllerDocs.java
@@ -1,0 +1,61 @@
+package gravit.code.admin.controller.docs;
+
+import gravit.code.admin.dto.request.InquiryAnswerCreateRequest;
+import gravit.code.admin.dto.request.InquiryAnswerUpdateRequest;
+import gravit.code.admin.dto.response.InquiryDetailResponse;
+import gravit.code.admin.dto.response.InquiryListItemResponse;
+import gravit.code.auth.domain.LoginUser;
+import gravit.code.global.dto.response.PageResponse;
+import gravit.code.inquiry.domain.InquiryStatus;
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.responses.ApiResponse;
+import io.swagger.v3.oas.annotations.responses.ApiResponses;
+import io.swagger.v3.oas.annotations.tags.Tag;
+import org.springframework.http.ResponseEntity;
+
+@Tag(name = "Admin Inquiry API", description = "백오피스 문의 관리 (상태별 조회 / 답변 등록·수정·삭제)")
+public interface AdminInquiryControllerDocs {
+
+    @Operation(summary = "문의 목록(상태별)", description = "status 미지정 시 전체 조회. 1-based 페이지, id 내림차순.")
+    @ApiResponses(@ApiResponse(responseCode = "200", description = "조회 성공"))
+    ResponseEntity<PageResponse<InquiryListItemResponse>> getInquiries(
+            InquiryStatus status,
+            int page
+    );
+
+    @Operation(summary = "문의 상세", description = "작성자 정보와 답변(있으면)을 포함한다.")
+    @ApiResponses({
+            @ApiResponse(responseCode = "200", description = "조회 성공"),
+            @ApiResponse(responseCode = "404", description = "존재하지 않는 문의")
+    })
+    ResponseEntity<InquiryDetailResponse> getInquiry(long inquiryId);
+
+    @Operation(summary = "문의 답변 등록", description = "답변 등록 시 문의 상태가 RESOLVED 로 자동 전환되고 작성자에게 알림이 발송된다.")
+    @ApiResponses({
+            @ApiResponse(responseCode = "201", description = "답변 등록 성공"),
+            @ApiResponse(responseCode = "404", description = "존재하지 않는 문의"),
+            @ApiResponse(responseCode = "409", description = "이미 답변이 등록된 문의")
+    })
+    ResponseEntity<InquiryDetailResponse> answerInquiry(
+            LoginUser loginUser,
+            long inquiryId,
+            InquiryAnswerCreateRequest request
+    );
+
+    @Operation(summary = "문의 답변 수정", description = "등록된 답변 내용을 수정한다. 상태는 RESOLVED 로 유지된다.")
+    @ApiResponses({
+            @ApiResponse(responseCode = "200", description = "답변 수정 성공"),
+            @ApiResponse(responseCode = "404", description = "존재하지 않는 문의 / 등록된 답변 없음")
+    })
+    ResponseEntity<InquiryDetailResponse> updateAnswer(
+            long inquiryId,
+            InquiryAnswerUpdateRequest request
+    );
+
+    @Operation(summary = "문의 답변 삭제", description = "답변 삭제 시 문의 상태가 PENDING 으로 되돌아간다.")
+    @ApiResponses({
+            @ApiResponse(responseCode = "204", description = "답변 삭제 성공"),
+            @ApiResponse(responseCode = "404", description = "존재하지 않는 문의 / 등록된 답변 없음")
+    })
+    ResponseEntity<Void> deleteAnswer(long inquiryId);
+}

--- a/src/main/java/gravit/code/admin/dto/request/InquiryAnswerCreateRequest.java
+++ b/src/main/java/gravit/code/admin/dto/request/InquiryAnswerCreateRequest.java
@@ -1,0 +1,13 @@
+package gravit.code.admin.dto.request;
+
+import io.swagger.v3.oas.annotations.media.Schema;
+import jakarta.validation.constraints.NotBlank;
+
+@Schema(description = "문의 답변 등록 request")
+public record InquiryAnswerCreateRequest(
+
+        @Schema(description = "답변 내용", requiredMode = Schema.RequiredMode.REQUIRED)
+        @NotBlank
+        String content
+) {
+}

--- a/src/main/java/gravit/code/admin/dto/request/InquiryAnswerUpdateRequest.java
+++ b/src/main/java/gravit/code/admin/dto/request/InquiryAnswerUpdateRequest.java
@@ -1,0 +1,13 @@
+package gravit.code.admin.dto.request;
+
+import io.swagger.v3.oas.annotations.media.Schema;
+import jakarta.validation.constraints.NotBlank;
+
+@Schema(description = "문의 답변 수정 request")
+public record InquiryAnswerUpdateRequest(
+
+        @Schema(description = "수정할 답변 내용", requiredMode = Schema.RequiredMode.REQUIRED)
+        @NotBlank
+        String content
+) {
+}

--- a/src/main/java/gravit/code/admin/dto/response/InquiryAnswerResponse.java
+++ b/src/main/java/gravit/code/admin/dto/response/InquiryAnswerResponse.java
@@ -1,0 +1,31 @@
+package gravit.code.admin.dto.response;
+
+import gravit.code.inquiry.domain.InquiryAnswer;
+import io.swagger.v3.oas.annotations.media.Schema;
+
+import java.time.LocalDateTime;
+
+@Schema(name = "AdminInquiryAnswerResponse")
+public record InquiryAnswerResponse(
+
+        long answerId,
+
+        String content,
+
+        @Schema(description = "답변을 작성한 관리자 ID")
+        long adminId,
+
+        LocalDateTime answeredAt,
+
+        LocalDateTime updatedAt
+) {
+    public static InquiryAnswerResponse from(InquiryAnswer answer) {
+        return new InquiryAnswerResponse(
+                answer.getId(),
+                answer.getContent(),
+                answer.getAdminId(),
+                answer.getCreatedAt(),
+                answer.getUpdatedAt()
+        );
+    }
+}

--- a/src/main/java/gravit/code/admin/dto/response/InquiryDetailResponse.java
+++ b/src/main/java/gravit/code/admin/dto/response/InquiryDetailResponse.java
@@ -1,0 +1,69 @@
+package gravit.code.admin.dto.response;
+
+import gravit.code.inquiry.domain.Inquiry;
+import gravit.code.inquiry.domain.InquiryAnswer;
+import gravit.code.user.domain.User;
+import io.swagger.v3.oas.annotations.media.Schema;
+import lombok.AccessLevel;
+import lombok.Builder;
+
+import java.time.LocalDateTime;
+
+@Schema(name = "AdminInquiryDetailResponse")
+@Builder(access = AccessLevel.PRIVATE)
+public record InquiryDetailResponse(
+
+        long inquiryId,
+
+        String title,
+
+        String type,
+
+        String content,
+
+        String status,
+
+        long submitterId,
+
+        @Schema(
+                description = "작성자 닉네임 (탈퇴한 사용자면 null)",
+                nullable = true
+        )
+        String submitterNickname,
+
+        @Schema(
+                description = "작성자 이메일 (탈퇴한 사용자면 null)",
+                nullable = true
+        )
+        String submitterEmail,
+
+        LocalDateTime createdAt,
+
+        LocalDateTime updatedAt,
+
+        @Schema(
+                description = "관리자 답변 (없으면 null)",
+                nullable = true
+        )
+        InquiryAnswerResponse answer
+) {
+    public static InquiryDetailResponse of(
+            Inquiry inquiry,
+            User submitter,
+            InquiryAnswer answer
+    ) {
+        return InquiryDetailResponse.builder()
+                .inquiryId(inquiry.getId())
+                .title(inquiry.getTitle())
+                .type(inquiry.getType().name())
+                .content(inquiry.getContent())
+                .status(inquiry.getStatus().name())
+                .submitterId(inquiry.getUserId())
+                .submitterNickname(submitter == null ? null : submitter.getNickname())
+                .submitterEmail(submitter == null ? null : submitter.getEmail())
+                .createdAt(inquiry.getCreatedAt())
+                .updatedAt(inquiry.getUpdatedAt())
+                .answer(answer == null ? null : InquiryAnswerResponse.from(answer))
+                .build();
+    }
+}

--- a/src/main/java/gravit/code/admin/dto/response/InquiryListItemResponse.java
+++ b/src/main/java/gravit/code/admin/dto/response/InquiryListItemResponse.java
@@ -1,0 +1,47 @@
+package gravit.code.admin.dto.response;
+
+import gravit.code.inquiry.domain.Inquiry;
+import gravit.code.user.domain.User;
+import io.swagger.v3.oas.annotations.media.Schema;
+import lombok.AccessLevel;
+import lombok.Builder;
+
+import java.time.LocalDateTime;
+
+@Schema(name = "AdminInquiryListItemResponse")
+@Builder(access = AccessLevel.PRIVATE)
+public record InquiryListItemResponse(
+
+        long inquiryId,
+
+        String title,
+
+        String type,
+
+        String status,
+
+        long submitterId,
+
+        @Schema(
+                description = "작성자 닉네임 (탈퇴한 사용자면 null)",
+                nullable = true
+        )
+        String submitterNickname,
+
+        LocalDateTime createdAt
+) {
+    public static InquiryListItemResponse of(
+            Inquiry inquiry,
+            User submitter
+    ) {
+        return InquiryListItemResponse.builder()
+                .inquiryId(inquiry.getId())
+                .title(inquiry.getTitle())
+                .type(inquiry.getType().name())
+                .status(inquiry.getStatus().name())
+                .submitterId(inquiry.getUserId())
+                .submitterNickname(submitter == null ? null : submitter.getNickname())
+                .createdAt(inquiry.getCreatedAt())
+                .build();
+    }
+}

--- a/src/main/java/gravit/code/admin/service/AdminInquiryService.java
+++ b/src/main/java/gravit/code/admin/service/AdminInquiryService.java
@@ -1,0 +1,141 @@
+package gravit.code.admin.service;
+
+import gravit.code.admin.dto.request.InquiryAnswerCreateRequest;
+import gravit.code.admin.dto.request.InquiryAnswerUpdateRequest;
+import gravit.code.admin.dto.response.InquiryDetailResponse;
+import gravit.code.admin.dto.response.InquiryListItemResponse;
+import gravit.code.admin.support.AdminPages;
+import gravit.code.global.dto.response.PageResponse;
+import gravit.code.global.event.InquiryAnsweredEvent;
+import gravit.code.global.exception.domain.CustomErrorCode;
+import gravit.code.global.exception.domain.RestApiException;
+import gravit.code.inquiry.domain.Inquiry;
+import gravit.code.inquiry.domain.InquiryAnswer;
+import gravit.code.inquiry.domain.InquiryStatus;
+import gravit.code.inquiry.repository.InquiryAnswerRepository;
+import gravit.code.inquiry.repository.InquiryRepository;
+import gravit.code.user.domain.User;
+import gravit.code.user.repository.UserRepository;
+import lombok.RequiredArgsConstructor;
+import org.springframework.context.ApplicationEventPublisher;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.Pageable;
+import org.springframework.data.domain.Sort;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+import java.util.List;
+import java.util.Map;
+import java.util.Set;
+import java.util.function.Function;
+import java.util.stream.Collectors;
+
+@Service
+@RequiredArgsConstructor
+public class AdminInquiryService {
+
+    private final InquiryRepository inquiryRepository;
+    private final InquiryAnswerRepository inquiryAnswerRepository;
+    private final UserRepository userRepository;
+    private final ApplicationEventPublisher publisher;
+
+    private static final Sort INQUIRY_LIST_SORT = Sort.by(Sort.Order.desc("id"));
+
+    @Transactional(readOnly = true)
+    public PageResponse<InquiryListItemResponse> getInquiries(
+            InquiryStatus status,
+            int page
+    ) {
+        Pageable pageable = AdminPages.of(page, INQUIRY_LIST_SORT);
+        Page<Inquiry> inquiries = (status == null)
+                ? inquiryRepository.findAll(pageable)
+                : inquiryRepository.findAllByStatus(status, pageable);
+
+        Map<Long, User> submittersById = loadSubmitters(inquiries.getContent());
+
+        return PageResponse.from(
+                inquiries.map(inquiry -> InquiryListItemResponse.of(inquiry, submittersById.get(inquiry.getUserId())))
+        );
+    }
+
+    @Transactional(readOnly = true)
+    public InquiryDetailResponse getInquiry(long inquiryId) {
+        Inquiry inquiry = inquiryRepository.findById(inquiryId)
+                .orElseThrow(() -> new RestApiException(CustomErrorCode.INQUIRY_NOT_FOUND));
+
+        InquiryAnswer answer = inquiryAnswerRepository.findByInquiryId(inquiryId).orElse(null);
+
+        User submitter = userRepository.findById(inquiry.getUserId()).orElse(null);
+
+        return InquiryDetailResponse.of(inquiry, submitter, answer);
+    }
+
+    @Transactional
+    public InquiryDetailResponse answer(
+            long adminId,
+            long inquiryId,
+            InquiryAnswerCreateRequest request
+    ) {
+        Inquiry inquiry = inquiryRepository.findById(inquiryId)
+                .orElseThrow(() -> new RestApiException(CustomErrorCode.INQUIRY_NOT_FOUND));
+
+        if (inquiryAnswerRepository.findByInquiryId(inquiryId).isPresent()) {
+            throw new RestApiException(CustomErrorCode.INQUIRY_ALREADY_ANSWERED);
+        }
+
+        InquiryAnswer answer = inquiryAnswerRepository.save(
+                InquiryAnswer.create(inquiryId, request.content(), adminId)
+        );
+        inquiry.resolve();
+
+        publisher.publishEvent(new InquiryAnsweredEvent(inquiryId, inquiry.getUserId(), inquiry.getTitle()));
+
+        User submitter = userRepository.findById(inquiry.getUserId()).orElse(null);
+
+        return InquiryDetailResponse.of(inquiry, submitter, answer);
+    }
+
+    @Transactional
+    public InquiryDetailResponse updateAnswer(
+            long inquiryId,
+            InquiryAnswerUpdateRequest request
+    ) {
+        Inquiry inquiry = inquiryRepository.findById(inquiryId)
+                .orElseThrow(() -> new RestApiException(CustomErrorCode.INQUIRY_NOT_FOUND));
+
+        InquiryAnswer answer = inquiryAnswerRepository.findByInquiryId(inquiryId)
+                .orElseThrow(() -> new RestApiException(CustomErrorCode.INQUIRY_ANSWER_NOT_FOUND));
+
+        answer.update(request.content());
+
+        User submitter = userRepository.findById(inquiry.getUserId()).orElse(null);
+
+        return InquiryDetailResponse.of(inquiry, submitter, answer);
+    }
+
+    @Transactional
+    public void deleteAnswer(long inquiryId) {
+        Inquiry inquiry = inquiryRepository.findById(inquiryId)
+                .orElseThrow(() -> new RestApiException(CustomErrorCode.INQUIRY_NOT_FOUND));
+
+        InquiryAnswer answer = inquiryAnswerRepository.findByInquiryId(inquiryId)
+                .orElseThrow(() -> new RestApiException(CustomErrorCode.INQUIRY_ANSWER_NOT_FOUND));
+
+        inquiryAnswerRepository.delete(answer);
+
+        inquiry.reopen();
+    }
+
+    private Map<Long, User> loadSubmitters(List<Inquiry> inquiries) {
+        Set<Long> userIds = inquiries.stream()
+                .map(Inquiry::getUserId)
+                .collect(Collectors.toSet());
+
+        if (userIds.isEmpty()) {
+            return Map.of();
+        }
+
+        return userRepository.findAllById(userIds).stream()
+                .collect(Collectors.toMap(User::getId, Function.identity()));
+    }
+}

--- a/src/main/java/gravit/code/global/event/InquiryAnsweredEvent.java
+++ b/src/main/java/gravit/code/global/event/InquiryAnsweredEvent.java
@@ -1,0 +1,8 @@
+package gravit.code.global.event;
+
+public record InquiryAnsweredEvent(
+        long inquiryId,
+        long userId,
+        String inquiryTitle
+) {
+}

--- a/src/main/java/gravit/code/global/exception/domain/CustomErrorCode.java
+++ b/src/main/java/gravit/code/global/exception/domain/CustomErrorCode.java
@@ -126,7 +126,9 @@ public enum CustomErrorCode implements ErrorCode {
     INQUIRY_CONTENT_INVALID(HttpStatus.BAD_REQUEST, "INQUIRY_4002", "문의 내용이 유효하지 않습니다."),
     INQUIRY_FORBIDDEN(HttpStatus.FORBIDDEN, "INQUIRY_4031", "본인의 문의만 접근할 수 있습니다."),
     INQUIRY_NOT_FOUND(HttpStatus.NOT_FOUND, "INQUIRY_4041", "존재하지 않는 문의입니다."),
+    INQUIRY_ANSWER_NOT_FOUND(HttpStatus.NOT_FOUND, "INQUIRY_4042", "등록된 답변이 없습니다."),
     INQUIRY_ALREADY_RESOLVED(HttpStatus.CONFLICT, "INQUIRY_4091", "이미 답변이 완료된 문의는 수정/삭제할 수 없습니다."),
+    INQUIRY_ALREADY_ANSWERED(HttpStatus.CONFLICT, "INQUIRY_4092", "이미 답변이 등록된 문의입니다."),
 
     // Staging (admin 콘텐츠 검수/승급)
     STAGING_LABEL_NOT_FOUND(HttpStatus.NOT_FOUND, "STAGING_4041", "존재하지 않는 스테이징 라벨입니다."),

--- a/src/main/java/gravit/code/inquiry/domain/Inquiry.java
+++ b/src/main/java/gravit/code/inquiry/domain/Inquiry.java
@@ -108,6 +108,16 @@ public class Inquiry extends BaseEntity {
         }
     }
 
+    // 관리자 답변 등록 시 자동 완료 처리
+    public void resolve() {
+        this.status = RESOLVED;
+    }
+
+    // 관리자 답변 삭제 시 미답변 상태로 되돌린다
+    public void reopen() {
+        this.status = PENDING;
+    }
+
     public boolean isOwnedBy(long userId) {
         return this.userId == userId;
     }

--- a/src/main/java/gravit/code/inquiry/domain/InquiryAnswer.java
+++ b/src/main/java/gravit/code/inquiry/domain/InquiryAnswer.java
@@ -53,4 +53,8 @@ public class InquiryAnswer extends BaseEntity {
                 .adminId(adminId)
                 .build();
     }
+
+    public void update(String content) {
+        this.content = content;
+    }
 }

--- a/src/main/java/gravit/code/inquiry/repository/InquiryRepository.java
+++ b/src/main/java/gravit/code/inquiry/repository/InquiryRepository.java
@@ -1,6 +1,7 @@
 package gravit.code.inquiry.repository;
 
 import gravit.code.inquiry.domain.Inquiry;
+import gravit.code.inquiry.domain.InquiryStatus;
 import org.springframework.data.domain.Page;
 import org.springframework.data.domain.Pageable;
 import org.springframework.data.jpa.repository.JpaRepository;
@@ -11,6 +12,11 @@ public interface InquiryRepository extends JpaRepository<Inquiry, Long> {
 
     Page<Inquiry> findAllByUserId(
             long userId,
+            Pageable pageable
+    );
+
+    Page<Inquiry> findAllByStatus(
+            InquiryStatus status,
             Pageable pageable
     );
 

--- a/src/main/java/gravit/code/notification/domain/NotificationActionType.java
+++ b/src/main/java/gravit/code/notification/domain/NotificationActionType.java
@@ -10,6 +10,7 @@ public enum NotificationActionType {
     NONE("버튼 없음"),                     // 액션 없음 (targetId 없음)
     GO_TO_LEARNING("학습하러 가기"),         // 학습 메인(targetId 없음) 또는 레슨 딥링크(targetId = unit)
     GO_TO_NOTICE("공지사항 바로가기"),       // targetId = noticeId
+    GO_TO_INQUIRY("문의 답변 보기"),         // targetId = inquiryId
     FOLLOW_BACK("맞팔로우"),               // targetId = 상대 userId
     UNFOLLOW("팔로우 취소"),               // targetId = 상대 userId (이미 맞팔로우한 경우)
     CONGRATULATE("축하하기");              // targetId = feedId

--- a/src/main/java/gravit/code/notification/domain/NotificationType.java
+++ b/src/main/java/gravit/code/notification/domain/NotificationType.java
@@ -21,7 +21,8 @@ public enum NotificationType {
     FRIEND_ACTIVITY(CONGRATULATE),     // 3.11 친구 활동
     NOTICE(GO_TO_NOTICE),              // 3.12 공지사항
     VERSION(GO_TO_NOTICE),             // 3.13 버전 관리
-    NEW_CONTENT(GO_TO_LEARNING);       // 3.14 새 콘텐츠 업데이트
+    NEW_CONTENT(GO_TO_LEARNING),       // 3.14 새 콘텐츠 업데이트
+    INQUIRY_ANSWERED(GO_TO_INQUIRY);   // 3.15 문의 답변 등록
 
     private final NotificationActionType actionType;
 

--- a/src/main/java/gravit/code/notification/listener/NotificationEventListener.java
+++ b/src/main/java/gravit/code/notification/listener/NotificationEventListener.java
@@ -1,5 +1,6 @@
 package gravit.code.notification.listener;
 
+import gravit.code.global.event.InquiryAnsweredEvent;
 import gravit.code.global.event.NoticeCreatedEvent;
 import gravit.code.global.event.SeasonRolledOverEvent;
 import gravit.code.notification.domain.NotificationType;
@@ -31,6 +32,17 @@ public class NotificationEventListener {
             notificationService.notifyAllUsers(NotificationType.NOTICE, message, event.noticeId());
         } catch (Exception e) {
             log.error("공지 알림 적재 실패 - noticeId: {}", event.noticeId(), e);
+        }
+    }
+
+    @TransactionalEventListener(phase = TransactionPhase.AFTER_COMMIT)
+    @Transactional(propagation = Propagation.REQUIRES_NEW)
+    public void handleInquiryAnswered(InquiryAnsweredEvent event) {
+        try {
+            String message = messageProvider.inquiryAnswered(event.inquiryTitle());
+            notificationFacade.notifyUser(event.userId(), NotificationType.INQUIRY_ANSWERED, message, event.inquiryId());
+        } catch (Exception e) {
+            log.error("문의 답변 알림 발송 실패 - inquiryId: {}", event.inquiryId(), e);
         }
     }
 

--- a/src/main/java/gravit/code/notification/support/NotificationMessageProvider.java
+++ b/src/main/java/gravit/code/notification/support/NotificationMessageProvider.java
@@ -61,6 +61,10 @@ public class NotificationMessageProvider {
         return "[공지] " + noticeTitle;
     }
 
+    public String inquiryAnswered(String inquiryTitle) {
+        return "문의하신 \"" + inquiryTitle + "\"에 답변이 등록되었어요 ✅";
+    }
+
     public String newContent() {
         return NEW_CONTENT_MESSAGE;
     }

--- a/src/main/resources/db/migration/V24__add_inquiry_answered_notification_type.sql
+++ b/src/main/resources/db/migration/V24__add_inquiry_answered_notification_type.sql
@@ -1,0 +1,12 @@
+--V24__add_inquiry_answered_notification_type.sql
+
+-- 문의 답변 알림(INQUIRY_ANSWERED) 타입 추가를 위해 notification type CHECK 제약을 갱신한다
+ALTER TABLE notification DROP CONSTRAINT IF EXISTS ck_notification_type;
+
+ALTER TABLE notification ADD CONSTRAINT ck_notification_type CHECK (
+    type IN (
+        'CONSECUTIVE_LEARNING_WARNING', 'DAILY_INCOMPLETE', 'INACTIVITY', 'SEASON_ENDING',
+        'SEASON_RESET', 'FOLLOW', 'CONGRATULATION', 'FRIEND_ACTIVITY',
+        'NOTICE', 'VERSION', 'NEW_CONTENT', 'INQUIRY_ANSWERED'
+    )
+);

--- a/src/test/java/gravit/code/admin/service/AdminInquiryServiceIntegrationTest.java
+++ b/src/test/java/gravit/code/admin/service/AdminInquiryServiceIntegrationTest.java
@@ -1,0 +1,397 @@
+package gravit.code.admin.service;
+
+import gravit.code.admin.dto.request.InquiryAnswerCreateRequest;
+import gravit.code.admin.dto.request.InquiryAnswerUpdateRequest;
+import gravit.code.admin.dto.response.InquiryDetailResponse;
+import gravit.code.admin.dto.response.InquiryListItemResponse;
+import gravit.code.global.dto.response.PageResponse;
+import gravit.code.global.event.InquiryAnsweredEvent;
+import gravit.code.global.exception.domain.RestApiException;
+import gravit.code.inquiry.domain.Inquiry;
+import gravit.code.inquiry.domain.InquiryAnswer;
+import gravit.code.inquiry.domain.InquiryStatus;
+import gravit.code.inquiry.domain.InquiryType;
+import gravit.code.inquiry.repository.InquiryAnswerRepository;
+import gravit.code.inquiry.repository.InquiryRepository;
+import gravit.code.support.TCSpringBootTest;
+import gravit.code.user.domain.User;
+import gravit.code.user.fixture.UserFixture;
+import gravit.code.user.repository.UserRepository;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Nested;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.test.context.event.ApplicationEvents;
+import org.springframework.test.context.event.RecordApplicationEvents;
+import org.springframework.test.util.ReflectionTestUtils;
+
+import java.util.List;
+
+import static gravit.code.global.exception.domain.CustomErrorCode.INQUIRY_ALREADY_ANSWERED;
+import static gravit.code.global.exception.domain.CustomErrorCode.INQUIRY_ANSWER_NOT_FOUND;
+import static gravit.code.global.exception.domain.CustomErrorCode.INQUIRY_NOT_FOUND;
+import static gravit.code.global.exception.domain.CustomErrorCode.PAGE_MUST_START_FROM_1;
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static org.assertj.core.api.SoftAssertions.assertSoftly;
+
+@TCSpringBootTest
+@RecordApplicationEvents
+class AdminInquiryServiceIntegrationTest {
+
+    @Autowired
+    private AdminInquiryService adminInquiryService;
+
+    @Autowired
+    private InquiryRepository inquiryRepository;
+
+    @Autowired
+    private InquiryAnswerRepository inquiryAnswerRepository;
+
+    @Autowired
+    private UserRepository userRepository;
+
+    @Autowired
+    private UserFixture userFixture;
+
+    private long submitterId;
+    private String submitterNickname;
+    private String submitterEmail;
+    private long adminId;
+
+    @BeforeEach
+    void setUp() {
+        User submitter = userFixture.일반_유저(1);
+        submitterId = submitter.getId();
+        submitterNickname = submitter.getNickname();
+        submitterEmail = submitter.getEmail();
+
+        adminId = userFixture.일반_유저(2).getId();
+    }
+
+    @Nested
+    @DisplayName("문의 목록을 조회할 때")
+    class GetInquiries {
+
+        @Test
+        void 상태_미지정이면_전체_문의를_id_내림차순으로_조회하고_작성자_닉네임을_매핑한다() {
+            // given
+            savePending(submitterId, "첫 번째");
+            savePending(submitterId, "두 번째");
+            Inquiry latest = savePending(submitterId, "세 번째");
+
+            // when
+            PageResponse<InquiryListItemResponse> result = adminInquiryService.getInquiries(null, 1);
+
+            // then
+            assertSoftly(softly -> {
+                softly.assertThat(result.contents()).hasSize(3);
+                softly.assertThat(result.contents().get(0).inquiryId()).isEqualTo(latest.getId());
+                softly.assertThat(result.contents().get(0).title()).isEqualTo("세 번째");
+                softly.assertThat(result.contents().get(0).submitterId()).isEqualTo(submitterId);
+                softly.assertThat(result.contents().get(0).submitterNickname()).isEqualTo(submitterNickname);
+            });
+        }
+
+        @Test
+        void status로_필터링하면_해당_상태의_문의만_조회된다() {
+            // given
+            savePending(submitterId, "대기 문의");
+            saveResolved(submitterId, "완료 문의");
+
+            // when
+            PageResponse<InquiryListItemResponse> pending = adminInquiryService.getInquiries(InquiryStatus.PENDING, 1);
+            PageResponse<InquiryListItemResponse> resolved = adminInquiryService.getInquiries(InquiryStatus.RESOLVED, 1);
+
+            // then
+            assertSoftly(softly -> {
+                softly.assertThat(pending.contents())
+                        .extracting(InquiryListItemResponse::status)
+                        .containsExactly(InquiryStatus.PENDING.name());
+                softly.assertThat(resolved.contents())
+                        .extracting(InquiryListItemResponse::status)
+                        .containsExactly(InquiryStatus.RESOLVED.name());
+            });
+        }
+
+        @Test
+        void 문의가_없으면_빈_목록을_반환한다() {
+            // when
+            PageResponse<InquiryListItemResponse> result = adminInquiryService.getInquiries(null, 1);
+
+            // then
+            assertThat(result.contents()).isEmpty();
+        }
+
+        @Test
+        void 탈퇴한_작성자의_문의는_작성자_닉네임이_null로_조회된다() {
+            // given
+            User leaving = userFixture.일반_유저(9);
+            long leavingId = leaving.getId();
+            savePending(leavingId, "탈퇴 예정자의 문의");
+            userRepository.delete(leaving); // @SQLDelete: soft delete
+
+            // when
+            PageResponse<InquiryListItemResponse> result = adminInquiryService.getInquiries(null, 1);
+
+            // then
+            InquiryListItemResponse item = result.contents().stream()
+                    .filter(i -> i.submitterId() == leavingId)
+                    .findFirst()
+                    .orElseThrow();
+            assertThat(item.submitterNickname()).isNull();
+        }
+
+        @Test
+        void page가_1보다_작으면_예외가_발생한다() {
+            // when & then
+            assertThatThrownBy(() -> adminInquiryService.getInquiries(null, 0))
+                    .isInstanceOf(RestApiException.class)
+                    .extracting(e -> ((RestApiException) e).getErrorCode())
+                    .isEqualTo(PAGE_MUST_START_FROM_1);
+        }
+    }
+
+    @Nested
+    @DisplayName("문의 상세를 조회할 때")
+    class GetInquiry {
+
+        @Test
+        void 작성자_정보와_답변을_함께_조회한다() {
+            // given
+            Inquiry inquiry = saveResolved(submitterId, "완료된 문의");
+            saveAnswer(inquiry.getId(), "확인 후 반영했습니다.");
+
+            // when
+            InquiryDetailResponse detail = adminInquiryService.getInquiry(inquiry.getId());
+
+            // then
+            assertSoftly(softly -> {
+                softly.assertThat(detail.inquiryId()).isEqualTo(inquiry.getId());
+                softly.assertThat(detail.status()).isEqualTo(InquiryStatus.RESOLVED.name());
+                softly.assertThat(detail.submitterId()).isEqualTo(submitterId);
+                softly.assertThat(detail.submitterNickname()).isEqualTo(submitterNickname);
+                softly.assertThat(detail.submitterEmail()).isEqualTo(submitterEmail);
+                softly.assertThat(detail.answer()).isNotNull();
+                softly.assertThat(detail.answer().content()).isEqualTo("확인 후 반영했습니다.");
+                softly.assertThat(detail.answer().adminId()).isEqualTo(adminId);
+            });
+        }
+
+        @Test
+        void 답변이_없으면_answer가_null로_조회된다() {
+            // given
+            Inquiry inquiry = savePending(submitterId, "답변 대기 문의");
+
+            // when
+            InquiryDetailResponse detail = adminInquiryService.getInquiry(inquiry.getId());
+
+            // then
+            assertSoftly(softly -> {
+                softly.assertThat(detail.status()).isEqualTo(InquiryStatus.PENDING.name());
+                softly.assertThat(detail.answer()).isNull();
+            });
+        }
+
+        @Test
+        void 존재하지_않는_문의면_예외가_발생한다() {
+            // when & then
+            assertThatThrownBy(() -> adminInquiryService.getInquiry(999L))
+                    .isInstanceOf(RestApiException.class)
+                    .extracting(e -> ((RestApiException) e).getErrorCode())
+                    .isEqualTo(INQUIRY_NOT_FOUND);
+        }
+    }
+
+    @Nested
+    @DisplayName("문의에 답변을 등록할 때")
+    class Answer {
+
+        @Test
+        void 답변이_저장되고_상태가_RESOLVED로_전환된다() {
+            // given
+            Inquiry inquiry = savePending(submitterId, "버그 문의");
+            InquiryAnswerCreateRequest request = new InquiryAnswerCreateRequest("재현 확인 후 수정했습니다.");
+
+            // when
+            InquiryDetailResponse detail = adminInquiryService.answer(adminId, inquiry.getId(), request);
+
+            // then
+            Inquiry persisted = inquiryRepository.findById(inquiry.getId()).orElseThrow();
+            InquiryAnswer savedAnswer = inquiryAnswerRepository.findByInquiryId(inquiry.getId()).orElseThrow();
+            assertSoftly(softly -> {
+                softly.assertThat(detail.status()).isEqualTo(InquiryStatus.RESOLVED.name());
+                softly.assertThat(detail.answer()).isNotNull();
+                softly.assertThat(detail.answer().content()).isEqualTo("재현 확인 후 수정했습니다.");
+                softly.assertThat(detail.answer().adminId()).isEqualTo(adminId);
+                softly.assertThat(persisted.getStatus()).isEqualTo(InquiryStatus.RESOLVED);
+                softly.assertThat(savedAnswer.getContent()).isEqualTo("재현 확인 후 수정했습니다.");
+            });
+        }
+
+        @Test
+        void 작성자에게_보낼_InquiryAnsweredEvent를_발행한다(ApplicationEvents events) {
+            // given
+            Inquiry inquiry = savePending(submitterId, "답변 알림 대상 문의");
+            InquiryAnswerCreateRequest request = new InquiryAnswerCreateRequest("답변 드립니다.");
+
+            // when
+            adminInquiryService.answer(adminId, inquiry.getId(), request);
+
+            // then
+            List<InquiryAnsweredEvent> published = events.stream(InquiryAnsweredEvent.class).toList();
+            assertThat(published).hasSize(1);
+            assertSoftly(softly -> {
+                softly.assertThat(published.get(0).inquiryId()).isEqualTo(inquiry.getId());
+                softly.assertThat(published.get(0).userId()).isEqualTo(submitterId);
+                softly.assertThat(published.get(0).inquiryTitle()).isEqualTo("답변 알림 대상 문의");
+            });
+        }
+
+        @Test
+        void 이미_답변이_등록된_문의면_예외가_발생한다() {
+            // given
+            Inquiry inquiry = savePending(submitterId, "중복 답변 문의");
+            saveAnswer(inquiry.getId(), "먼저 등록된 답변");
+            InquiryAnswerCreateRequest request = new InquiryAnswerCreateRequest("나중에 등록 시도하는 답변");
+
+            // when & then
+            assertThatThrownBy(() -> adminInquiryService.answer(adminId, inquiry.getId(), request))
+                    .isInstanceOf(RestApiException.class)
+                    .extracting(e -> ((RestApiException) e).getErrorCode())
+                    .isEqualTo(INQUIRY_ALREADY_ANSWERED);
+        }
+
+        @Test
+        void 존재하지_않는_문의면_예외가_발생한다() {
+            // given
+            InquiryAnswerCreateRequest request = new InquiryAnswerCreateRequest("답변");
+
+            // when & then
+            assertThatThrownBy(() -> adminInquiryService.answer(adminId, 999L, request))
+                    .isInstanceOf(RestApiException.class)
+                    .extracting(e -> ((RestApiException) e).getErrorCode())
+                    .isEqualTo(INQUIRY_NOT_FOUND);
+        }
+    }
+
+    @Nested
+    @DisplayName("답변을 수정할 때")
+    class UpdateAnswer {
+
+        @Test
+        void 답변_내용이_수정되고_상태는_RESOLVED로_유지된다() {
+            // given
+            Inquiry inquiry = saveResolved(submitterId, "답변 수정 대상");
+            saveAnswer(inquiry.getId(), "초기 답변");
+            InquiryAnswerUpdateRequest request = new InquiryAnswerUpdateRequest("수정된 답변");
+
+            // when
+            InquiryDetailResponse detail = adminInquiryService.updateAnswer(inquiry.getId(), request);
+
+            // then
+            InquiryAnswer persisted = inquiryAnswerRepository.findByInquiryId(inquiry.getId()).orElseThrow();
+            assertSoftly(softly -> {
+                softly.assertThat(detail.answer().content()).isEqualTo("수정된 답변");
+                softly.assertThat(detail.status()).isEqualTo(InquiryStatus.RESOLVED.name());
+                softly.assertThat(persisted.getContent()).isEqualTo("수정된 답변");
+            });
+        }
+
+        @Test
+        void 등록된_답변이_없으면_예외가_발생한다() {
+            // given
+            Inquiry inquiry = savePending(submitterId, "답변 없는 문의");
+            InquiryAnswerUpdateRequest request = new InquiryAnswerUpdateRequest("수정 답변");
+
+            // when & then
+            assertThatThrownBy(() -> adminInquiryService.updateAnswer(inquiry.getId(), request))
+                    .isInstanceOf(RestApiException.class)
+                    .extracting(e -> ((RestApiException) e).getErrorCode())
+                    .isEqualTo(INQUIRY_ANSWER_NOT_FOUND);
+        }
+
+        @Test
+        void 존재하지_않는_문의면_예외가_발생한다() {
+            // given
+            InquiryAnswerUpdateRequest request = new InquiryAnswerUpdateRequest("수정 답변");
+
+            // when & then
+            assertThatThrownBy(() -> adminInquiryService.updateAnswer(999L, request))
+                    .isInstanceOf(RestApiException.class)
+                    .extracting(e -> ((RestApiException) e).getErrorCode())
+                    .isEqualTo(INQUIRY_NOT_FOUND);
+        }
+    }
+
+    @Nested
+    @DisplayName("답변을 삭제할 때")
+    class DeleteAnswer {
+
+        @Test
+        void 답변이_삭제되고_상태가_PENDING으로_되돌아간다() {
+            // given
+            Inquiry inquiry = saveResolved(submitterId, "답변 삭제 대상");
+            saveAnswer(inquiry.getId(), "삭제될 답변");
+
+            // when
+            adminInquiryService.deleteAnswer(inquiry.getId());
+
+            // then
+            Inquiry persisted = inquiryRepository.findById(inquiry.getId()).orElseThrow();
+            assertSoftly(softly -> {
+                softly.assertThat(inquiryAnswerRepository.findByInquiryId(inquiry.getId())).isEmpty();
+                softly.assertThat(persisted.getStatus()).isEqualTo(InquiryStatus.PENDING);
+            });
+        }
+
+        @Test
+        void 등록된_답변이_없으면_예외가_발생한다() {
+            // given
+            Inquiry inquiry = savePending(submitterId, "답변 없는 문의");
+
+            // when & then
+            assertThatThrownBy(() -> adminInquiryService.deleteAnswer(inquiry.getId()))
+                    .isInstanceOf(RestApiException.class)
+                    .extracting(e -> ((RestApiException) e).getErrorCode())
+                    .isEqualTo(INQUIRY_ANSWER_NOT_FOUND);
+        }
+
+        @Test
+        void 존재하지_않는_문의면_예외가_발생한다() {
+            // when & then
+            assertThatThrownBy(() -> adminInquiryService.deleteAnswer(999L))
+                    .isInstanceOf(RestApiException.class)
+                    .extracting(e -> ((RestApiException) e).getErrorCode())
+                    .isEqualTo(INQUIRY_NOT_FOUND);
+        }
+    }
+
+    private Inquiry savePending(
+            long userId,
+            String title
+    ) {
+        return inquiryRepository.save(
+                Inquiry.create(title, InquiryType.BUG_REPORT, "내용", userId)
+        );
+    }
+
+    private Inquiry saveResolved(
+            long userId,
+            String title
+    ) {
+        Inquiry inquiry = Inquiry.create(title, InquiryType.BUG_REPORT, "내용", userId);
+        ReflectionTestUtils.setField(inquiry, "status", InquiryStatus.RESOLVED);
+        return inquiryRepository.save(inquiry);
+    }
+
+    private InquiryAnswer saveAnswer(
+            long inquiryId,
+            String content
+    ) {
+        return inquiryAnswerRepository.save(
+                InquiryAnswer.create(inquiryId, content, adminId)
+        );
+    }
+}


### PR DESCRIPTION
### 1. 연관 이슈

---
 - close #405

<br>

### 2. 구현 사항

---
**관리자 문의(Inquiry) API**

- 백오피스 문의 처리 API 추가 (`/api/v1/admin/inquiries`): 상태별 목록 조회 / 상세(작성자·답변 포함) / 답변 등록·수정·삭제
- 답변 등록 시 상태 자동 `RESOLVED`, 답변 삭제 시 `PENDING` 복귀
- 답변 등록 시 작성자에게 알림 발송 (`INQUIRY_ANSWERED` 타입 추가, 이벤트 기반)
- `AdminInquiryService` 통합 테스트 18케이스 추가

> ⚠️ `feat/404-inquiry-api` 기반 스택 PR입니다. #406 머지 후 베이스가 dev로 정리됩니다.