### PR TITLE
refactor: 메인페이지 API 위젯별 분리 및 통합 API Deprecated 처리(#415)

### DIFF
--- a/.claude/requirements/done/REQ-015.md
+++ b/.claude/requirements/done/REQ-015.md
@@ -1,0 +1,94 @@
+# [REQ-015] 메인페이지 API를 도메인 성격에 맞게 분리
+
+## 개요
+단일 Facade에서 6개 도메인 데이터를 조합해 반환하던 `GET /api/v1/users/main-page`를 위젯별 조회 API로 분리하여 결합도를 낮추고, 특정 도메인 장애가 메인페이지 전체 장애로 전파되지 않도록 한다. 이미 동일하게 분리된 `MyPageController`(`/api/v1/my-pages`)와 같은 2-Facade 패턴을 따르고, 기존 통합 API는 **동결(freeze) 후 Deprecated**로 유지한다. (이슈 #415)
+
+## 설계 원칙
+- **경로 = 화면 단위, 메서드·DTO = 리소스 단위.** 컨트롤러 경로만 `main-pages`로 묶고, 위임 메서드와 응답 DTO는 화면명(`MainPage*`)이 아니라 반환 리소스명으로 짓는다.
+  - 이유: 기존 `MyPage*` 메서드와 `MainPage*` 신규 메서드가 같은 클래스에서 2글자(my/main) 차이로 나란히 앉으면 오독을 유발한다 (특히 `LearningFacade.getMyPageLearning` ↔ 신규 학습 상세).
+- **레거시는 재사용 대상이 아니라 격리 대상.** deprecated 코드가 신규 코드를 재사용하도록 엮지 않는다 (facade→facade 및 화면 전용 Facade 회피). Strangler Fig 방식으로 신규를 옆에 세우고 레거시는 동결한다.
+
+## API
+
+화면 전용 컨트롤러 `MainPageController`(`/api/v1/main-pages`)에 위젯별 엔드포인트를 두고, `MyPageController`와 동일하게 도메인 Facade/Service로 위임한다.
+
+| Method | Path | 설명 | 위임 대상 |
+|--------|------|------|-----------|
+| GET | `/api/v1/main-pages/profile` | 유저 프로필·레벨 (profileImgNumber, nickname, userLevelDetail) | `UserFacade#getProfileSummary` (신규) |
+| GET | `/api/v1/main-pages/league` | 리그 정보 (leagueDetail) | `UserLeagueService#getUserLeagueDetail` (기존) |
+| GET | `/api/v1/main-pages/learning` | 학습 정보 (learningDetail) | `LearningFacade#getLearningDetail` (신규) |
+| GET | `/api/v1/main-pages/units` | 추천 유닛 (recommendedUnits) | `UnitQueryService#getRecommendedUnits` (기존) |
+| GET | `/api/v1/main-pages/weekly-record` | 주간 학습 기록 (weeklyLearningRecord) | `DailyLearningRecordService#getWeeklyLearningRecord` (기존) |
+| GET | `/api/v1/main-pages/mission` | 미션 정보 (missionDetail) | `MissionService#getMissionDetail` (기존) |
+| GET | `/api/v1/users/main-page` (기존) | 통합 API — **Deprecated 유지 (동결)**, 후속 릴리스에서 제거 | `UserFacade#getMainPage` (동결) |
+
+## 구현 계획 (메서드 레벨)
+
+### 1. 신규 생성
+- **`MainPageController`** (`@RequestMapping("/api/v1/main-pages")`, `implements MainPageControllerDocs`)
+  - 주입: `UserFacade`, `LearningFacade`, `UserLeagueService`, `UnitQueryService`, `DailyLearningRecordService`, `MissionService` (Facade가 있으면 Facade, 없으면 Service 직접 주입 — `MyPageController`와 동일 원칙)
+  - `getProfile()` → `userFacade.getProfileSummary(userId)`
+  - `getLeague()` → `userLeagueService.getUserLeagueDetail(userId)`
+  - `getLearning()` → `learningFacade.getLearningDetail(userId)`
+  - `getUnits()` → `unitQueryService.getRecommendedUnits(userId)`
+  - `getWeeklyRecord()` → `dailyLearningRecordService.getWeeklyLearningRecord(userId)`
+  - `getMission()` → `missionService.getMissionDetail(userId)`
+- **`MainPageControllerDocs`** — 위 6개 엔드포인트 Swagger 인터페이스
+- **`ProfileSummaryResponse`** (record) — `profileImgNumber`, `nickname`, `userLevelDetailResponse`(기존 `UserLevelDetailResponse` 재사용)
+
+### 2. 신규 메서드 (2개만 신규 작성)
+- **`UserFacade#getProfileSummary(long userId): ProfileSummaryResponse`**
+  - 유저의 프로필 이미지·닉네임·레벨 상세를 반환. (동결된 `getMainPage`와 같은 클래스에 공존하나 이름이 겹치지 않음)
+- **`LearningFacade#getLearningDetail(long userId): LearningDetailResponse`**
+  - 학습 상세(최근 학습 챕터·유닛 진행 요약·챕터 진행률) 조합을 **신규 작성**한다. (동결된 `UserFacade`의 private `getLearningDetail`과 병존하는 일시적 중복 — 레거시 제거 시 소멸)
+  - `LearningFacade`에 의존성 추가: `LearningQueryService`, `UnitQueryService`, `ChapterQueryService` (기존 보유 `LearningProgressRateService` 재사용)
+
+### 3. 재사용 (엔드포인트 노출만, 새 메서드/이름 없음)
+- 리그: `UserLeagueService#getUserLeagueDetail`
+- 추천 유닛: `UnitQueryService#getRecommendedUnits`
+- 주간 기록: `DailyLearningRecordService#getWeeklyLearningRecord`
+- 미션: `MissionService#getMissionDetail`
+
+### 4. 기존 통합 API — 동결 + Deprecated
+- **레거시 코드는 리팩터링하지 않는다.** `UserFacade#getMainPage`와 private `getLearningDetail`은 내부를 그대로 두고 어노테이션만 추가한다.
+  - `UserController#getMainPage`: `@Deprecated(forRemoval = true)`
+  - `UserFacade#getMainPage`: `@Deprecated(forRemoval = true)`
+  - `UserControllerDocs`의 해당 오퍼레이션: `@Operation(deprecated = true)` (Swagger UI 취소선)
+- `@Deprecated`는 런타임 차단이 아닌 신호이므로 엔드포인트는 계속 정상 응답한다.
+- (선택) 소비자향 deprecation 위생: RFC 8594 `Deprecation`/`Sunset` 응답 헤더, Prometheus 사용량 카운터로 호출 추이 계측 → 0에 수렴 시 안전 제거.
+- 실제 제거는 프론트가 6개 위젯 API로 전환 완료된 후 **후속 이슈**에서 통째로 처리한다 (레거시 `getMainPage`·private `getLearningDetail`·`MainPageResponse` 동시 제거).
+
+## 비즈니스 규칙
+- 기존 `MainPageResponse`가 조합하던 6개 필드를 위젯별 API로 분리한다: 유저 프로필·레벨, 리그, 학습, 추천 유닛, 주간 학습 기록, 미션.
+- 각 엔드포인트는 해당 도메인의 Facade/Service로만 위임하여, `UserFacade.getMainPage`에 집중됐던 도메인 간 결합을 해소한다.
+- 특정 위젯 조회 실패가 다른 위젯 API 응답에 영향을 주지 않아야 한다 (장애 격리).
+- 각 분리 API의 응답 DTO는 기존 하위 응답(`LeagueDetailResponse`, `LearningDetailResponse`, `RecommendedUnitResponse`, `WeeklyLearningRecordResponse`, `MissionDetailResponse`)을 재사용하고, 프로필·레벨만 신규 `ProfileSummaryResponse`로 감싼다.
+- 신규 위임 메서드·DTO는 화면명이 아닌 리소스명으로 짓는다 (설계 원칙 참조).
+- 기존 통합 API(`/main-page`)는 동결 후 Deprecated로 유지한다 (제거하지 않음, 후속 릴리스로 이관).
+- Swagger는 `MainPageControllerDocs`를 신규 작성하고, 기존 `/main-page`는 `@Operation(deprecated = true)`로 표기한다.
+
+## 테스트
+
+### 유지 (동결)
+- `UserFacadeIntegrationTest`의 `GetMainPage` 중첩 클래스(정상 반환 / 학습 기록 없는 사용자 / 사용자 미존재 예외 3케이스): 레거시가 계속 동작함을 보장하기 위해 **수정·삭제 없이 그대로 유지**한다.
+
+### 추가
+- **`LearningFacade#getLearningDetail`** — 신규 학습 상세 조합 통합 테스트 (정상 / 학습 기록 없는 사용자 케이스).
+- **`UserFacade#getProfileSummary`** — 프로필 이미지·닉네임·레벨 상세 반환 통합 테스트.
+- 이미 서비스 단위로 커버된 위젯은 진입점 회귀 검증만 보강 (중복 테스트 지양):
+  - 추천 유닛: `UnitQueryServiceIntegrationTest` (기존)
+  - 주간 학습 기록: `DailyLearningRecordServiceIntegrationTest` (기존)
+  - 미션: `MissionServiceIntegrationTest` (기존)
+  - 리그: `UserLeagueServiceIntegrationTest` (기존)
+- Controller 계층 테스트는 프로젝트 관례상 필수 아님(현재 `FriendControllerTest`만 존재) → 선택 사항.
+
+## 참고
+- 관련 엔티티: User, Learning, Chapter, Unit, DailyLearningRecord, UserLeague, Mission
+- 관련 도메인 패키지: user, learning, chapter, unit, dailyLearningRecord, userLeague, mission
+- 선례: `MyPageController`(`/api/v1/my-pages`)가 마이페이지를 위젯별 엔드포인트 + 2개 도메인 Facade(`UserFacade`, `LearningFacade`) 위임으로 분리한 구조를 그대로 따른다 (별도 화면 Facade 없음).
+- 기존 코드: `UserController#getMainPage`, `UserFacade#getMainPage`(+private `getLearningDetail`), `MainPageResponse` — 전부 동결 대상.
+- 기존 테스트: `UserFacadeIntegrationTest.GetMainPage`(동결·유지), 도메인별 서비스 통합 테스트(재사용).
+- 확정 사항 요약:
+  - 구조: 전용 `MainPageController` + 2-Facade 위임 (화면 Facade·facade→facade 없음)
+  - 네이밍: 경로=화면(`main-pages`), 메서드·DTO=리소스
+  - 레거시: Strangler Fig — 동결 + `@Deprecated`, 후속 릴리스에서 제거

--- a/.claude/requirements/index.md
+++ b/.claude/requirements/index.md
@@ -12,6 +12,7 @@
 
 | 태그 | 설명 |
 |------|------|
+| REQ-015 | 메인페이지 API를 도메인 성격에 맞게 분리 (이슈 #415) |
 | REQ-014 | Test/Cheat API prod 비활성화 (@Profile("!prod")) — 컨벤션 정비는 후속 |
 | REQ-012 | 문의(Inquiry) API — 유저 CRUD, 답변 도메인(InquiryAnswer) 분리 (이슈 #404) |
 | REQ-011 | 소셜 알림 (팔로우, 축하하기 받음, 친구 활동) |

--- a/src/main/java/gravit/code/learning/facade/LearningFacade.java
+++ b/src/main/java/gravit/code/learning/facade/LearningFacade.java
@@ -1,19 +1,26 @@
 package gravit.code.learning.facade;
 
+import gravit.code.chapter.domain.Chapter;
 import gravit.code.chapter.dto.response.TopChapterResponse;
+import gravit.code.chapter.service.ChapterQueryService;
 import gravit.code.dailyLearningRecord.dto.response.DailySolvedCountResponse;
 import gravit.code.dailyLearningRecord.dto.response.WeeklyLearningReportResponse;
 import gravit.code.dailyLearningRecord.service.DailyLearningRecordService;
 import gravit.code.global.annotation.Facade;
 import gravit.code.global.consts.TimeZoneConst;
+import gravit.code.learning.domain.Learning;
+import gravit.code.learning.dto.response.LearningDetailResponse;
 import gravit.code.learning.dto.response.LearningHistoryResponse;
 import gravit.code.learning.dto.response.LearningSummaryResponse;
 import gravit.code.learning.dto.response.MyPageLearningResponse;
 import gravit.code.learning.dto.response.MyPageSummaryResponse;
 import gravit.code.learning.dto.response.WeakConceptResponse;
 import gravit.code.learning.service.LearningProgressRateService;
+import gravit.code.learning.service.LearningQueryService;
 import gravit.code.lesson.service.LessonQueryService;
 import gravit.code.lesson.service.LessonSubmissionQueryService;
+import gravit.code.unit.dto.response.UnitProgressSummaryResponse;
+import gravit.code.unit.service.UnitQueryService;
 import gravit.code.user.service.UserService;
 import lombok.RequiredArgsConstructor;
 import org.springframework.transaction.annotation.Transactional;
@@ -27,10 +34,32 @@ import java.util.stream.IntStream;
 public class LearningFacade {
 
     private final LearningProgressRateService learningProgressRateService;
+    private final LearningQueryService learningQueryService;
     private final LessonSubmissionQueryService lessonSubmissionQueryService;
     private final LessonQueryService lessonQueryService;
     private final DailyLearningRecordService dailyLearningRecordService;
+    private final UnitQueryService unitQueryService;
+    private final ChapterQueryService chapterQueryService;
     private final UserService userService;
+
+    @Transactional(readOnly = true)
+    public LearningDetailResponse getLearningDetail(long userId) {
+        Learning learning = learningQueryService.getLearning(userId);
+        long chapterId = learning.getRecentSolvedChapterId();
+
+        List<UnitProgressSummaryResponse> units = unitQueryService.getAllUnitProgressSummariesInChapter(chapterId, userId);
+
+        Chapter recentSolvedChapter = chapterQueryService.getChapter(chapterId);
+        double chapterProgressRate = learningProgressRateService.getChapterProgress(chapterId, userId);
+
+        return LearningDetailResponse.of(
+                learning.getConsecutiveSolvedDays(),
+                recentSolvedChapter.getId(),
+                recentSolvedChapter.getTitle(),
+                chapterProgressRate,
+                units
+        );
+    }
 
     @Transactional(readOnly = true)
     public MyPageLearningResponse getMyPageLearning(long userId) {

--- a/src/main/java/gravit/code/user/controller/MainPageController.java
+++ b/src/main/java/gravit/code/user/controller/MainPageController.java
@@ -1,0 +1,67 @@
+package gravit.code.user.controller;
+
+import gravit.code.auth.domain.LoginUser;
+import gravit.code.dailyLearningRecord.dto.response.WeeklyLearningRecordResponse;
+import gravit.code.dailyLearningRecord.service.DailyLearningRecordService;
+import gravit.code.league.dto.response.LeagueDetailResponse;
+import gravit.code.learning.dto.response.LearningDetailResponse;
+import gravit.code.learning.facade.LearningFacade;
+import gravit.code.mission.dto.response.MissionDetailResponse;
+import gravit.code.mission.service.MissionService;
+import gravit.code.unit.dto.response.RecommendedUnitResponse;
+import gravit.code.unit.service.UnitQueryService;
+import gravit.code.user.controller.docs.MainPageControllerDocs;
+import gravit.code.user.dto.response.ProfileSummaryResponse;
+import gravit.code.user.facade.UserFacade;
+import gravit.code.userLeague.service.UserLeagueService;
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.ResponseEntity;
+import org.springframework.security.core.annotation.AuthenticationPrincipal;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+import java.util.List;
+
+@RestController
+@RequiredArgsConstructor
+@RequestMapping("/api/v1/main-pages")
+public class MainPageController implements MainPageControllerDocs {
+
+    private final UserFacade userFacade;
+    private final LearningFacade learningFacade;
+    private final UserLeagueService userLeagueService;
+    private final UnitQueryService unitQueryService;
+    private final DailyLearningRecordService dailyLearningRecordService;
+    private final MissionService missionService;
+
+    @GetMapping("/profile")
+    public ResponseEntity<ProfileSummaryResponse> getProfile(@AuthenticationPrincipal LoginUser loginUser) {
+        return ResponseEntity.ok(userFacade.getProfileSummary(loginUser.getId()));
+    }
+
+    @GetMapping("/league")
+    public ResponseEntity<LeagueDetailResponse> getLeague(@AuthenticationPrincipal LoginUser loginUser) {
+        return ResponseEntity.ok(userLeagueService.getUserLeagueDetail(loginUser.getId()));
+    }
+
+    @GetMapping("/learning")
+    public ResponseEntity<LearningDetailResponse> getLearning(@AuthenticationPrincipal LoginUser loginUser) {
+        return ResponseEntity.ok(learningFacade.getLearningDetail(loginUser.getId()));
+    }
+
+    @GetMapping("/units")
+    public ResponseEntity<List<RecommendedUnitResponse>> getUnits(@AuthenticationPrincipal LoginUser loginUser) {
+        return ResponseEntity.ok(unitQueryService.getRecommendedUnits(loginUser.getId()));
+    }
+
+    @GetMapping("/weekly-record")
+    public ResponseEntity<WeeklyLearningRecordResponse> getWeeklyRecord(@AuthenticationPrincipal LoginUser loginUser) {
+        return ResponseEntity.ok(dailyLearningRecordService.getWeeklyLearningRecord(loginUser.getId()));
+    }
+
+    @GetMapping("/mission")
+    public ResponseEntity<MissionDetailResponse> getMission(@AuthenticationPrincipal LoginUser loginUser) {
+        return ResponseEntity.ok(missionService.getMissionDetail(loginUser.getId()));
+    }
+}

--- a/src/main/java/gravit/code/user/controller/UserController.java
+++ b/src/main/java/gravit/code/user/controller/UserController.java
@@ -68,6 +68,7 @@ public class UserController implements UserControllerDocs {
         return ResponseEntity.ok().build();
     }
 
+    @Deprecated(forRemoval = true)
     @GetMapping("/main-page")
     public ResponseEntity<MainPageResponse> getMainPage(@AuthenticationPrincipal LoginUser loginUser){
         return ResponseEntity.status(HttpStatus.OK).body(userFacade.getMainPage(loginUser.getId()));

--- a/src/main/java/gravit/code/user/controller/docs/MainPageControllerDocs.java
+++ b/src/main/java/gravit/code/user/controller/docs/MainPageControllerDocs.java
@@ -1,0 +1,168 @@
+package gravit.code.user.controller.docs;
+
+import gravit.code.auth.domain.LoginUser;
+import gravit.code.dailyLearningRecord.dto.response.WeeklyLearningRecordResponse;
+import gravit.code.global.exception.domain.ErrorResponse;
+import gravit.code.league.dto.response.LeagueDetailResponse;
+import gravit.code.learning.dto.response.LearningDetailResponse;
+import gravit.code.mission.dto.response.MissionDetailResponse;
+import gravit.code.unit.dto.response.RecommendedUnitResponse;
+import gravit.code.user.dto.response.ProfileSummaryResponse;
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.media.Content;
+import io.swagger.v3.oas.annotations.media.ExampleObject;
+import io.swagger.v3.oas.annotations.media.Schema;
+import io.swagger.v3.oas.annotations.responses.ApiResponse;
+import io.swagger.v3.oas.annotations.responses.ApiResponses;
+import io.swagger.v3.oas.annotations.tags.Tag;
+import org.springframework.http.MediaType;
+import org.springframework.http.ResponseEntity;
+import org.springframework.security.core.annotation.AuthenticationPrincipal;
+
+import java.util.List;
+
+@Tag(name = "MainPage API", description = "메인페이지 위젯별 조회 API")
+public interface MainPageControllerDocs {
+
+    @Operation(summary = "메인페이지 프로필 조회", description = "메인페이지 유저 프로필(프로필 이미지, 닉네임)과 레벨 상세를 조회합니다<br>" +
+            "🔐 <strong>Jwt 필요</strong><br>")
+    @ApiResponses({
+            @ApiResponse(responseCode = "200", description = "✅ 메인페이지 프로필 조회 성공"),
+            @ApiResponse(responseCode = "404", description = "🚨 유저 조회 실패",
+                    content = @Content(mediaType = MediaType.APPLICATION_JSON_VALUE,
+                            examples = {
+                                    @ExampleObject(
+                                            name = "유저 조회 실패",
+                                            value = "{\"error\" : \"USER_4041\", \"message\" : \"존재하지 않는 유저입니다.\"}"
+                                    )
+                            },
+                            schema = @Schema(implementation = ErrorResponse.class))
+            ),
+            @ApiResponse(responseCode = "500", description = "🚨 예기치 못한 예외 발생",
+                    content = @Content(mediaType = MediaType.APPLICATION_JSON_VALUE,
+                            examples = {
+                                    @ExampleObject(
+                                            name = "예기치 못한 예외 발생",
+                                            value = "{\"error\" : \"GLOBAL_5001\", \"message\" : \"예기치 못한 예외 발생\"}"
+                                    )
+                            },
+                            schema = @Schema(implementation = ErrorResponse.class))
+            )
+    })
+    ResponseEntity<ProfileSummaryResponse> getProfile(@AuthenticationPrincipal LoginUser loginUser);
+
+    @Operation(summary = "메인페이지 리그 조회", description = "메인페이지 리그 정보(리그 상세)를 조회합니다<br>" +
+            "🔐 <strong>Jwt 필요</strong><br>")
+    @ApiResponses({
+            @ApiResponse(responseCode = "200", description = "✅ 메인페이지 리그 조회 성공"),
+            @ApiResponse(responseCode = "404", description = "🚨 유저 리그 조회 실패",
+                    content = @Content(mediaType = MediaType.APPLICATION_JSON_VALUE,
+                            examples = {
+                                    @ExampleObject(
+                                            name = "유저 리그 조회 실패",
+                                            value = "{\"error\" : \"U_L_4041\", \"message\" : \"유저의 리그가 존재하지 않습니다\"}"
+                                    )
+                            },
+                            schema = @Schema(implementation = ErrorResponse.class))
+            ),
+            @ApiResponse(responseCode = "500", description = "🚨 예기치 못한 예외 발생",
+                    content = @Content(mediaType = MediaType.APPLICATION_JSON_VALUE,
+                            examples = {
+                                    @ExampleObject(
+                                            name = "예기치 못한 예외 발생",
+                                            value = "{\"error\" : \"GLOBAL_5001\", \"message\" : \"예기치 못한 예외 발생\"}"
+                                    )
+                            },
+                            schema = @Schema(implementation = ErrorResponse.class))
+            )
+    })
+    ResponseEntity<LeagueDetailResponse> getLeague(@AuthenticationPrincipal LoginUser loginUser);
+
+    @Operation(summary = "메인페이지 학습 조회", description = "메인페이지 학습 상세(최근 학습 챕터, 챕터 진행률, 유닛 진행 요약)를 조회합니다<br>" +
+            "🔐 <strong>Jwt 필요</strong><br>")
+    @ApiResponses({
+            @ApiResponse(responseCode = "200", description = "✅ 메인페이지 학습 조회 성공"),
+            @ApiResponse(responseCode = "404", description = "🚨 학습 정보 조회 실패",
+                    content = @Content(mediaType = MediaType.APPLICATION_JSON_VALUE,
+                            examples = {
+                                    @ExampleObject(
+                                            name = "학습 정보 조회 실패",
+                                            value = "{\"error\" : \"LEARNING_4041\", \"message\" : \"학습 정보 조회에 실패하였습니다.\"}"
+                                    )
+                            },
+                            schema = @Schema(implementation = ErrorResponse.class))
+            ),
+            @ApiResponse(responseCode = "500", description = "🚨 예기치 못한 예외 발생",
+                    content = @Content(mediaType = MediaType.APPLICATION_JSON_VALUE,
+                            examples = {
+                                    @ExampleObject(
+                                            name = "예기치 못한 예외 발생",
+                                            value = "{\"error\" : \"GLOBAL_5001\", \"message\" : \"예기치 못한 예외 발생\"}"
+                                    )
+                            },
+                            schema = @Schema(implementation = ErrorResponse.class))
+            )
+    })
+    ResponseEntity<LearningDetailResponse> getLearning(@AuthenticationPrincipal LoginUser loginUser);
+
+    @Operation(summary = "메인페이지 추천 유닛 조회", description = "메인페이지 추천 유닛 목록을 조회합니다<br>" +
+            "🔐 <strong>Jwt 필요</strong><br>")
+    @ApiResponses({
+            @ApiResponse(responseCode = "200", description = "✅ 메인페이지 추천 유닛 조회 성공"),
+            @ApiResponse(responseCode = "500", description = "🚨 예기치 못한 예외 발생",
+                    content = @Content(mediaType = MediaType.APPLICATION_JSON_VALUE,
+                            examples = {
+                                    @ExampleObject(
+                                            name = "예기치 못한 예외 발생",
+                                            value = "{\"error\" : \"GLOBAL_5001\", \"message\" : \"예기치 못한 예외 발생\"}"
+                                    )
+                            },
+                            schema = @Schema(implementation = ErrorResponse.class))
+            )
+    })
+    ResponseEntity<List<RecommendedUnitResponse>> getUnits(@AuthenticationPrincipal LoginUser loginUser);
+
+    @Operation(summary = "메인페이지 주간 학습 기록 조회", description = "메인페이지 주간 학습 기록을 조회합니다<br>" +
+            "🔐 <strong>Jwt 필요</strong><br>")
+    @ApiResponses({
+            @ApiResponse(responseCode = "200", description = "✅ 메인페이지 주간 학습 기록 조회 성공"),
+            @ApiResponse(responseCode = "500", description = "🚨 예기치 못한 예외 발생",
+                    content = @Content(mediaType = MediaType.APPLICATION_JSON_VALUE,
+                            examples = {
+                                    @ExampleObject(
+                                            name = "예기치 못한 예외 발생",
+                                            value = "{\"error\" : \"GLOBAL_5001\", \"message\" : \"예기치 못한 예외 발생\"}"
+                                    )
+                            },
+                            schema = @Schema(implementation = ErrorResponse.class))
+            )
+    })
+    ResponseEntity<WeeklyLearningRecordResponse> getWeeklyRecord(@AuthenticationPrincipal LoginUser loginUser);
+
+    @Operation(summary = "메인페이지 미션 조회", description = "메인페이지 미션 정보(미션 상세)를 조회합니다<br>" +
+            "🔐 <strong>Jwt 필요</strong><br>")
+    @ApiResponses({
+            @ApiResponse(responseCode = "200", description = "✅ 메인페이지 미션 조회 성공"),
+            @ApiResponse(responseCode = "404", description = "🚨 미션 조회 실패",
+                    content = @Content(mediaType = MediaType.APPLICATION_JSON_VALUE,
+                            examples = {
+                                    @ExampleObject(
+                                            name = "미션 조회 실패",
+                                            value = "{\"error\" : \"MISSION_4041\", \"message\" : \"사용자의 미션 조회에 실패하였습니다.\"}"
+                                    )
+                            },
+                            schema = @Schema(implementation = ErrorResponse.class))
+            ),
+            @ApiResponse(responseCode = "500", description = "🚨 예기치 못한 예외 발생",
+                    content = @Content(mediaType = MediaType.APPLICATION_JSON_VALUE,
+                            examples = {
+                                    @ExampleObject(
+                                            name = "예기치 못한 예외 발생",
+                                            value = "{\"error\" : \"GLOBAL_5001\", \"message\" : \"예기치 못한 예외 발생\"}"
+                                    )
+                            },
+                            schema = @Schema(implementation = ErrorResponse.class))
+            )
+    })
+    ResponseEntity<MissionDetailResponse> getMission(@AuthenticationPrincipal LoginUser loginUser);
+}

--- a/src/main/java/gravit/code/user/controller/docs/UserControllerDocs.java
+++ b/src/main/java/gravit/code/user/controller/docs/UserControllerDocs.java
@@ -212,7 +212,8 @@ public interface UserControllerDocs {
     @PatchMapping("/restore")
     ResponseEntity<Void> restoreUser(@RequestParam("providerId") String providerId);
 
-    @Operation(summary = "메인 페이지 조회", description = "사용자의 메인 페이지 정보를 조회합니다<br>" +
+    @Operation(summary = "메인 페이지 조회", deprecated = true, description = "[Deprecated] 위젯별 API(GET /api/v1/main-pages/*)로 분리되었습니다(#415). 후속 릴리스에서 제거 예정입니다.<br>" +
+            "사용자의 메인 페이지 정보를 조회합니다<br>" +
             "닉네임, 리그명, 레벨 정보, 미션 정보, 학습 정보를 포함합니다<br>" +
             "🔐 <strong>Jwt 필요</strong><br>")
     @ApiResponses({

--- a/src/main/java/gravit/code/user/dto/response/ProfileSummaryResponse.java
+++ b/src/main/java/gravit/code/user/dto/response/ProfileSummaryResponse.java
@@ -1,0 +1,29 @@
+package gravit.code.user.dto.response;
+
+import io.swagger.v3.oas.annotations.media.Schema;
+import lombok.AccessLevel;
+import lombok.Builder;
+
+@Builder(access = AccessLevel.PRIVATE)
+public record ProfileSummaryResponse(
+        @Schema(requiredMode = Schema.RequiredMode.REQUIRED)
+        int profileImgNumber,
+
+        @Schema(requiredMode = Schema.RequiredMode.REQUIRED)
+        String nickname,
+
+        @Schema(requiredMode = Schema.RequiredMode.REQUIRED)
+        UserLevelDetailResponse userLevelDetailResponse
+) {
+    public static ProfileSummaryResponse of(
+            int profileImgNumber,
+            String nickname,
+            UserLevelDetailResponse userLevelDetailResponse
+    ) {
+        return ProfileSummaryResponse.builder()
+                .profileImgNumber(profileImgNumber)
+                .nickname(nickname)
+                .userLevelDetailResponse(userLevelDetailResponse)
+                .build();
+    }
+}

--- a/src/main/java/gravit/code/user/facade/UserFacade.java
+++ b/src/main/java/gravit/code/user/facade/UserFacade.java
@@ -8,7 +8,6 @@ import gravit.code.global.annotation.Facade;
 import gravit.code.league.dto.response.LeagueDetailResponse;
 import gravit.code.learning.domain.Learning;
 import gravit.code.learning.dto.response.LearningDetailResponse;
-import gravit.code.learning.service.LearningCommandService;
 import gravit.code.learning.service.LearningProgressRateService;
 import gravit.code.learning.service.LearningQueryService;
 import gravit.code.mission.dto.response.MissionDetailResponse;
@@ -19,6 +18,7 @@ import gravit.code.unit.service.UnitQueryService;
 import gravit.code.user.domain.User;
 import gravit.code.user.dto.response.MainPageResponse;
 import gravit.code.user.dto.response.MyPageBannerResponse;
+import gravit.code.user.dto.response.ProfileSummaryResponse;
 import gravit.code.user.dto.response.UserLevelDetailResponse;
 import gravit.code.user.service.UserService;
 import gravit.code.userLeague.service.UserLeagueService;
@@ -35,22 +35,42 @@ public class UserFacade {
     private final UserLeagueService userLeagueService;
     private final UnitQueryService unitQueryService;
     private final LearningQueryService learningQueryService;
-    private final LearningCommandService learningCommandService;
     private final ChapterQueryService chapterQueryService;
     private final LearningProgressRateService learningProgressRateService;
     private final MissionService missionService;
     private final DailyLearningRecordService dailyLearningRecordService;
 
     @Transactional(readOnly = true)
+    public ProfileSummaryResponse getProfileSummary(long userId) {
+        User user = userService.getUser(userId);
+
+        UserLevelDetailResponse userLevelDetailResponse = user.getLevel().getUserLevelDetail();
+
+        return ProfileSummaryResponse.of(
+                user.getProfileImgNumber(),
+                user.getNickname(),
+                userLevelDetailResponse
+        );
+    }
+
+    /**
+     * @deprecated 위젯별 API(GET /api/v1/main-pages/*)로 분리됨(#415). 후속 릴리스에서 제거 예정.
+     */
+    @Deprecated(forRemoval = true)
+    @Transactional(readOnly = true)
     public MainPageResponse getMainPage(long userId) {
         User user = userService.getUser(userId);
         Learning learning = learningQueryService.getLearning(userId);
 
         UserLevelDetailResponse userLevelDetailResponse = user.getLevel().getUserLevelDetail();
+
         LeagueDetailResponse leagueDetailResponse = userLeagueService.getUserLeagueDetail(userId);
         LearningDetailResponse learningDetailResponse = getLearningDetail(userId, learning);
+
         List<RecommendedUnitResponse> recommendedUnitResponses = unitQueryService.getRecommendedUnits(userId);
+
         WeeklyLearningRecordResponse weeklyLearningRecordResponse = dailyLearningRecordService.getWeeklyLearningRecord(userId);
+
         MissionDetailResponse missionDetailResponse = missionService.getMissionDetail(userId);
 
         return MainPageResponse.of(

--- a/src/test/java/gravit/code/learning/facade/LearningFacadeIntegrationTest.java
+++ b/src/test/java/gravit/code/learning/facade/LearningFacadeIntegrationTest.java
@@ -1,0 +1,123 @@
+package gravit.code.learning.facade;
+
+import gravit.code.chapter.domain.Chapter;
+import gravit.code.chapter.repository.ChapterRepository;
+import gravit.code.global.exception.domain.RestApiException;
+import gravit.code.learning.domain.Learning;
+import gravit.code.learning.dto.response.LearningDetailResponse;
+import gravit.code.learning.repository.LearningRepository;
+import gravit.code.lesson.domain.Lesson;
+import gravit.code.lesson.domain.LessonSubmission;
+import gravit.code.lesson.repository.LessonRepository;
+import gravit.code.lesson.repository.LessonSubmissionRepository;
+import gravit.code.support.TCSpringBootTest;
+import gravit.code.unit.domain.Unit;
+import gravit.code.unit.repository.UnitRepository;
+import gravit.code.user.domain.Role;
+import gravit.code.user.domain.User;
+import gravit.code.user.repository.UserRepository;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Nested;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.test.context.jdbc.Sql;
+import org.springframework.test.util.ReflectionTestUtils;
+
+import static gravit.code.global.exception.domain.CustomErrorCode.LEARNING_NOT_FOUND;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static org.assertj.core.api.SoftAssertions.assertSoftly;
+
+@TCSpringBootTest
+@Sql(scripts = "classpath:sql/reset_main_page_ids.sql", executionPhase = Sql.ExecutionPhase.BEFORE_TEST_METHOD)
+class LearningFacadeIntegrationTest {
+
+    @Autowired
+    private LearningFacade learningFacade;
+
+    @Autowired
+    private UserRepository userRepository;
+
+    @Autowired
+    private ChapterRepository chapterRepository;
+
+    @Autowired
+    private UnitRepository unitRepository;
+
+    @Autowired
+    private LessonRepository lessonRepository;
+
+    @Autowired
+    private LessonSubmissionRepository lessonSubmissionRepository;
+
+    @Autowired
+    private LearningRepository learningRepository;
+
+    @Nested
+    @DisplayName("메인 페이지 학습 상세를 조회할 때")
+    class GetLearningDetail {
+
+        @Test
+        void 최근_학습_챕터와_유닛_진행_요약을_정상적으로_반환한다() {
+            // given
+            User user = userRepository.save(User.create("test@test.com", "provider_1", "테스터", "handle1", 3, Role.USER));
+
+            Chapter chapter = chapterRepository.save(Chapter.create("운영체제", "운영체제 기초 개념"));
+            Unit unit = unitRepository.save(Unit.create("프로세스", "프로세스 개념", chapter.getId()));
+            unitRepository.save(Unit.create("스레드", "스레드 개념", chapter.getId()));
+            Lesson lesson = lessonRepository.save(Lesson.create("레슨1", unit.getId()));
+            lessonSubmissionRepository.save(LessonSubmission.create(120, 100, lesson.getId(), user.getId()));
+
+            Learning learning = Learning.create(user.getId());
+            ReflectionTestUtils.setField(learning, "recentSolvedChapterId", chapter.getId());
+            ReflectionTestUtils.setField(learning, "consecutiveSolvedDays", 5);
+            learningRepository.save(learning);
+
+            // when
+            LearningDetailResponse result = learningFacade.getLearningDetail(user.getId());
+
+            // then
+            assertSoftly(softly -> {
+                softly.assertThat(result.consecutiveSolvedDays()).isEqualTo(5);
+                softly.assertThat(result.recentSolvedChapterId()).isEqualTo(chapter.getId());
+                softly.assertThat(result.recentSolvedChapterTitle()).isEqualTo("운영체제");
+                softly.assertThat(result.units()).hasSize(2);
+            });
+        }
+
+        @Test
+        void 학습_기록이_없는_사용자도_학습_상세를_정상적으로_반환한다() {
+            // given
+            User user = userRepository.save(User.create("test@test.com", "provider_1", "테스터", "handle1", 1, Role.USER));
+
+            // Learning.create 기본 recentSolvedChapterId=1L 이므로 id 1 챕터가 존재해야 한다 (reset SQL 로 id 1부터 시작)
+            Chapter chapter = chapterRepository.save(Chapter.create("운영체제", "운영체제 기초 개념"));
+            unitRepository.save(Unit.create("프로세스", "프로세스 개념", chapter.getId()));
+            unitRepository.save(Unit.create("스레드", "스레드 개념", chapter.getId()));
+
+            learningRepository.save(Learning.create(user.getId()));
+
+            // when
+            LearningDetailResponse result = learningFacade.getLearningDetail(user.getId());
+
+            // then
+            assertSoftly(softly -> {
+                softly.assertThat(result.consecutiveSolvedDays()).isZero();
+                softly.assertThat(result.recentSolvedChapterProgressRate()).isZero();
+                softly.assertThat(result.recentSolvedChapterId()).isEqualTo(chapter.getId());
+                softly.assertThat(result.units()).hasSize(2);
+            });
+        }
+
+        @Test
+        void 학습_정보가_없으면_예외를_던진다() {
+            // given
+            long nonExistentUserId = 999L;
+
+            // when & then
+            assertThatThrownBy(() -> learningFacade.getLearningDetail(nonExistentUserId))
+                    .isInstanceOf(RestApiException.class)
+                    .extracting(e -> ((RestApiException) e).getErrorCode())
+                    .isEqualTo(LEARNING_NOT_FOUND);
+        }
+    }
+}

--- a/src/test/java/gravit/code/user/facade/UserFacadeIntegrationTest.java
+++ b/src/test/java/gravit/code/user/facade/UserFacadeIntegrationTest.java
@@ -25,6 +25,7 @@ import gravit.code.user.domain.Role;
 import gravit.code.user.domain.User;
 import gravit.code.user.dto.response.MainPageResponse;
 import gravit.code.user.dto.response.MyPageBannerResponse;
+import gravit.code.user.dto.response.ProfileSummaryResponse;
 import gravit.code.user.repository.UserRepository;
 import gravit.code.userLeague.domain.UserLeague;
 import gravit.code.userLeague.repository.UserLeagueRepository;
@@ -173,6 +174,39 @@ class UserFacadeIntegrationTest {
             assertThatThrownBy(() -> userFacade.getMainPage(nonExistentUserId))
                     .isInstanceOf(RestApiException.class)
                     .extracting("errorCode")
+                    .isEqualTo(USER_NOT_FOUND);
+        }
+    }
+
+    @Nested
+    @DisplayName("메인 페이지 프로필을 조회할 때")
+    class GetProfileSummary {
+
+        @Test
+        void 프로필_이미지_닉네임_레벨_상세를_정상적으로_반환한다() {
+            // given
+            User user = userRepository.save(User.create("test@test.com", "provider_1", "테스터", "handle1", 3, Role.USER));
+
+            // when
+            ProfileSummaryResponse result = userFacade.getProfileSummary(user.getId());
+
+            // then
+            assertSoftly(softly -> {
+                softly.assertThat(result.profileImgNumber()).isEqualTo(3);
+                softly.assertThat(result.nickname()).isEqualTo("테스터");
+                softly.assertThat(result.userLevelDetailResponse().level()).isEqualTo(1);
+            });
+        }
+
+        @Test
+        void 사용자가_존재하지_않으면_예외를_던진다() {
+            // given
+            long nonExistentUserId = 999L;
+
+            // when & then
+            assertThatThrownBy(() -> userFacade.getProfileSummary(nonExistentUserId))
+                    .isInstanceOf(RestApiException.class)
+                    .extracting(e -> ((RestApiException) e).getErrorCode())
                     .isEqualTo(USER_NOT_FOUND);
         }
     }


### PR DESCRIPTION
### 1. 연관 이슈

---
 - close #415

<br>

### 2. 구현 사항

---
**메인페이지 통합 API를 위젯별로 분리**

- `MainPageController`(`/api/v1/main-pages`) 신규 — 프로필/리그/학습/추천유닛/주간기록/미션 **6개 위젯 엔드포인트**로 분리 (도메인 결합·장애 전파 해소, `MyPageController`와 동일한 2-Facade 위임 패턴)
- 신규 위임 메서드 2개: `UserFacade#getProfileSummary`, `LearningFacade#getLearningDetail`
- 프로필만 `ProfileSummaryResponse` 신규, 나머지 위젯은 기존 하위 응답 DTO 재사용 → **위젯 응답 필드명 변경 없음** (프론트는 래퍼 벗기기·경로 이동만 반영)
- 레거시 통합 API(`GET /users/main-page`)는 Strangler Fig로 **동결 + `@Deprecated(forRemoval)`** 처리 (실제 제거는 프론트 전환 후 후속 이슈)

**테스트**

- `getProfileSummary`, `getLearningDetail` Facade 통합 테스트 추가 (정상 / 예외 케이스)
- 기존 `GetMainPage` 테스트는 레거시 동작 보장 위해 무수정 유지

🤖 Generated with [Claude Code](https://claude.com/claude-code)