### PR TITLE
feat: 팔로우 알림 일원화 및 알림 timeAgo 추가

### DIFF
--- a/src/main/java/gravit/code/friend/service/FriendService.java
+++ b/src/main/java/gravit/code/friend/service/FriendService.java
@@ -9,6 +9,7 @@ import gravit.code.friend.dto.response.FollowingResponse;
 import gravit.code.friend.dto.response.FriendResponse;
 import gravit.code.friend.repository.FriendRepository;
 import gravit.code.global.dto.response.SliceResponse;
+import gravit.code.global.event.FollowedEvent;
 import gravit.code.global.exception.domain.CustomErrorCode;
 import gravit.code.global.exception.domain.RestApiException;
 import gravit.code.mission.dto.event.FollowMissionEvent;
@@ -64,6 +65,7 @@ public class FriendService {
         friendRepository.save(friend);
 
         publisher.publishEvent(new FollowMissionEvent(followerId));
+        publisher.publishEvent(new FollowedEvent(followerId, followeeId));
 
         return FriendResponse.from(friend);
     }

--- a/src/main/java/gravit/code/global/event/FollowedEvent.java
+++ b/src/main/java/gravit/code/global/event/FollowedEvent.java
@@ -1,0 +1,7 @@
+package gravit.code.global.event;
+
+public record FollowedEvent(
+        long followerId,
+        long followeeId
+) {
+}

--- a/src/main/java/gravit/code/global/util/TimeAgoFormatter.java
+++ b/src/main/java/gravit/code/global/util/TimeAgoFormatter.java
@@ -1,0 +1,29 @@
+package gravit.code.global.util;
+
+import java.time.LocalDateTime;
+import java.time.ZoneId;
+import java.time.temporal.ChronoUnit;
+
+// 생성 시각을 "방금 전 / N분 전 / N시간 전 / N일 전(최대 7일)" 상대 표현으로 변환한다
+public final class TimeAgoFormatter {
+
+    private static final ZoneId KST = ZoneId.of("Asia/Seoul");
+    private static final long MAX_DAYS = 7;
+
+    private TimeAgoFormatter() {
+    }
+
+    public static String format(LocalDateTime createdAt) {
+        LocalDateTime now = LocalDateTime.now(KST);
+
+        long minutes = ChronoUnit.MINUTES.between(createdAt, now);
+        if (minutes < 1) return "방금 전";
+        if (minutes < 60) return minutes + "분 전";
+
+        long hours = ChronoUnit.HOURS.between(createdAt, now);
+        if (hours < 24) return hours + "시간 전";
+
+        long days = ChronoUnit.DAYS.between(createdAt, now);
+        return Math.min(days, MAX_DAYS) + "일 전";
+    }
+}

--- a/src/main/java/gravit/code/notification/controller/NotificationController.java
+++ b/src/main/java/gravit/code/notification/controller/NotificationController.java
@@ -5,17 +5,14 @@ import gravit.code.global.dto.response.SliceResponse;
 import gravit.code.notification.controller.docs.NotificationDocs;
 import gravit.code.notification.dto.response.NotificationResponse;
 import gravit.code.notification.facade.NotificationFacade;
-import jakarta.validation.constraints.Min;
 import lombok.RequiredArgsConstructor;
 import org.springframework.http.ResponseEntity;
 import org.springframework.security.core.annotation.AuthenticationPrincipal;
-import org.springframework.validation.annotation.Validated;
 import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RequestParam;
 import org.springframework.web.bind.annotation.RestController;
 
-@Validated
 @RestController
 @RequestMapping("/api/v1/notifications")
 @RequiredArgsConstructor
@@ -26,7 +23,7 @@ public class NotificationController implements NotificationDocs {
     @GetMapping
     public ResponseEntity<SliceResponse<NotificationResponse>> getInbox(
             @AuthenticationPrincipal LoginUser loginUser,
-            @RequestParam(defaultValue = "0") @Min(0) int page
+            @RequestParam(defaultValue = "0") int page
     ) {
         SliceResponse<NotificationResponse> inbox = notificationFacade.getInbox(loginUser.getId(), page);
         return ResponseEntity.ok(inbox);

--- a/src/main/java/gravit/code/notification/controller/docs/NotificationDocs.java
+++ b/src/main/java/gravit/code/notification/controller/docs/NotificationDocs.java
@@ -5,8 +5,6 @@ import gravit.code.global.dto.response.SliceResponse;
 import gravit.code.notification.dto.response.NotificationResponse;
 import io.swagger.v3.oas.annotations.Operation;
 import io.swagger.v3.oas.annotations.Parameter;
-import io.swagger.v3.oas.annotations.media.Content;
-import io.swagger.v3.oas.annotations.media.ExampleObject;
 import io.swagger.v3.oas.annotations.responses.ApiResponse;
 import io.swagger.v3.oas.annotations.responses.ApiResponses;
 import io.swagger.v3.oas.annotations.tags.Tag;
@@ -33,47 +31,7 @@ public interface NotificationDocs {
     @ApiResponses({
             @ApiResponse(
                     responseCode = "200",
-                    description = "✅ 조회 성공",
-                    content = @Content(
-                            mediaType = "application/json",
-                            examples = @ExampleObject(
-                                    name = "inbox-sample",
-                                    value = """
-                                            {
-                                              "hasNextPage": true,
-                                              "contents": [
-                                                {
-                                                  "id": 101,
-                                                  "type": "FOLLOW",
-                                                  "message": "홍길동님이 나를 팔로우했어요! 👀",
-                                                  "actionType": "FOLLOW_BACK",
-                                                  "targetId": 42,
-                                                  "read": false,
-                                                  "createdAt": "2025-09-25T10:00:00"
-                                                },
-                                                {
-                                                  "id": 100,
-                                                  "type": "FOLLOW",
-                                                  "message": "김철수님이 나를 팔로우했어요! 👀",
-                                                  "actionType": "UNFOLLOW",
-                                                  "targetId": 37,
-                                                  "read": true,
-                                                  "createdAt": "2025-09-24T08:30:00"
-                                                },
-                                                {
-                                                  "id": 99,
-                                                  "type": "FRIEND_ACTIVITY",
-                                                  "message": "이영희님이 OS행성을 정복했어요! 🌍",
-                                                  "actionType": "CONGRATULATE",
-                                                  "targetId": 55,
-                                                  "read": false,
-                                                  "createdAt": "2025-09-23T20:15:00"
-                                                }
-                                              ]
-                                            }
-                                            """
-                            )
-                    )
+                    description = "✅ 조회 성공"
             )
     })
     @GetMapping

--- a/src/main/java/gravit/code/notification/dto/response/NotificationResponse.java
+++ b/src/main/java/gravit/code/notification/dto/response/NotificationResponse.java
@@ -1,5 +1,6 @@
 package gravit.code.notification.dto.response;
 
+import gravit.code.global.util.TimeAgoFormatter;
 import gravit.code.notification.domain.Notification;
 import gravit.code.notification.domain.NotificationActionType;
 import io.swagger.v3.oas.annotations.media.Schema;
@@ -44,6 +45,13 @@ public record NotificationResponse(
         @Schema(description = "생성 시각", requiredMode = Schema.RequiredMode.REQUIRED)
         LocalDateTime createdAt,
 
+        @Schema(
+                description = "생성 시각의 상대 표현 (방금 전 / N분 전 / N시간 전 / N일 전, 최대 7일 전)",
+                example = "3시간 전",
+                requiredMode = Schema.RequiredMode.REQUIRED
+        )
+        String timeAgo,
+
         @Schema(description = "팔로우 알림의 상대 유저 정보 (FOLLOW 알림이 아니거나 탈퇴한 유저면 null)")
         NotificationActor actor
 
@@ -61,6 +69,7 @@ public record NotificationResponse(
                 .targetId(notification.getTargetId())
                 .read(notification.isRead())
                 .createdAt(notification.getCreatedAt())
+                .timeAgo(TimeAgoFormatter.format(notification.getCreatedAt()))
                 .actor(actor)
                 .build();
     }

--- a/src/main/java/gravit/code/notification/listener/NotificationEventListener.java
+++ b/src/main/java/gravit/code/notification/listener/NotificationEventListener.java
@@ -1,5 +1,6 @@
 package gravit.code.notification.listener;
 
+import gravit.code.global.event.FollowedEvent;
 import gravit.code.global.event.InquiryAnsweredEvent;
 import gravit.code.global.event.NoticeCreatedEvent;
 import gravit.code.global.event.SeasonRolledOverEvent;
@@ -7,6 +8,7 @@ import gravit.code.notification.domain.NotificationType;
 import gravit.code.notification.facade.NotificationFacade;
 import gravit.code.notification.service.NotificationService;
 import gravit.code.notification.support.NotificationMessageProvider;
+import gravit.code.user.service.UserService;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.log4j.Log4j2;
 import org.springframework.stereotype.Component;
@@ -23,6 +25,7 @@ public class NotificationEventListener {
     private final NotificationService notificationService;
     private final NotificationMessageProvider messageProvider;
     private final NotificationFacade notificationFacade;
+    private final UserService userService;
 
     @TransactionalEventListener(phase = TransactionPhase.AFTER_COMMIT)
     @Transactional(propagation = Propagation.REQUIRES_NEW)
@@ -32,6 +35,18 @@ public class NotificationEventListener {
             notificationService.notifyAllUsers(NotificationType.NOTICE, message, event.noticeId());
         } catch (Exception e) {
             log.error("공지 알림 적재 실패 - noticeId: {}", event.noticeId(), e);
+        }
+    }
+
+    @TransactionalEventListener(phase = TransactionPhase.AFTER_COMMIT)
+    @Transactional(propagation = Propagation.REQUIRES_NEW)
+    public void handleFollowed(FollowedEvent event) {
+        try {
+            String followerNickname = userService.getUser(event.followerId()).getNickname();
+            String message = messageProvider.followReceived(followerNickname);
+            notificationFacade.notifyUser(event.followeeId(), NotificationType.FOLLOW, message, event.followerId());
+        } catch (Exception e) {
+            log.error("팔로우 알림 발송 실패 - followerId: {}, followeeId: {}", event.followerId(), event.followeeId(), e);
         }
     }
 

--- a/src/main/java/gravit/code/social/dto/response/SocialFeedResponse.java
+++ b/src/main/java/gravit/code/social/dto/response/SocialFeedResponse.java
@@ -1,12 +1,11 @@
 package gravit.code.social.dto.response;
 
+import gravit.code.global.util.TimeAgoFormatter;
 import gravit.code.social.domain.FeedEventType;
 import gravit.code.social.dto.internal.SocialFeedProjection;
 import io.swagger.v3.oas.annotations.media.Schema;
 
 import java.time.LocalDateTime;
-import java.time.ZoneId;
-import java.time.temporal.ChronoUnit;
 
 public record SocialFeedResponse(
         @Schema(requiredMode = Schema.RequiredMode.REQUIRED)
@@ -47,7 +46,7 @@ public record SocialFeedResponse(
                 projection.actorProfileImgNumber(),
                 projection.actorHandle(),
                 generateMessage(projection.eventType(), projection.eventValue()),
-                computeTimeAgo(projection.createdAt()),
+                TimeAgoFormatter.format(projection.createdAt()),
                 canCongratulate,
                 projection.createdAt()
         );
@@ -63,19 +62,5 @@ public record SocialFeedResponse(
             case TIER_PROMOTION -> eventValue + "로 승급했어요!";
             case LEVEL_UP -> "LV." + eventValue + "로 레벨업했어요!";
         };
-    }
-
-    private static String computeTimeAgo(LocalDateTime createdAt) {
-        LocalDateTime now = LocalDateTime.now(ZoneId.of("Asia/Seoul"));
-        long minutes = ChronoUnit.MINUTES.between(createdAt, now);
-
-        if (minutes < 1) return "방금 전";
-        if (minutes < 60) return minutes + "분 전";
-
-        long hours = ChronoUnit.HOURS.between(createdAt, now);
-        if (hours < 24) return hours + "시간 전";
-
-        long days = ChronoUnit.DAYS.between(createdAt, now);
-        return Math.min(days, 7) + "일 전";
     }
 }

--- a/src/main/java/gravit/code/social/facade/SocialFacade.java
+++ b/src/main/java/gravit/code/social/facade/SocialFacade.java
@@ -57,9 +57,8 @@ public class SocialFacade {
             long userId,
             long targetUserId
     ) {
+        // 팔로우 알림은 FriendService.following()이 발행하는 FollowedEvent를 통해 일원화 처리된다
         friendService.following(userId, targetUserId);
-        String followerNickname = userService.getUser(userId).getNickname();
-        notificationFacade.notifyUser(targetUserId, NotificationType.FOLLOW, messageProvider.followReceived(followerNickname), userId);
     }
 
     @Transactional(readOnly = true)


### PR DESCRIPTION
### 1. 연관 이슈

---
 - 해당 없음

<br>

### 2. 구현 사항

---
**구현 사항 1 — 알림 인박스 조회 500 에러(HV000151) 수정**

`GET /api/v1/notifications` 호출 시 `ConstraintDeclarationException(HV000151)`로 500이 발생하던 문제를 해결했습니다.

- 원인: `NotificationController.getInbox`(구현체)의 `page` 파라미터에만 `@Min(0)`이 선언되어 있어, `NotificationDocs`(인터페이스) 메서드의 파라미터 제약 설정과 충돌했습니다. Bean Validation은 구현/오버라이드 메서드가 인터페이스에 없던 파라미터 제약을 추가하는 것을 금지합니다.
- 조치: 컨트롤러에서 `@Min(0)`과 (더 이상 검증 대상이 없어진) `@Validated`를 제거하고 관련 import를 정리했습니다.

<br>

**구현 사항 2 — 팔로우 알림 발행 일원화 (FollowedEvent)**

팔로우 엔드포인트가 둘(`friends/following`, `social/follow`)인데 `social/follow`에서만 알림이 생성되던 불일치를 통일했습니다.

- `FollowedEvent(followerId, followeeId)`를 신설하고, 두 경로가 공통으로 거치는 `FriendService.following()`에서 이를 발행하도록 변경했습니다.
- `NotificationEventListener.handleFollowed()`를 추가해 트랜잭션 커밋 직후(`AFTER_COMMIT`, `REQUIRES_NEW`) 팔로위에게 `FOLLOW` 알림을 생성합니다. 기존 알림 이벤트(공지/문의 답변 등)와 동일한 패턴을 따릅니다.
- 중복 알림 방지를 위해 `SocialFacade.follow()`의 직접 알림 호출은 제거했습니다.
- 결과적으로 어느 엔드포인트로 팔로우하든 알림이 정확히 1건 생성되며, 팔로우 트랜잭션이 롤백되면 알림도 발송되지 않습니다.

<br>

**구현 사항 3 — 알림 응답에 timeAgo 상대 시간 추가**

피드와 동일하게 알림 목록에도 "방금 전 / N분 전 / N시간 전 / N일 전(최대 7일)" 형태의 상대 시간을 제공합니다.

- `NotificationResponse`에 `timeAgo` 필드를 추가하고 `createdAt` 기준으로 채웁니다.
- `SocialFeedResponse`에 중복되어 있던 상대 시간 계산 로직을 `global/util/TimeAgoFormatter` 공용 유틸로 추출해 양쪽에서 재사용합니다. (계산식은 기존과 동일, `Asia/Seoul` 기준)

<br>

### 3. 검증

---
- 메인/테스트 컴파일 통과
- `SocialFacadeIntegrationTest` 통과(팔로우 → 알림 생성, 이벤트 경로 end-to-end 확인)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * 팔로우가 발생하면 상대방에게 알림이 자동으로 전송됩니다.
  * 알림과 피드에 생성 시점을 기준으로 한 상대 시간 표시(예: “방금 전”, “3분 전”)가 추가되었습니다.

* **Bug Fixes**
  * 팔로우 관련 알림 처리 흐름이 정리되어, 더 일관된 방식으로 동작합니다.
  * 알림 목록 조회에서 불필요한 입력 검증이 완화되었습니다.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->