### PR TITLE
feat: 문의 목록 응답에 전체 개수(totalElements) 추가(#410)

### DIFF
--- a/src/main/java/gravit/code/global/dto/response/PageResponse.java
+++ b/src/main/java/gravit/code/global/dto/response/PageResponse.java
@@ -16,6 +16,9 @@ public record PageResponse<T>(
         boolean hasNext,
 
         @Schema(requiredMode = Schema.RequiredMode.REQUIRED)
+        long totalElements,
+
+        @Schema(requiredMode = Schema.RequiredMode.REQUIRED)
         List<T> contents
 ) {
     public static <T> PageResponse<T> from(Page<T> page) {
@@ -23,6 +26,7 @@ public record PageResponse<T>(
                 page.getNumber() + 1,
                 page.getTotalPages(),
                 page.hasNext(),
+                page.getTotalElements(),
                 page.getContent()
         );
     }

--- a/src/main/java/gravit/code/inquiry/controller/docs/InquiryControllerDocs.java
+++ b/src/main/java/gravit/code/inquiry/controller/docs/InquiryControllerDocs.java
@@ -60,6 +60,7 @@ public interface InquiryControllerDocs {
                                       "page": 1,
                                       "totalPages": 3,
                                       "hasNext": true,
+                                      "totalElements": 27,
                                       "contents": [
                                         {
                                           "id": 12,

--- a/src/main/java/gravit/code/inquiry/dto/response/InquirySummaryPageResponse.java
+++ b/src/main/java/gravit/code/inquiry/dto/response/InquirySummaryPageResponse.java
@@ -29,6 +29,13 @@ public class InquirySummaryPageResponse {
     public boolean hasNext;
 
     @Schema(
+            description = "전체 문의 개수",
+            example = "27",
+            requiredMode = Schema.RequiredMode.REQUIRED
+    )
+    public long totalElements;
+
+    @Schema(
             description = "문의 요약 목록",
             requiredMode = Schema.RequiredMode.REQUIRED
     )

--- a/src/main/java/gravit/code/notice/controller/docs/NoticeQueryControllerDocs.java
+++ b/src/main/java/gravit/code/notice/controller/docs/NoticeQueryControllerDocs.java
@@ -38,6 +38,7 @@ public interface NoticeQueryControllerDocs {
                                       "page": 1,
                                       "totalPages": 5,
                                       "hasNext": true,
+                                      "totalElements": 42,
                                       "contents": [
                                         {
                                           "id": 123,

--- a/src/main/java/gravit/code/notice/dto/response/NoticeSummaryPageResponse.java
+++ b/src/main/java/gravit/code/notice/dto/response/NoticeSummaryPageResponse.java
@@ -29,6 +29,13 @@ public class NoticeSummaryPageResponse {
     public boolean hasNext;
 
     @Schema(
+            description = "전체 공지 개수",
+            example = "42",
+            requiredMode = Schema.RequiredMode.REQUIRED
+    )
+    public long totalElements;
+
+    @Schema(
             description = "공지 요약 목록",
             requiredMode = Schema.RequiredMode.REQUIRED
     )

--- a/src/test/java/gravit/code/inquiry/service/InquiryQueryServiceIntegrationTest.java
+++ b/src/test/java/gravit/code/inquiry/service/InquiryQueryServiceIntegrationTest.java
@@ -56,6 +56,7 @@ class InquiryQueryServiceIntegrationTest {
             assertSoftly(softly -> {
                 softly.assertThat(result.page()).isEqualTo(1);
                 softly.assertThat(result.hasNext()).isFalse();
+                softly.assertThat(result.totalElements()).isEqualTo(2);
                 softly.assertThat(result.contents()).hasSize(2);
                 // id 내림차순 → 나중에 저장된 second 가 먼저
                 softly.assertThat(result.contents().get(0).id()).isEqualTo(second.getId());

--- a/src/test/java/gravit/code/inquiry/service/InquiryQueryServiceUnitTest.java
+++ b/src/test/java/gravit/code/inquiry/service/InquiryQueryServiceUnitTest.java
@@ -66,6 +66,7 @@ class InquiryQueryServiceUnitTest {
             assertSoftly(softly -> {
                 softly.assertThat(result.page()).isEqualTo(1);
                 softly.assertThat(result.hasNext()).isFalse();
+                softly.assertThat(result.totalElements()).isEqualTo(1);
                 softly.assertThat(result.contents()).hasSize(1);
                 softly.assertThat(result.contents().get(0).id()).isEqualTo(INQUIRY_ID);
                 softly.assertThat(result.contents().get(0).status()).isEqualTo("PENDING");


### PR DESCRIPTION
### 1. 연관 이슈

---
 - close #410

<br>

### 2. 구현 사항

---
**페이지 응답에 전체 개수 노출**

공통 `PageResponse`에 `totalElements`를 추가해 문의 목록 조회 시 전체 문의 개수를 함께 반환합니다. `Page.getTotalElements()`를 사용하므로 추가 쿼리는 없습니다. 공통 DTO 변경에 따라 notice Swagger 미러 문서도 함께 반영했고, inquiry 단위/통합 테스트에 검증을 추가했습니다.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **새 기능**
  * 공지와 문의의 페이지 응답에 전체 개수 정보가 추가되어, 목록의 총 항목 수를 함께 확인할 수 있습니다.
* **버그 수정**
  * 페이지 응답에 포함되는 전체 개수 값이 실제 조회 결과와 일치하도록 반영되었습니다.
* **문서**
  * 공지 및 문의 목록 API 예시 응답에 전체 개수 항목이 포함되도록 업데이트했습니다.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->