### PR TITLE
refactor: 팀 컨벤션 적용

### DIFF
--- a/src/main/java/gravit/code/admin/controller/AdminChapterController.java
+++ b/src/main/java/gravit/code/admin/controller/AdminChapterController.java
@@ -10,6 +10,7 @@ import gravit.code.admin.service.AdminChapterService;
 import gravit.code.global.dto.response.PageResponse;
 import jakarta.validation.Valid;
 import lombok.RequiredArgsConstructor;
+import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.PatchMapping;
@@ -30,17 +31,17 @@ public class AdminChapterController implements AdminChapterControllerDocs {
     public ResponseEntity<PageResponse<ChapterListItemResponse>> getChapters(
             @RequestParam(value = "page", defaultValue = "1") int page
     ) {
-        return ResponseEntity.ok(adminChapterService.getChapters(page));
+        return ResponseEntity.status(HttpStatus.OK).body(adminChapterService.getChapters(page));
     }
 
     @GetMapping("/{chapterId}")
     public ResponseEntity<ChapterDetailResponse> getChapter(@PathVariable("chapterId") Long chapterId) {
-        return ResponseEntity.ok(adminChapterService.getChapter(chapterId));
+        return ResponseEntity.status(HttpStatus.OK).body(adminChapterService.getChapter(chapterId));
     }
 
     @GetMapping("/{chapterId}/stats")
     public ResponseEntity<ChapterStatsResponse> getChapterStats(@PathVariable("chapterId") Long chapterId) {
-        return ResponseEntity.ok(adminChapterService.getChapterStats(chapterId));
+        return ResponseEntity.status(HttpStatus.OK).body(adminChapterService.getChapterStats(chapterId));
     }
 
     @PatchMapping("/{chapterId}")
@@ -49,7 +50,7 @@ public class AdminChapterController implements AdminChapterControllerDocs {
             @Valid @RequestBody ChapterUpdateRequest request
     ) {
         adminChapterService.updateChapter(chapterId, request);
-        return ResponseEntity.ok().build();
+        return ResponseEntity.status(HttpStatus.OK).build();
     }
 
     @GetMapping("/{chapterId}/units")
@@ -57,6 +58,6 @@ public class AdminChapterController implements AdminChapterControllerDocs {
             @PathVariable("chapterId") Long chapterId,
             @RequestParam(value = "page", defaultValue = "1") int page
     ) {
-        return ResponseEntity.ok(adminChapterService.getUnits(chapterId, page));
+        return ResponseEntity.status(HttpStatus.OK).body(adminChapterService.getUnits(chapterId, page));
     }
 }

--- a/src/main/java/gravit/code/admin/controller/AdminDashboardController.java
+++ b/src/main/java/gravit/code/admin/controller/AdminDashboardController.java
@@ -4,6 +4,7 @@ import gravit.code.admin.controller.docs.AdminDashboardControllerDocs;
 import gravit.code.admin.dto.response.DashboardSummaryResponse;
 import gravit.code.admin.service.AdminDashboardService;
 import lombok.RequiredArgsConstructor;
+import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.RequestMapping;
@@ -18,6 +19,6 @@ public class AdminDashboardController implements AdminDashboardControllerDocs {
 
     @GetMapping("/summary")
     public ResponseEntity<DashboardSummaryResponse> getSummary() {
-        return ResponseEntity.ok(adminDashboardService.getSummary());
+        return ResponseEntity.status(HttpStatus.OK).body(adminDashboardService.getSummary());
     }
 }

--- a/src/main/java/gravit/code/admin/controller/AdminInquiryController.java
+++ b/src/main/java/gravit/code/admin/controller/AdminInquiryController.java
@@ -36,12 +36,12 @@ public class AdminInquiryController implements AdminInquiryControllerDocs {
             @RequestParam(value = "status", required = false) InquiryStatus status,
             @RequestParam(value = "page", defaultValue = "1") int page
     ) {
-        return ResponseEntity.ok(adminInquiryService.getInquiries(status, page));
+        return ResponseEntity.status(HttpStatus.OK).body(adminInquiryService.getInquiries(status, page));
     }
 
     @GetMapping("/{inquiryId}")
     public ResponseEntity<InquiryDetailResponse> getInquiry(@PathVariable("inquiryId") long inquiryId) {
-        return ResponseEntity.ok(adminInquiryService.getInquiry(inquiryId));
+        return ResponseEntity.status(HttpStatus.OK).body(adminInquiryService.getInquiry(inquiryId));
     }
 
     @PostMapping("/{inquiryId}/answer")
@@ -59,12 +59,12 @@ public class AdminInquiryController implements AdminInquiryControllerDocs {
             @PathVariable("inquiryId") long inquiryId,
             @Valid @RequestBody InquiryAnswerUpdateRequest request
     ) {
-        return ResponseEntity.ok(adminInquiryService.updateAnswer(inquiryId, request));
+        return ResponseEntity.status(HttpStatus.OK).body(adminInquiryService.updateAnswer(inquiryId, request));
     }
 
     @DeleteMapping("/{inquiryId}/answer")
     public ResponseEntity<Void> deleteAnswer(@PathVariable("inquiryId") long inquiryId) {
         adminInquiryService.deleteAnswer(inquiryId);
-        return ResponseEntity.noContent().build();
+        return ResponseEntity.status(HttpStatus.NO_CONTENT).build();
     }
 }

--- a/src/main/java/gravit/code/admin/controller/AdminLessonController.java
+++ b/src/main/java/gravit/code/admin/controller/AdminLessonController.java
@@ -8,6 +8,7 @@ import gravit.code.admin.service.AdminLessonService;
 import gravit.code.global.dto.response.PageResponse;
 import jakarta.validation.Valid;
 import lombok.RequiredArgsConstructor;
+import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.PatchMapping;
@@ -26,7 +27,7 @@ public class AdminLessonController implements AdminLessonControllerDocs {
 
     @GetMapping("/{lessonId}")
     public ResponseEntity<LessonDetailResponse> getLesson(@PathVariable("lessonId") Long lessonId) {
-        return ResponseEntity.ok(adminLessonService.getLesson(lessonId));
+        return ResponseEntity.status(HttpStatus.OK).body(adminLessonService.getLesson(lessonId));
     }
 
     @PatchMapping("/{lessonId}")
@@ -35,7 +36,7 @@ public class AdminLessonController implements AdminLessonControllerDocs {
             @Valid @RequestBody LessonUpdateRequest request
     ) {
         adminLessonService.updateLesson(lessonId, request);
-        return ResponseEntity.ok().build();
+        return ResponseEntity.status(HttpStatus.OK).build();
     }
 
     @GetMapping("/{lessonId}/problems")
@@ -43,6 +44,6 @@ public class AdminLessonController implements AdminLessonControllerDocs {
             @PathVariable("lessonId") Long lessonId,
             @RequestParam(value = "page", defaultValue = "1") int page
     ) {
-        return ResponseEntity.ok(adminLessonService.getProblems(lessonId, page));
+        return ResponseEntity.status(HttpStatus.OK).body(adminLessonService.getProblems(lessonId, page));
     }
 }

--- a/src/main/java/gravit/code/admin/controller/AdminMeController.java
+++ b/src/main/java/gravit/code/admin/controller/AdminMeController.java
@@ -5,6 +5,7 @@ import gravit.code.admin.dto.response.AdminMeResponse;
 import gravit.code.admin.service.AdminMeService;
 import gravit.code.auth.domain.LoginUser;
 import lombok.RequiredArgsConstructor;
+import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
 import org.springframework.security.core.annotation.AuthenticationPrincipal;
 import org.springframework.web.bind.annotation.GetMapping;
@@ -20,6 +21,6 @@ public class AdminMeController implements AdminMeControllerDocs {
 
     @GetMapping
     public ResponseEntity<AdminMeResponse> getMe(@AuthenticationPrincipal LoginUser loginUser) {
-        return ResponseEntity.ok(adminMeService.getMe(loginUser.getId()));
+        return ResponseEntity.status(HttpStatus.OK).body(adminMeService.getMe(loginUser.getId()));
     }
 }

--- a/src/main/java/gravit/code/admin/controller/AdminNoticeController.java
+++ b/src/main/java/gravit/code/admin/controller/AdminNoticeController.java
@@ -32,12 +32,12 @@ public class AdminNoticeController implements AdminNoticeControllerDocs {
 
     @GetMapping
     public ResponseEntity<PageResponse<NoticeListItemResponse>> getNotices(@RequestParam(value = "page", defaultValue = "1") int page) {
-        return ResponseEntity.ok(adminNoticeService.getNotices(page));
+        return ResponseEntity.status(HttpStatus.OK).body(adminNoticeService.getNotices(page));
     }
 
     @GetMapping("/{noticeId}")
     public ResponseEntity<NoticeDetailResponse> getNotice(@PathVariable("noticeId") Long noticeId) {
-        return ResponseEntity.ok(adminNoticeService.getNotice(noticeId));
+        return ResponseEntity.status(HttpStatus.OK).body(adminNoticeService.getNotice(noticeId));
     }
 
     @PostMapping
@@ -56,7 +56,7 @@ public class AdminNoticeController implements AdminNoticeControllerDocs {
             @Valid @RequestBody NoticeUpdateRequest request
     ) {
         NoticeDetailResponse notice = adminNoticeService.updateNotice(loginUser.getId(), noticeId, request);
-        return ResponseEntity.ok(notice);
+        return ResponseEntity.status(HttpStatus.OK).body(notice);
     }
 
     @DeleteMapping("/{noticeId}")
@@ -65,6 +65,6 @@ public class AdminNoticeController implements AdminNoticeControllerDocs {
             @PathVariable("noticeId") Long noticeId
     ) {
         adminNoticeService.deleteNotice(loginUser.getId(), noticeId);
-        return ResponseEntity.noContent().build();
+        return ResponseEntity.status(HttpStatus.NO_CONTENT).build();
     }
 }

--- a/src/main/java/gravit/code/admin/controller/AdminProblemController.java
+++ b/src/main/java/gravit/code/admin/controller/AdminProblemController.java
@@ -7,6 +7,7 @@ import gravit.code.admin.dto.response.ProblemDetailResponse;
 import gravit.code.admin.service.AdminProblemService;
 import jakarta.validation.Valid;
 import lombok.RequiredArgsConstructor;
+import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.PatchMapping;
@@ -24,7 +25,7 @@ public class AdminProblemController implements AdminProblemControllerDocs {
 
     @GetMapping("/{problemId}")
     public ResponseEntity<ProblemDetailResponse> getProblem(@PathVariable("problemId") Long problemId) {
-        return ResponseEntity.ok(adminProblemService.getProblem(problemId));
+        return ResponseEntity.status(HttpStatus.OK).body(adminProblemService.getProblem(problemId));
     }
 
     @PatchMapping("/{problemId}/objective")
@@ -33,7 +34,7 @@ public class AdminProblemController implements AdminProblemControllerDocs {
             @Valid @RequestBody ObjectiveProblemUpdateRequest request
     ) {
         adminProblemService.updateObjective(problemId, request);
-        return ResponseEntity.ok().build();
+        return ResponseEntity.status(HttpStatus.OK).build();
     }
 
     @PatchMapping("/{problemId}/subjective")
@@ -42,6 +43,6 @@ public class AdminProblemController implements AdminProblemControllerDocs {
             @Valid @RequestBody SubjectiveProblemUpdateRequest request
     ) {
         adminProblemService.updateSubjective(problemId, request);
-        return ResponseEntity.ok().build();
+        return ResponseEntity.status(HttpStatus.OK).build();
     }
 }

--- a/src/main/java/gravit/code/admin/controller/AdminReportController.java
+++ b/src/main/java/gravit/code/admin/controller/AdminReportController.java
@@ -9,6 +9,7 @@ import gravit.code.global.dto.response.PageResponse;
 import gravit.code.report.domain.ReportType;
 import jakarta.validation.Valid;
 import lombok.RequiredArgsConstructor;
+import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.PatchMapping;
@@ -31,12 +32,12 @@ public class AdminReportController implements AdminReportControllerDocs {
             @RequestParam(value = "reportType", required = false) ReportType reportType,
             @RequestParam(value = "isResolved", required = false) Boolean isResolved
     ) {
-        return ResponseEntity.ok(adminReportService.getReports(page, reportType, isResolved));
+        return ResponseEntity.status(HttpStatus.OK).body(adminReportService.getReports(page, reportType, isResolved));
     }
 
     @GetMapping("/{reportId}")
     public ResponseEntity<ReportDetailResponse> getReport(@PathVariable("reportId") Long reportId) {
-        return ResponseEntity.ok(adminReportService.getReport(reportId));
+        return ResponseEntity.status(HttpStatus.OK).body(adminReportService.getReport(reportId));
     }
 
     @PatchMapping("/{reportId}/status")
@@ -45,6 +46,6 @@ public class AdminReportController implements AdminReportControllerDocs {
             @Valid @RequestBody ReportStatusUpdateRequest request
     ) {
         adminReportService.updateResolved(reportId, request.isResolved());
-        return ResponseEntity.ok().build();
+        return ResponseEntity.status(HttpStatus.OK).build();
     }
 }

--- a/src/main/java/gravit/code/admin/controller/AdminStagingController.java
+++ b/src/main/java/gravit/code/admin/controller/AdminStagingController.java
@@ -15,6 +15,7 @@ import gravit.code.auth.domain.LoginUser;
 import gravit.code.global.dto.response.PageResponse;
 import jakarta.validation.Valid;
 import lombok.RequiredArgsConstructor;
+import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
 import org.springframework.security.core.annotation.AuthenticationPrincipal;
 import org.springframework.web.bind.annotation.GetMapping;
@@ -38,12 +39,12 @@ public class AdminStagingController implements AdminStagingControllerDocs {
             @RequestParam(value = "page", defaultValue = "1") int page,
             @RequestParam(value = "status", required = false) LabelStatus status
     ) {
-        return ResponseEntity.ok(adminStagingService.getLabels(page, status));
+        return ResponseEntity.status(HttpStatus.OK).body(adminStagingService.getLabels(page, status));
     }
 
     @GetMapping("/labels/{label}")
     public ResponseEntity<StagingLabelDetailResponse> getLabelDetail(@PathVariable("label") String label) {
-        return ResponseEntity.ok(adminStagingService.getLabelDetail(label));
+        return ResponseEntity.status(HttpStatus.OK).body(adminStagingService.getLabelDetail(label));
     }
 
     @PatchMapping("/lessons/{lessonId}")
@@ -52,7 +53,7 @@ public class AdminStagingController implements AdminStagingControllerDocs {
             @Valid @RequestBody StagingLessonUpdateRequest request
     ) {
         adminStagingService.updateLesson(lessonId, request);
-        return ResponseEntity.ok().build();
+        return ResponseEntity.status(HttpStatus.OK).build();
     }
 
     @PatchMapping("/problems/{problemId}")
@@ -61,7 +62,7 @@ public class AdminStagingController implements AdminStagingControllerDocs {
             @Valid @RequestBody StagingProblemUpdateRequest request
     ) {
         adminStagingService.updateProblem(problemId, request);
-        return ResponseEntity.ok().build();
+        return ResponseEntity.status(HttpStatus.OK).build();
     }
 
     @PatchMapping("/options/{optionId}")
@@ -70,7 +71,7 @@ public class AdminStagingController implements AdminStagingControllerDocs {
             @Valid @RequestBody StagingOptionUpdateRequest request
     ) {
         adminStagingService.updateOption(optionId, request);
-        return ResponseEntity.ok().build();
+        return ResponseEntity.status(HttpStatus.OK).build();
     }
 
     @PatchMapping("/answers/{answerId}")
@@ -79,7 +80,7 @@ public class AdminStagingController implements AdminStagingControllerDocs {
             @Valid @RequestBody StagingAnswerUpdateRequest request
     ) {
         adminStagingService.updateAnswer(answerId, request);
-        return ResponseEntity.ok().build();
+        return ResponseEntity.status(HttpStatus.OK).build();
     }
 
     @PatchMapping("/labels/{label}/status")
@@ -89,6 +90,6 @@ public class AdminStagingController implements AdminStagingControllerDocs {
             @Valid @RequestBody LabelStatusUpdateRequest request
     ) {
         adminStagingPromoteService.promote(loginUser.getId(), label, request.status());
-        return ResponseEntity.ok().build();
+        return ResponseEntity.status(HttpStatus.OK).build();
     }
 }

--- a/src/main/java/gravit/code/admin/controller/AdminUnitController.java
+++ b/src/main/java/gravit/code/admin/controller/AdminUnitController.java
@@ -8,6 +8,7 @@ import gravit.code.admin.service.AdminUnitService;
 import gravit.code.global.dto.response.PageResponse;
 import jakarta.validation.Valid;
 import lombok.RequiredArgsConstructor;
+import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.PatchMapping;
@@ -26,7 +27,7 @@ public class AdminUnitController implements AdminUnitControllerDocs {
 
     @GetMapping("/{unitId}")
     public ResponseEntity<UnitDetailResponse> getUnit(@PathVariable("unitId") Long unitId) {
-        return ResponseEntity.ok(adminUnitService.getUnit(unitId));
+        return ResponseEntity.status(HttpStatus.OK).body(adminUnitService.getUnit(unitId));
     }
 
     @PatchMapping("/{unitId}")
@@ -35,7 +36,7 @@ public class AdminUnitController implements AdminUnitControllerDocs {
             @Valid @RequestBody UnitUpdateRequest request
     ) {
         adminUnitService.updateUnit(unitId, request);
-        return ResponseEntity.ok().build();
+        return ResponseEntity.status(HttpStatus.OK).build();
     }
 
     @GetMapping("/{unitId}/lessons")
@@ -43,6 +44,6 @@ public class AdminUnitController implements AdminUnitControllerDocs {
             @PathVariable("unitId") Long unitId,
             @RequestParam(value = "page", defaultValue = "1") int page
     ) {
-        return ResponseEntity.ok(adminUnitService.getLessons(unitId, page));
+        return ResponseEntity.status(HttpStatus.OK).body(adminUnitService.getLessons(unitId, page));
     }
 }

--- a/src/main/java/gravit/code/admin/controller/AdminUserController.java
+++ b/src/main/java/gravit/code/admin/controller/AdminUserController.java
@@ -12,6 +12,7 @@ import gravit.code.user.domain.Role;
 import gravit.code.user.domain.UserStatus;
 import jakarta.validation.Valid;
 import lombok.RequiredArgsConstructor;
+import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
 import org.springframework.security.core.annotation.AuthenticationPrincipal;
 import org.springframework.web.bind.annotation.GetMapping;
@@ -36,12 +37,12 @@ public class AdminUserController implements AdminUserControllerDocs {
             @RequestParam(value = "status", required = false) UserStatus status,
             @RequestParam(value = "role", required = false) Role role
     ) {
-        return ResponseEntity.ok(adminUserService.getUsers(page, search, status, role));
+        return ResponseEntity.status(HttpStatus.OK).body(adminUserService.getUsers(page, search, status, role));
     }
 
     @GetMapping("/{userId}")
     public ResponseEntity<UserDetailResponse> getUser(@PathVariable("userId") Long userId) {
-        return ResponseEntity.ok(adminUserService.getUser(userId));
+        return ResponseEntity.status(HttpStatus.OK).body(adminUserService.getUser(userId));
     }
 
     @PatchMapping("/{userId}/status")
@@ -51,7 +52,7 @@ public class AdminUserController implements AdminUserControllerDocs {
             @Valid @RequestBody UserStatusUpdateRequest request
     ) {
         adminUserService.updateStatus(loginUser.getId(), userId, request.status());
-        return ResponseEntity.ok().build();
+        return ResponseEntity.status(HttpStatus.OK).build();
     }
 
     @PatchMapping("/{userId}/role")
@@ -61,6 +62,6 @@ public class AdminUserController implements AdminUserControllerDocs {
             @Valid @RequestBody UserRoleUpdateRequest request
     ) {
         adminUserService.updateRole(loginUser.getId(), userId, request.role());
-        return ResponseEntity.ok().build();
+        return ResponseEntity.status(HttpStatus.OK).build();
     }
 }

--- a/src/main/java/gravit/code/admin/domain/audit/AuditLog.java
+++ b/src/main/java/gravit/code/admin/domain/audit/AuditLog.java
@@ -1,5 +1,6 @@
 package gravit.code.admin.domain.audit;
 
+import gravit.code.global.consts.TimeZoneConst;
 import jakarta.persistence.Column;
 import jakarta.persistence.Entity;
 import jakarta.persistence.EnumType;
@@ -14,7 +15,6 @@ import lombok.Getter;
 import lombok.NoArgsConstructor;
 
 import java.time.LocalDateTime;
-import java.time.ZoneId;
 
 import static java.time.temporal.ChronoUnit.MICROS;
 
@@ -23,8 +23,6 @@ import static java.time.temporal.ChronoUnit.MICROS;
 @Getter
 @NoArgsConstructor(access = AccessLevel.PROTECTED)
 public class AuditLog {
-
-    private static final ZoneId SEOUL = ZoneId.of("Asia/Seoul");
 
     @Id
     @GeneratedValue(strategy = GenerationType.IDENTITY)
@@ -62,7 +60,7 @@ public class AuditLog {
         this.targetId = targetId;
         this.beforeValue = beforeValue;
         this.afterValue = afterValue;
-        this.createdAt = LocalDateTime.now(SEOUL).truncatedTo(MICROS);
+        this.createdAt = LocalDateTime.now(TimeZoneConst.KST).truncatedTo(MICROS);
     }
 
     public static AuditLog create(

--- a/src/main/java/gravit/code/admin/domain/staging/StagingLabel.java
+++ b/src/main/java/gravit/code/admin/domain/staging/StagingLabel.java
@@ -1,5 +1,6 @@
 package gravit.code.admin.domain.staging;
 
+import gravit.code.global.consts.TimeZoneConst;
 import jakarta.persistence.Column;
 import jakarta.persistence.Entity;
 import jakarta.persistence.EnumType;
@@ -12,7 +13,6 @@ import lombok.Getter;
 import lombok.NoArgsConstructor;
 
 import java.time.LocalDateTime;
-import java.time.ZoneId;
 
 /**
  * 스테이징 라벨. PK(id)·status·created_at 은 generator 적재 시 DB 가 발번/기본값 처리한다.
@@ -72,7 +72,7 @@ public class StagingLabel {
                 .unitId(unitId)
                 .description(description)
                 .status(LabelStatus.PENDING)
-                .createdAt(LocalDateTime.now(ZoneId.of("Asia/Seoul")))
+                .createdAt(LocalDateTime.now(TimeZoneConst.KST))
                 .build();
     }
 

--- a/src/main/java/gravit/code/auth/controller/OAuthController.java
+++ b/src/main/java/gravit/code/auth/controller/OAuthController.java
@@ -39,7 +39,7 @@ public class OAuthController implements OAuthControllerDocs {
             @RequestParam String dest
     ) {
         String loginUrl = oAuthLoginUrlService.generateLoginUrl(provider, dest);
-        return ResponseEntity.ok(Map.of("loginUrl", loginUrl));
+        return ResponseEntity.status(HttpStatus.OK).body(Map.of("loginUrl", loginUrl));
     }
 
     /**
@@ -55,7 +55,7 @@ public class OAuthController implements OAuthControllerDocs {
         String code = authCodeRequest.code();
 
         if(code == null){
-            return  ResponseEntity.badRequest().build();
+            return  ResponseEntity.status(HttpStatus.BAD_REQUEST).build();
         }
 
         OAuthUserInfo userInfo = oAuthClientService.getUserInfo(code, provider, dest);

--- a/src/main/java/gravit/code/auth/dto/oauth/GoogleUserInfo.java
+++ b/src/main/java/gravit/code/auth/dto/oauth/GoogleUserInfo.java
@@ -1,13 +1,8 @@
 package gravit.code.auth.dto.oauth;
 
-import lombok.RequiredArgsConstructor;
-
 import java.util.Map;
 
-@RequiredArgsConstructor
-public class GoogleUserInfo implements OAuthUserInfo {
-
-    private final Map<String, Object> attributes;
+public record GoogleUserInfo(Map<String, Object> attributes) implements OAuthUserInfo {
 
     @Override
     public String getProvider() {

--- a/src/main/java/gravit/code/auth/dto/oauth/KakaoUserInfo.java
+++ b/src/main/java/gravit/code/auth/dto/oauth/KakaoUserInfo.java
@@ -1,13 +1,8 @@
 package gravit.code.auth.dto.oauth;
 
-import lombok.RequiredArgsConstructor;
-
 import java.util.Map;
 
-@RequiredArgsConstructor
-public class KakaoUserInfo implements OAuthUserInfo {
-
-    private final Map<String, Object> attributes;
+public record KakaoUserInfo(Map<String, Object> attributes) implements OAuthUserInfo {
 
     @Override
     public String getProvider() {

--- a/src/main/java/gravit/code/auth/dto/oauth/NaverUserInfo.java
+++ b/src/main/java/gravit/code/auth/dto/oauth/NaverUserInfo.java
@@ -2,11 +2,10 @@ package gravit.code.auth.dto.oauth;
 
 import java.util.Map;
 
-public class NaverUserInfo implements OAuthUserInfo {
+public record NaverUserInfo(Map<String, Object> attributes) implements OAuthUserInfo {
 
-    private final Map<String, Object> attributes;
-    public NaverUserInfo(Map<String, Object> attributes){
-        this.attributes = (Map<String, Object>)attributes.get("response");
+    public NaverUserInfo {
+        attributes = (Map<String, Object>) attributes.get("response");
     }
 
     @Override

--- a/src/main/java/gravit/code/auth/dto/oauth/android/GoogleAndroidUserInfo.java
+++ b/src/main/java/gravit/code/auth/dto/oauth/android/GoogleAndroidUserInfo.java
@@ -1,22 +1,18 @@
 package gravit.code.auth.dto.oauth.android;
 
 import gravit.code.auth.dto.oauth.OAuthUserInfo;
-import lombok.RequiredArgsConstructor;
 
 import java.util.Map;
 
 import static gravit.code.auth.dto.oauth.android.support.AndroidOAuthClaimsExtractor.getClaimAsString;
 import static gravit.code.auth.dto.oauth.android.support.AndroidOAuthClaimsExtractor.isBlank;
 
-@RequiredArgsConstructor
-public class GoogleAndroidUserInfo implements OAuthUserInfo {
+public record GoogleAndroidUserInfo(Map<String, Object> claims) implements OAuthUserInfo {
 
     private static final String PROVIDER = "google";
     private static final String CLAIM_SUB = "sub";
     private static final String CLAIM_EMAIL = "email";
     private static final String CLAIM_NAME = "name";
-
-    private final Map<String, Object> claims;
 
     @Override
     public String getProvider() {
@@ -40,6 +36,4 @@ public class GoogleAndroidUserInfo implements OAuthUserInfo {
         String name = getClaimAsString(claims, CLAIM_NAME);
         return isBlank(name) ? null : name;
     }
-
-
 }

--- a/src/main/java/gravit/code/auth/dto/oauth/android/KakaoAndroidUserInfo.java
+++ b/src/main/java/gravit/code/auth/dto/oauth/android/KakaoAndroidUserInfo.java
@@ -1,23 +1,18 @@
 package gravit.code.auth.dto.oauth.android;
 
 import gravit.code.auth.dto.oauth.OAuthUserInfo;
-import lombok.RequiredArgsConstructor;
 
 import java.util.Map;
 
 import static gravit.code.auth.dto.oauth.android.support.AndroidOAuthClaimsExtractor.getClaimAsString;
 import static gravit.code.auth.dto.oauth.android.support.AndroidOAuthClaimsExtractor.isBlank;
 
-
-@RequiredArgsConstructor
-public class KakaoAndroidUserInfo implements OAuthUserInfo {
+public record KakaoAndroidUserInfo(Map<String, Object> claims) implements OAuthUserInfo {
 
     private static final String PROVIDER = "kakao";
     private static final String CLAIM_SUB = "sub";
     private static final String CLAIM_EMAIL = "email";
     private static final String CLAIM_NAME = "nickname";
-
-    private final Map<String, Object> claims;
 
     @Override
     public String getProvider() {

--- a/src/main/java/gravit/code/auth/dto/oauth/android/NaverAndroidUserInfo.java
+++ b/src/main/java/gravit/code/auth/dto/oauth/android/NaverAndroidUserInfo.java
@@ -2,21 +2,11 @@ package gravit.code.auth.dto.oauth.android;
 
 import gravit.code.auth.dto.oauth.OAuthUserInfo;
 
-
-public class NaverAndroidUserInfo implements OAuthUserInfo {
-    private final String providerId;
-    private final String email;
-    private final String nickname;
-
-    public NaverAndroidUserInfo(
-            String providerId,
-            String email,
-            String nickname
-    ) {
-        this.providerId = providerId;
-        this.email = email;
-        this.nickname = nickname;
-    }
+public record NaverAndroidUserInfo(
+        String providerId,
+        String email,
+        String nickname
+) implements OAuthUserInfo {
 
     @Override
     public String getProvider() {
@@ -25,17 +15,16 @@ public class NaverAndroidUserInfo implements OAuthUserInfo {
 
     @Override
     public String getProviderId() {
-        return this.providerId;
+        return providerId;
     }
 
     @Override
     public String getEmail() {
-        return this.email;
+        return email;
     }
 
     @Override
     public String getName() {
-        return this.nickname;
+        return nickname;
     }
-
 }

--- a/src/main/java/gravit/code/auth/service/AuthTokenProvider.java
+++ b/src/main/java/gravit/code/auth/service/AuthTokenProvider.java
@@ -13,12 +13,12 @@ import gravit.code.user.domain.User;
 import gravit.code.user.repository.UserRepository;
 import lombok.RequiredArgsConstructor;
 import org.springframework.security.core.Authentication;
-import org.springframework.stereotype.Component;
+import org.springframework.stereotype.Service;
 
 import java.util.Map;
 import java.util.Objects;
 
-@Component
+@Service
 @RequiredArgsConstructor
 public class AuthTokenProvider {
 

--- a/src/main/java/gravit/code/auth/token/JwtProvider.java
+++ b/src/main/java/gravit/code/auth/token/JwtProvider.java
@@ -3,6 +3,7 @@ package gravit.code.auth.token;
 import gravit.code.auth.domain.LoginUser;
 import gravit.code.auth.domain.Subject;
 import gravit.code.auth.token.config.JwtProperties;
+import gravit.code.global.consts.TimeZoneConst;
 import gravit.code.global.exception.domain.CustomErrorCode;
 import gravit.code.global.exception.domain.RestApiException;
 import gravit.code.user.domain.User;
@@ -23,7 +24,6 @@ import javax.crypto.SecretKey;
 import javax.crypto.spec.SecretKeySpec;
 import java.nio.charset.StandardCharsets;
 import java.time.Duration;
-import java.time.ZoneId;
 import java.time.ZonedDateTime;
 import java.util.Collection;
 import java.util.Collections;
@@ -38,7 +38,6 @@ import static io.jsonwebtoken.Jwts.SIG.HS256;
 public class JwtProvider {
 
     private final SecretKey secretKey;
-    private static final ZoneId SEOUL_ZONE = ZoneId.of("Asia/Seoul");
 
     public JwtProvider(JwtProperties jwtProperties) {
         this.secretKey = new SecretKeySpec(jwtProperties.secret().getBytes(StandardCharsets.UTF_8), "HmacSHA256");
@@ -49,7 +48,7 @@ public class JwtProvider {
             Map<String, String> claims,
             Duration expireTime
     ) {
-        ZonedDateTime now = ZonedDateTime.now(SEOUL_ZONE);
+        ZonedDateTime now = ZonedDateTime.now(TimeZoneConst.KST);
         ZonedDateTime expiredDateTime = now.plus(expireTime);
 
         Date nowDate = Date.from(now.toInstant());
@@ -68,7 +67,7 @@ public class JwtProvider {
             Subject subject,
             Duration expireTime
     ) {
-        ZonedDateTime now = ZonedDateTime.now(SEOUL_ZONE);
+        ZonedDateTime now = ZonedDateTime.now(TimeZoneConst.KST);
         ZonedDateTime expiredDateTime = now.plus(expireTime);
 
         Date nowDate = Date.from(now.toInstant());

--- a/src/main/java/gravit/code/bookmark/controller/BookmarkController.java
+++ b/src/main/java/gravit/code/bookmark/controller/BookmarkController.java
@@ -41,7 +41,7 @@ public class BookmarkController implements BookmarkControllerDocs {
             @Valid @RequestBody BookmarkSaveRequest request
     ) {
         bookmarkService.addBookmark(loginUser.getId(), request);
-        return ResponseEntity.ok().build();
+        return ResponseEntity.status(HttpStatus.OK).build();
     }
 
     @DeleteMapping
@@ -50,7 +50,7 @@ public class BookmarkController implements BookmarkControllerDocs {
             @Valid @RequestBody BookmarkDeleteRequest request
     ) {
         bookmarkService.deleteBookmark(loginUser.getId(), request);
-        return ResponseEntity.noContent().build();
+        return ResponseEntity.status(HttpStatus.NO_CONTENT).build();
     }
 
 }

--- a/src/main/java/gravit/code/bookmark/controller/BookmarkController.java
+++ b/src/main/java/gravit/code/bookmark/controller/BookmarkController.java
@@ -31,7 +31,7 @@ public class BookmarkController implements BookmarkControllerDocs {
     public ResponseEntity<BookmarkedProblemResponse> getAllBookmarkedProblemInUnit(
             @AuthenticationPrincipal LoginUser loginUser,
             @PathVariable("unitId") Long unitId
-    ){
+    ) {
         return ResponseEntity.status(HttpStatus.OK).body(bookmarkFacade.getAllBookmarkedProblemInUnit(loginUser.getId(), unitId));
     }
 
@@ -39,7 +39,7 @@ public class BookmarkController implements BookmarkControllerDocs {
     public ResponseEntity<Void> addBookmark(
             @AuthenticationPrincipal LoginUser loginUser,
             @Valid @RequestBody BookmarkSaveRequest request
-    ){
+    ) {
         bookmarkService.addBookmark(loginUser.getId(), request);
         return ResponseEntity.ok().build();
     }
@@ -47,7 +47,7 @@ public class BookmarkController implements BookmarkControllerDocs {
     @DeleteMapping
     public ResponseEntity<Void> deleteBookmark(
             @AuthenticationPrincipal LoginUser loginUser,
-            @Valid@RequestBody BookmarkDeleteRequest request
+            @Valid @RequestBody BookmarkDeleteRequest request
     ) {
         bookmarkService.deleteBookmark(loginUser.getId(), request);
         return ResponseEntity.noContent().build();

--- a/src/main/java/gravit/code/bookmark/domain/Bookmark.java
+++ b/src/main/java/gravit/code/bookmark/domain/Bookmark.java
@@ -25,7 +25,7 @@ public class Bookmark {
     @Column(name = "problem_id", nullable = false)
     private long problemId;
 
-    @Column(name = "user_id",  nullable = false)
+    @Column(name = "user_id", nullable = false)
     private long userId;
 
     @Column(name = "created_at", nullable = false)

--- a/src/main/java/gravit/code/bookmark/domain/Bookmark.java
+++ b/src/main/java/gravit/code/bookmark/domain/Bookmark.java
@@ -1,5 +1,6 @@
 package gravit.code.bookmark.domain;
 
+import gravit.code.global.consts.TimeZoneConst;
 import jakarta.persistence.Column;
 import jakarta.persistence.Entity;
 import jakarta.persistence.GeneratedValue;
@@ -11,7 +12,6 @@ import lombok.Getter;
 import lombok.NoArgsConstructor;
 
 import java.time.LocalDateTime;
-import java.time.ZoneId;
 
 @Entity
 @Getter
@@ -35,7 +35,7 @@ public class Bookmark {
     private Bookmark(long problemId, long userId) {
         this.problemId = problemId;
         this.userId = userId;
-        this.createdAt = LocalDateTime.now(ZoneId.of("Asia/Seoul"));
+        this.createdAt = LocalDateTime.now(TimeZoneConst.KST);
     }
 
     public static Bookmark create(long problemId, long userId) {

--- a/src/main/java/gravit/code/bookmark/domain/Bookmark.java
+++ b/src/main/java/gravit/code/bookmark/domain/Bookmark.java
@@ -8,14 +8,14 @@ import jakarta.persistence.Id;
 import lombok.AccessLevel;
 import lombok.Builder;
 import lombok.Getter;
-import lombok.RequiredArgsConstructor;
+import lombok.NoArgsConstructor;
 
 import java.time.LocalDateTime;
 import java.time.ZoneId;
 
 @Entity
 @Getter
-@RequiredArgsConstructor(access = AccessLevel.PROTECTED)
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
 public class Bookmark {
 
     @Id

--- a/src/main/java/gravit/code/bookmark/service/BookmarkService.java
+++ b/src/main/java/gravit/code/bookmark/service/BookmarkService.java
@@ -23,7 +23,7 @@ public class BookmarkService {
     public void addBookmark(
             long userId,
             BookmarkSaveRequest request
-    ){
+    ) {
         if(bookmarkRepository.existsByProblemIdAndUserId(request.problemId(), userId))
             throw new RestApiException(CustomErrorCode.BOOKMARK_DUPLICATED);
 
@@ -58,7 +58,7 @@ public class BookmarkService {
     public List<ProblemDetailResponse> getAllBookmarkedProblemInUnit(
             long userId,
             long unitId
-    ){
+    ) {
         return bookmarkRepository.findBookmarkedProblemDetailByUnitIdAndUserId(unitId, userId);
     }
 }

--- a/src/main/java/gravit/code/csnote/controller/CSNoteController.java
+++ b/src/main/java/gravit/code/csnote/controller/CSNoteController.java
@@ -12,6 +12,7 @@ import org.springframework.core.io.ClassPathResource;
 import org.springframework.core.io.Resource;
 import org.springframework.http.ContentDisposition;
 import org.springframework.http.HttpHeaders;
+import org.springframework.http.HttpStatus;
 import org.springframework.http.MediaType;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.GetMapping;
@@ -69,7 +70,7 @@ public class CSNoteController implements CSNoteControllerDocs {
             ClassPathResource resource = new ClassPathResource(filePath);
 
             if(!resource.exists()){
-                return ResponseEntity.notFound().build();
+                return ResponseEntity.status(HttpStatus.NOT_FOUND).build();
             }
 
             HttpHeaders headers = new HttpHeaders();
@@ -80,10 +81,10 @@ public class CSNoteController implements CSNoteControllerDocs {
                             .build()
             );
 
-            return ResponseEntity.ok().headers(headers).body(resource);
+            return ResponseEntity.status(HttpStatus.OK).headers(headers).body(resource);
 
         }catch (Exception e){
-            return ResponseEntity.internalServerError().build();
+            return ResponseEntity.status(HttpStatus.INTERNAL_SERVER_ERROR).build();
         }
     }
 

--- a/src/main/java/gravit/code/fcm/controller/FcmTokenController.java
+++ b/src/main/java/gravit/code/fcm/controller/FcmTokenController.java
@@ -9,6 +9,7 @@ import gravit.code.fcm.service.FcmTokenQueryService;
 import jakarta.validation.Valid;
 import jakarta.validation.constraints.NotBlank;
 import lombok.RequiredArgsConstructor;
+import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
 import org.springframework.security.core.annotation.AuthenticationPrincipal;
 import org.springframework.validation.annotation.Validated;
@@ -34,7 +35,7 @@ public class FcmTokenController implements FcmTokenControllerDocs {
             @Valid @RequestBody RegisterFcmTokenRequest request
     ){
         fcmTokenCommandService.registerFcmToken(loginUser.getId(), request);
-        return ResponseEntity.ok().build();
+        return ResponseEntity.status(HttpStatus.OK).build();
     }
 
     @GetMapping("/exists")
@@ -43,7 +44,7 @@ public class FcmTokenController implements FcmTokenControllerDocs {
             @NotBlank(message = "디바이스 아이디가 비어있습니다.")
             @RequestParam("deviceId") String deviceId
     ){
-        return ResponseEntity.ok(fcmTokenQueryService.checkFcmTokenExist(loginUser.getId(), deviceId));
+        return ResponseEntity.status(HttpStatus.OK).body(fcmTokenQueryService.checkFcmTokenExist(loginUser.getId(), deviceId));
     }
 
 }

--- a/src/main/java/gravit/code/friend/controller/FriendController.java
+++ b/src/main/java/gravit/code/friend/controller/FriendController.java
@@ -98,6 +98,6 @@ public class FriendController implements FriendControllerDocs {
             @RequestParam(defaultValue = "0") int page
     ){
         SliceResponse<SearchUserDto> pageResponse = friendService.searchUsersForFollowing(loginUser.getId(), queryText, page);
-        return ResponseEntity.ok(pageResponse);
+        return ResponseEntity.status(HttpStatus.OK).body(pageResponse);
     }
 }

--- a/src/main/java/gravit/code/friend/domain/Friend.java
+++ b/src/main/java/gravit/code/friend/domain/Friend.java
@@ -29,7 +29,7 @@ public class Friend extends BaseEntity {
     private Long followeeId;
 
 
-    @Builder
+    @Builder(access = AccessLevel.PRIVATE)
     private Friend(
             long followerId,
             long followeeId

--- a/src/main/java/gravit/code/friend/dto/response/FollowerSliceResponse.java
+++ b/src/main/java/gravit/code/friend/dto/response/FollowerSliceResponse.java
@@ -5,18 +5,19 @@ import io.swagger.v3.oas.annotations.media.Schema;
 import java.util.List;
 
 @Schema(description = "팔로워 목록 슬라이스 응답")
-public class FollowerSliceResponse {
+public record FollowerSliceResponse(
 
-    @Schema(
-            description = "다음 페이지 존재 여부",
-            example = "false",
-            requiredMode = Schema.RequiredMode.REQUIRED
-    )
-    public boolean hasNextPage;
+        @Schema(
+                description = "다음 페이지 존재 여부",
+                example = "false",
+                requiredMode = Schema.RequiredMode.REQUIRED
+        )
+        boolean hasNextPage,
 
-    @Schema(
-            description = "팔로워 목록",
-            requiredMode = Schema.RequiredMode.REQUIRED
-    )
-    public List<FollowerResponse> contents;
+        @Schema(
+                description = "팔로워 목록",
+                requiredMode = Schema.RequiredMode.REQUIRED
+        )
+        List<FollowerResponse> contents
+) {
 }

--- a/src/main/java/gravit/code/friend/dto/response/FriendResponse.java
+++ b/src/main/java/gravit/code/friend/dto/response/FriendResponse.java
@@ -2,9 +2,10 @@ package gravit.code.friend.dto.response;
 
 import gravit.code.friend.domain.Friend;
 import io.swagger.v3.oas.annotations.media.Schema;
+import lombok.AccessLevel;
 import lombok.Builder;
 
-@Builder
+@Builder(access = AccessLevel.PRIVATE)
 public record FriendResponse(
 
         @Schema(requiredMode = Schema.RequiredMode.REQUIRED)

--- a/src/main/java/gravit/code/friend/dto/response/SearchUserSliceResponse.java
+++ b/src/main/java/gravit/code/friend/dto/response/SearchUserSliceResponse.java
@@ -6,18 +6,19 @@ import io.swagger.v3.oas.annotations.media.Schema;
 import java.util.List;
 
 @Schema(description = "사용자 검색 슬라이스 응답")
-public class SearchUserSliceResponse {
+public record SearchUserSliceResponse(
 
-    @Schema(
-            description = "다음 페이지 존재 여부",
-            example = "false",
-            requiredMode = Schema.RequiredMode.REQUIRED
-    )
-    public boolean hasNextPage;
+        @Schema(
+                description = "다음 페이지 존재 여부",
+                example = "false",
+                requiredMode = Schema.RequiredMode.REQUIRED
+        )
+        boolean hasNextPage,
 
-    @Schema(
-            description = "검색 결과 목록",
-            requiredMode = Schema.RequiredMode.REQUIRED
-    )
-    public List<SearchUserDto> contents;
+        @Schema(
+                description = "검색 결과 목록",
+                requiredMode = Schema.RequiredMode.REQUIRED
+        )
+        List<SearchUserDto> contents
+) {
 }

--- a/src/main/java/gravit/code/global/config/TimeConfig.java
+++ b/src/main/java/gravit/code/global/config/TimeConfig.java
@@ -1,16 +1,16 @@
 package gravit.code.global.config;
 
+import gravit.code.global.consts.TimeZoneConst;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
 
 import java.time.Clock;
-import java.time.ZoneId;
 
 @Configuration
 public class TimeConfig {
 
     @Bean
     public Clock clock() {
-        return Clock.system(ZoneId.of("Asia/Seoul"));
+        return Clock.system(TimeZoneConst.KST);
     }
 }

--- a/src/main/java/gravit/code/global/dto/response/SliceResponse.java
+++ b/src/main/java/gravit/code/global/dto/response/SliceResponse.java
@@ -1,12 +1,13 @@
 package gravit.code.global.dto.response;
 
 import io.swagger.v3.oas.annotations.media.Schema;
+import lombok.AccessLevel;
 import lombok.Builder;
 import org.springframework.data.domain.Slice;
 
 import java.util.List;
 
-@Builder
+@Builder(access = AccessLevel.PRIVATE)
 public record SliceResponse<T>(
         @Schema(requiredMode = Schema.RequiredMode.REQUIRED)
         boolean hasNextPage,

--- a/src/main/java/gravit/code/global/entity/BaseEntity.java
+++ b/src/main/java/gravit/code/global/entity/BaseEntity.java
@@ -1,5 +1,6 @@
 package gravit.code.global.entity;
 
+import gravit.code.global.consts.TimeZoneConst;
 import jakarta.persistence.EntityListeners;
 import jakarta.persistence.MappedSuperclass;
 import jakarta.persistence.PrePersist;
@@ -10,7 +11,6 @@ import org.hibernate.annotations.DynamicUpdate;
 import org.springframework.data.jpa.domain.support.AuditingEntityListener;
 
 import java.time.LocalDateTime;
-import java.time.ZoneId;
 
 import static java.time.temporal.ChronoUnit.MICROS;
 
@@ -24,17 +24,15 @@ public abstract class BaseEntity {
     private LocalDateTime createdAt;
     private LocalDateTime updatedAt;
 
-    private static final ZoneId SEOUL = ZoneId.of("Asia/Seoul");
-
     @PrePersist
     public void onPrePersist(){
-        LocalDateTime now = LocalDateTime.now(SEOUL).truncatedTo(MICROS);
+        LocalDateTime now = LocalDateTime.now(TimeZoneConst.KST).truncatedTo(MICROS);
         this.createdAt = now;
         this.updatedAt = now;
     }
 
     @PreUpdate
     public void onPreUpdate(){
-        this.updatedAt = LocalDateTime.now(SEOUL).truncatedTo(MICROS);
+        this.updatedAt = LocalDateTime.now(TimeZoneConst.KST).truncatedTo(MICROS);
     }
 }

--- a/src/main/java/gravit/code/global/exception/domain/CustomErrorCode.java
+++ b/src/main/java/gravit/code/global/exception/domain/CustomErrorCode.java
@@ -111,6 +111,7 @@ public enum CustomErrorCode implements ErrorCode {
     ACTIVE_SEASON_NOT_FOUND(HttpStatus.NOT_FOUND, "SEASON_4041", "ACTIVE 시즌이 없습니다."),
     BATCH_PREP_SEASON_CONFLICT(HttpStatus.CONFLICT, "SEASON_4091", "배치 처리 도중, PREP 시즌 생성 관련하여 충돌이 발생하였습니다."),
     BATCH_ACTIVE_SEASON_CONFLICT(HttpStatus.CONFLICT, "SEASON_4092", "배치 처리 도중, ACTIVE 시즌 생성 관련하여 충돌이 발생하였습니다."),
+    INVALID_SEASON_STATUS_TRANSITION(HttpStatus.CONFLICT, "SEASON_4093", "시즌 상태 전이가 유효하지 않습니다."),
 
     // Notice
     NOTICE_TITLE_INVALID(HttpStatus.BAD_REQUEST, "NOTICE_4001", "공지 사항의 제목이 유효하지 않습니다."),

--- a/src/main/java/gravit/code/global/exception/domain/ErrorResponse.java
+++ b/src/main/java/gravit/code/global/exception/domain/ErrorResponse.java
@@ -1,7 +1,12 @@
 package gravit.code.global.exception.domain;
 
+import lombok.AccessLevel;
 import lombok.Builder;
 
-@Builder
+@Builder(access = AccessLevel.PRIVATE)
 public record ErrorResponse<T>(String error, T message) {
+
+    public static <T> ErrorResponse<T> of(String error, T message) {
+        return new ErrorResponse<>(error, message);
+    }
 }

--- a/src/main/java/gravit/code/global/exception/handler/GlobalExceptionHandler.java
+++ b/src/main/java/gravit/code/global/exception/handler/GlobalExceptionHandler.java
@@ -75,10 +75,7 @@ public class GlobalExceptionHandler {
     public ResponseEntity<ErrorResponse<String>> handleSoftDeleted(AccountSoftDeletedException ex) {
         String errorCode = "USER_423";
         String message = ex.getProviderId();
-        ErrorResponse<String> errorResponse = ErrorResponse.<String>builder()
-                .error(errorCode)
-                .message(message)
-                .build();
+        ErrorResponse<String> errorResponse = ErrorResponse.of(errorCode, message);
         HttpStatus status = HttpStatus.LOCKED;
         return ResponseEntity.status(status).body(errorResponse);
     }
@@ -94,16 +91,10 @@ public class GlobalExceptionHandler {
     }
 
     private ErrorResponse<String> makeErrorResponse(ErrorCode errorCode){
-        return ErrorResponse.<String>builder()
-                .error(errorCode.getCode())
-                .message(errorCode.getMessage())
-                .build();
+        return ErrorResponse.of(errorCode.getCode(), errorCode.getMessage());
     }
 
     private ErrorResponse<List<String>> makeErrorResponse(List<String> message){
-        return ErrorResponse.<List<String>>builder()
-                .error(CustomErrorCode.INVALID_PARAMS.getCode())
-                .message(message)
-                .build();
+        return ErrorResponse.of(CustomErrorCode.INVALID_PARAMS.getCode(), message);
     }
 }

--- a/src/main/java/gravit/code/global/util/TimeAgoFormatter.java
+++ b/src/main/java/gravit/code/global/util/TimeAgoFormatter.java
@@ -1,20 +1,20 @@
 package gravit.code.global.util;
 
+import gravit.code.global.consts.TimeZoneConst;
+
 import java.time.LocalDateTime;
-import java.time.ZoneId;
 import java.time.temporal.ChronoUnit;
 
 // 생성 시각을 "방금 전 / N분 전 / N시간 전 / N일 전(최대 7일)" 상대 표현으로 변환한다
 public final class TimeAgoFormatter {
 
-    private static final ZoneId KST = ZoneId.of("Asia/Seoul");
     private static final long MAX_DAYS = 7;
 
     private TimeAgoFormatter() {
     }
 
     public static String format(LocalDateTime createdAt) {
-        LocalDateTime now = LocalDateTime.now(KST);
+        LocalDateTime now = LocalDateTime.now(TimeZoneConst.KST);
 
         long minutes = ChronoUnit.MINUTES.between(createdAt, now);
         if (minutes < 1) return "방금 전";

--- a/src/main/java/gravit/code/inquiry/controller/InquiryController.java
+++ b/src/main/java/gravit/code/inquiry/controller/InquiryController.java
@@ -43,7 +43,7 @@ public class InquiryController implements InquiryControllerDocs {
             @AuthenticationPrincipal LoginUser loginUser,
             @RequestParam(value = "page", defaultValue = "1") int page
     ) {
-        return ResponseEntity.ok(inquiryQueryService.getMyInquiries(loginUser.getId(), page));
+        return ResponseEntity.status(HttpStatus.OK).body(inquiryQueryService.getMyInquiries(loginUser.getId(), page));
     }
 
     @GetMapping("/{inquiryId}")
@@ -51,6 +51,6 @@ public class InquiryController implements InquiryControllerDocs {
             @AuthenticationPrincipal LoginUser loginUser,
             @PathVariable("inquiryId") long inquiryId
     ) {
-        return ResponseEntity.ok(inquiryQueryService.getMyInquiryDetail(loginUser.getId(), inquiryId));
+        return ResponseEntity.status(HttpStatus.OK).body(inquiryQueryService.getMyInquiryDetail(loginUser.getId(), inquiryId));
     }
 }

--- a/src/main/java/gravit/code/inquiry/domain/Inquiry.java
+++ b/src/main/java/gravit/code/inquiry/domain/Inquiry.java
@@ -46,7 +46,7 @@ public class Inquiry extends BaseEntity {
     @Column(name = "user_id", nullable = false)
     private long userId;
 
-    @Builder
+    @Builder(access = AccessLevel.PRIVATE)
     private Inquiry(
             String title,
             InquiryType type,

--- a/src/main/java/gravit/code/inquiry/domain/InquiryAnswer.java
+++ b/src/main/java/gravit/code/inquiry/domain/InquiryAnswer.java
@@ -31,7 +31,7 @@ public class InquiryAnswer extends BaseEntity {
     @Column(name = "admin_id", nullable = false)
     private long adminId;
 
-    @Builder
+    @Builder(access = AccessLevel.PRIVATE)
     private InquiryAnswer(
             long inquiryId,
             String content,

--- a/src/main/java/gravit/code/inquiry/dto/response/InquiryDetailResponse.java
+++ b/src/main/java/gravit/code/inquiry/dto/response/InquiryDetailResponse.java
@@ -3,11 +3,12 @@ package gravit.code.inquiry.dto.response;
 import gravit.code.inquiry.domain.Inquiry;
 import gravit.code.inquiry.domain.InquiryAnswer;
 import io.swagger.v3.oas.annotations.media.Schema;
+import lombok.AccessLevel;
 import lombok.Builder;
 
 import java.time.LocalDateTime;
 
-@Builder
+@Builder(access = AccessLevel.PRIVATE)
 public record InquiryDetailResponse(
 
         @Schema(requiredMode = Schema.RequiredMode.REQUIRED)

--- a/src/main/java/gravit/code/inquiry/dto/response/InquirySummaryPageResponse.java
+++ b/src/main/java/gravit/code/inquiry/dto/response/InquirySummaryPageResponse.java
@@ -5,39 +5,40 @@ import io.swagger.v3.oas.annotations.media.Schema;
 import java.util.List;
 
 @Schema(description = "문의 요약 페이지 응답")
-public class InquirySummaryPageResponse {
+public record InquirySummaryPageResponse(
 
-    @Schema(
-            description = "현재 페이지 번호",
-            example = "1",
-            requiredMode = Schema.RequiredMode.REQUIRED
-    )
-    public int page;
+        @Schema(
+                description = "현재 페이지 번호",
+                example = "1",
+                requiredMode = Schema.RequiredMode.REQUIRED
+        )
+        int page,
 
-    @Schema(
-            description = "전체 페이지 수",
-            example = "3",
-            requiredMode = Schema.RequiredMode.REQUIRED
-    )
-    public int totalPages;
+        @Schema(
+                description = "전체 페이지 수",
+                example = "3",
+                requiredMode = Schema.RequiredMode.REQUIRED
+        )
+        int totalPages,
 
-    @Schema(
-            description = "다음 페이지 존재 여부",
-            example = "true",
-            requiredMode = Schema.RequiredMode.REQUIRED
-    )
-    public boolean hasNext;
+        @Schema(
+                description = "다음 페이지 존재 여부",
+                example = "true",
+                requiredMode = Schema.RequiredMode.REQUIRED
+        )
+        boolean hasNext,
 
-    @Schema(
-            description = "전체 문의 개수",
-            example = "27",
-            requiredMode = Schema.RequiredMode.REQUIRED
-    )
-    public long totalElements;
+        @Schema(
+                description = "전체 문의 개수",
+                example = "27",
+                requiredMode = Schema.RequiredMode.REQUIRED
+        )
+        long totalElements,
 
-    @Schema(
-            description = "문의 요약 목록",
-            requiredMode = Schema.RequiredMode.REQUIRED
-    )
-    public List<InquirySummaryResponse> contents;
+        @Schema(
+                description = "문의 요약 목록",
+                requiredMode = Schema.RequiredMode.REQUIRED
+        )
+        List<InquirySummaryResponse> contents
+) {
 }

--- a/src/main/java/gravit/code/league/controller/LeagueController.java
+++ b/src/main/java/gravit/code/league/controller/LeagueController.java
@@ -24,7 +24,7 @@ public class LeagueController implements LeagueControllerSpecification {
 
     @GetMapping("/{leagueId}")
     public ResponseEntity<LeagueResponse> getLeague(@PathVariable("leagueId") Long leagueId) {
-        return ResponseEntity.ok(leagueService.getLeague(leagueId));
+        return ResponseEntity.status(HttpStatus.OK).body(leagueService.getLeague(leagueId));
     }
 
     @GetMapping("/home")

--- a/src/main/java/gravit/code/league/domain/League.java
+++ b/src/main/java/gravit/code/league/domain/League.java
@@ -31,7 +31,7 @@ public class League {
     @Column(name = "sort_order", nullable = false, unique = true)
     private int sortOrder;
 
-    @Builder
+    @Builder(access = AccessLevel.PRIVATE)
     private League(
             String name,
             int maxLp,

--- a/src/main/java/gravit/code/league/dto/response/LeagueResponse.java
+++ b/src/main/java/gravit/code/league/dto/response/LeagueResponse.java
@@ -2,9 +2,10 @@ package gravit.code.league.dto.response;
 
 import gravit.code.league.domain.League;
 import io.swagger.v3.oas.annotations.media.Schema;
+import lombok.AccessLevel;
 import lombok.Builder;
 
-@Builder
+@Builder(access = AccessLevel.PRIVATE)
 public record LeagueResponse(
 
         @Schema(requiredMode = Schema.RequiredMode.REQUIRED)

--- a/src/main/java/gravit/code/notice/domain/Notice.java
+++ b/src/main/java/gravit/code/notice/domain/Notice.java
@@ -68,7 +68,7 @@ public class Notice extends BaseEntity {
     @Column(name = "deleted_at")
     private LocalDateTime deletedAt;
 
-    @Builder
+    @Builder(access = AccessLevel.PRIVATE)
     private Notice (
             String title,
             String summary,

--- a/src/main/java/gravit/code/notice/domain/Notice.java
+++ b/src/main/java/gravit/code/notice/domain/Notice.java
@@ -1,5 +1,6 @@
 package gravit.code.notice.domain;
 
+import gravit.code.global.consts.TimeZoneConst;
 import gravit.code.global.entity.BaseEntity;
 import gravit.code.global.exception.domain.CustomErrorCode;
 import gravit.code.global.exception.domain.RestApiException;
@@ -23,7 +24,6 @@ import org.hibernate.annotations.SQLDelete;
 import org.hibernate.annotations.SQLRestriction;
 
 import java.time.LocalDateTime;
-import java.time.ZoneId;
 
 import static gravit.code.notice.domain.NoticeStatus.*;
 import static java.time.temporal.ChronoUnit.MICROS;
@@ -36,7 +36,6 @@ import static java.time.temporal.ChronoUnit.MICROS;
 @SQLRestriction("deleted_at IS NULL")
 public class Notice extends BaseEntity {
 
-    private static final ZoneId SEOUL = ZoneId.of("Asia/Seoul");
     private static final int TITLE_MAX_SIZE = 50;
     private static final int SUMMARY_MAX_SIZE = 255;
 
@@ -148,13 +147,13 @@ public class Notice extends BaseEntity {
         }
 
         if (next == PUBLISHED && this.publishedAt == null) {
-            this.publishedAt = LocalDateTime.now(SEOUL).truncatedTo(MICROS);
+            this.publishedAt = LocalDateTime.now(TimeZoneConst.KST).truncatedTo(MICROS);
         }
     }
 
     private static LocalDateTime getLocalDateTime(NoticeStatus status) {
         if (status == PUBLISHED) {
-            return LocalDateTime.now(SEOUL).truncatedTo(MICROS);
+            return LocalDateTime.now(TimeZoneConst.KST).truncatedTo(MICROS);
         }
         return null;
     }

--- a/src/main/java/gravit/code/notice/dto/response/NoticeDetailResponse.java
+++ b/src/main/java/gravit/code/notice/dto/response/NoticeDetailResponse.java
@@ -2,11 +2,12 @@ package gravit.code.notice.dto.response;
 
 import gravit.code.notice.domain.Notice;
 import io.swagger.v3.oas.annotations.media.Schema;
+import lombok.AccessLevel;
 import lombok.Builder;
 
 import java.time.LocalDateTime;
 
-@Builder
+@Builder(access = AccessLevel.PRIVATE)
 public record NoticeDetailResponse(
 
         @Schema(requiredMode = Schema.RequiredMode.REQUIRED)

--- a/src/main/java/gravit/code/notice/dto/response/NoticeSummaryPageResponse.java
+++ b/src/main/java/gravit/code/notice/dto/response/NoticeSummaryPageResponse.java
@@ -5,39 +5,40 @@ import io.swagger.v3.oas.annotations.media.Schema;
 import java.util.List;
 
 @Schema(description = "공지 요약 페이지 응답")
-public class NoticeSummaryPageResponse {
+public record NoticeSummaryPageResponse(
 
-    @Schema(
-            description = "현재 페이지 번호",
-            example = "1",
-            requiredMode = Schema.RequiredMode.REQUIRED
-    )
-    public int page;
+        @Schema(
+                description = "현재 페이지 번호",
+                example = "1",
+                requiredMode = Schema.RequiredMode.REQUIRED
+        )
+        int page,
 
-    @Schema(
-            description = "전체 페이지 수",
-            example = "5",
-            requiredMode = Schema.RequiredMode.REQUIRED
-    )
-    public int totalPages;
+        @Schema(
+                description = "전체 페이지 수",
+                example = "5",
+                requiredMode = Schema.RequiredMode.REQUIRED
+        )
+        int totalPages,
 
-    @Schema(
-            description = "다음 페이지 존재 여부",
-            example = "true",
-            requiredMode = Schema.RequiredMode.REQUIRED
-    )
-    public boolean hasNext;
+        @Schema(
+                description = "다음 페이지 존재 여부",
+                example = "true",
+                requiredMode = Schema.RequiredMode.REQUIRED
+        )
+        boolean hasNext,
 
-    @Schema(
-            description = "전체 공지 개수",
-            example = "42",
-            requiredMode = Schema.RequiredMode.REQUIRED
-    )
-    public long totalElements;
+        @Schema(
+                description = "전체 공지 개수",
+                example = "42",
+                requiredMode = Schema.RequiredMode.REQUIRED
+        )
+        long totalElements,
 
-    @Schema(
-            description = "공지 요약 목록",
-            requiredMode = Schema.RequiredMode.REQUIRED
-    )
-    public List<NoticeSummaryResponse> contents;
+        @Schema(
+                description = "공지 요약 목록",
+                requiredMode = Schema.RequiredMode.REQUIRED
+        )
+        List<NoticeSummaryResponse> contents
+) {
 }

--- a/src/main/java/gravit/code/notification/controller/NotificationController.java
+++ b/src/main/java/gravit/code/notification/controller/NotificationController.java
@@ -6,6 +6,7 @@ import gravit.code.notification.controller.docs.NotificationDocs;
 import gravit.code.notification.dto.response.NotificationResponse;
 import gravit.code.notification.facade.NotificationFacade;
 import lombok.RequiredArgsConstructor;
+import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
 import org.springframework.security.core.annotation.AuthenticationPrincipal;
 import org.springframework.web.bind.annotation.GetMapping;
@@ -26,6 +27,6 @@ public class NotificationController implements NotificationDocs {
             @RequestParam(defaultValue = "0") int page
     ) {
         SliceResponse<NotificationResponse> inbox = notificationFacade.getInbox(loginUser.getId(), page);
-        return ResponseEntity.ok(inbox);
+        return ResponseEntity.status(HttpStatus.OK).body(inbox);
     }
 }

--- a/src/main/java/gravit/code/problem/controller/ProblemController.java
+++ b/src/main/java/gravit/code/problem/controller/ProblemController.java
@@ -39,6 +39,6 @@ public class ProblemController implements ProblemControllerDocs {
             @Valid @RequestBody ProblemSubmissionRequest request
     ){
         problemSubmissionCommandService.saveProblemSubmission(loginUser.getId(), request);
-        return ResponseEntity.ok().build();
+        return ResponseEntity.status(HttpStatus.OK).build();
     }
 }

--- a/src/main/java/gravit/code/report/controller/ReportController.java
+++ b/src/main/java/gravit/code/report/controller/ReportController.java
@@ -5,6 +5,7 @@ import gravit.code.report.dto.request.ProblemReportSubmitRequest;
 import gravit.code.report.service.ReportService;
 import jakarta.validation.Valid;
 import lombok.RequiredArgsConstructor;
+import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
 import org.springframework.security.core.annotation.AuthenticationPrincipal;
 import org.springframework.web.bind.annotation.PostMapping;
@@ -25,6 +26,6 @@ public class ReportController implements ReportControllerDocs {
             @Valid @RequestBody ProblemReportSubmitRequest request
     ){
         reportService.submitProblemReport(loginUser.getId(), request);
-        return ResponseEntity.ok().build();
+        return ResponseEntity.status(HttpStatus.OK).build();
     }
 }

--- a/src/main/java/gravit/code/report/domain/Report.java
+++ b/src/main/java/gravit/code/report/domain/Report.java
@@ -1,5 +1,6 @@
 package gravit.code.report.domain;
 
+import gravit.code.global.consts.TimeZoneConst;
 import gravit.code.report.dto.request.ProblemReportSubmitRequest;
 import jakarta.persistence.Column;
 import jakarta.persistence.Entity;
@@ -14,7 +15,6 @@ import lombok.Getter;
 import lombok.NoArgsConstructor;
 
 import java.time.LocalDateTime;
-import java.time.ZoneId;
 
 @Entity
 @Getter
@@ -56,7 +56,7 @@ public class Report {
         this.problemId = problemId;
         this.userId = userId;
         this.isResolved = false;
-        this.submittedAt = LocalDateTime.now(ZoneId.of("Asia/Seoul"));
+        this.submittedAt = LocalDateTime.now(TimeZoneConst.KST);
     }
 
     public static Report create(

--- a/src/main/java/gravit/code/report/domain/Report.java
+++ b/src/main/java/gravit/code/report/domain/Report.java
@@ -44,7 +44,7 @@ public class Report {
     @Column(name = "submitted_at", columnDefinition = "timestamp", nullable = false)
     private LocalDateTime submittedAt;
 
-    @Builder
+    @Builder(access = AccessLevel.PRIVATE)
     private Report(
             ReportType reportType,
             String content,
@@ -67,6 +67,20 @@ public class Report {
                 .reportType(ReportType.from(request.reportType()))
                 .content(request.content() == null ? "-" : request.content())
                 .problemId(request.problemId())
+                .userId(userId)
+                .build();
+    }
+
+    public static Report of(
+            ReportType reportType,
+            String content,
+            long problemId,
+            long userId
+    ) {
+        return Report.builder()
+                .reportType(reportType)
+                .content(content)
+                .problemId(problemId)
                 .userId(userId)
                 .build();
     }

--- a/src/main/java/gravit/code/season/domain/Season.java
+++ b/src/main/java/gravit/code/season/domain/Season.java
@@ -45,7 +45,7 @@ public class Season {
     @Column(name = "tz", nullable = false)
     private String tz;
 
-    @Builder
+    @Builder(access = AccessLevel.PRIVATE)
     private Season(
             String seasonKey,
             LocalDateTime startsAt,

--- a/src/main/java/gravit/code/season/domain/Season.java
+++ b/src/main/java/gravit/code/season/domain/Season.java
@@ -1,5 +1,7 @@
 package gravit.code.season.domain;
 
+import gravit.code.global.exception.domain.CustomErrorCode;
+import gravit.code.global.exception.domain.RestApiException;
 import jakarta.persistence.Column;
 import jakarta.persistence.Entity;
 import jakarta.persistence.EnumType;
@@ -105,7 +107,7 @@ public class Season {
 
     private void validateStatus(SeasonStatus expected) {
         if (this.status != expected) {
-            throw new RuntimeException();
+            throw new RestApiException(CustomErrorCode.INVALID_SEASON_STATUS_TRANSITION);
         }
     }
 

--- a/src/main/java/gravit/code/security/exception/CustomAccessDeniedHandler.java
+++ b/src/main/java/gravit/code/security/exception/CustomAccessDeniedHandler.java
@@ -38,9 +38,6 @@ public class CustomAccessDeniedHandler implements AccessDeniedHandler {
     }
 
     private ErrorResponse<String> makeErrorResponse(ErrorCode errorCode) {
-        return ErrorResponse.<String>builder()
-                .error(errorCode.getCode())
-                .message(errorCode.getMessage())
-                .build();
+        return ErrorResponse.of(errorCode.getCode(), errorCode.getMessage());
     }
 }

--- a/src/main/java/gravit/code/security/exception/CustomAuthenticationEntryPoint.java
+++ b/src/main/java/gravit/code/security/exception/CustomAuthenticationEntryPoint.java
@@ -42,9 +42,6 @@ public class CustomAuthenticationEntryPoint implements AuthenticationEntryPoint 
     }
 
     private ErrorResponse<String> makeErrorResponse(ErrorCode errorCode) {
-        return ErrorResponse.<String>builder()
-                .error(errorCode.getCode())
-                .message(errorCode.getMessage())
-                .build();
+        return ErrorResponse.of(errorCode.getCode(), errorCode.getMessage());
     }
 }

--- a/src/main/java/gravit/code/social/controller/SocialController.java
+++ b/src/main/java/gravit/code/social/controller/SocialController.java
@@ -7,6 +7,7 @@ import gravit.code.social.dto.response.RecommendUserResponse;
 import gravit.code.social.dto.response.SocialFeedResponse;
 import gravit.code.social.facade.SocialFacade;
 import lombok.RequiredArgsConstructor;
+import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
 import org.springframework.security.core.annotation.AuthenticationPrincipal;
 import org.springframework.web.bind.annotation.DeleteMapping;
@@ -31,7 +32,7 @@ public class SocialController implements SocialControllerDocs {
             @AuthenticationPrincipal LoginUser loginUser
     ) {
         List<RecommendUserResponse> result = socialFacade.getRecommendedUsers(loginUser.getId());
-        return ResponseEntity.ok(result);
+        return ResponseEntity.status(HttpStatus.OK).body(result);
     }
 
     @PostMapping("/follow/{userId}")
@@ -40,7 +41,7 @@ public class SocialController implements SocialControllerDocs {
             @PathVariable long userId
     ) {
         socialFacade.follow(loginUser.getId(), userId);
-        return ResponseEntity.noContent().build();
+        return ResponseEntity.status(HttpStatus.NO_CONTENT).build();
     }
 
     @GetMapping("/feed")
@@ -49,7 +50,7 @@ public class SocialController implements SocialControllerDocs {
             @RequestParam(defaultValue = "0") int page
     ) {
         SliceResponse<SocialFeedResponse> feed = socialFacade.getFeed(loginUser.getId(), page);
-        return ResponseEntity.ok(feed);
+        return ResponseEntity.status(HttpStatus.OK).body(feed);
     }
 
     @DeleteMapping("/feed/{feedId}")
@@ -58,7 +59,7 @@ public class SocialController implements SocialControllerDocs {
             @PathVariable long feedId
     ) {
         socialFacade.hideFeed(loginUser.getId(), feedId);
-        return ResponseEntity.noContent().build();
+        return ResponseEntity.status(HttpStatus.NO_CONTENT).build();
     }
 
     @PostMapping("/feed/{feedId}/congratulate")
@@ -67,6 +68,6 @@ public class SocialController implements SocialControllerDocs {
             @PathVariable long feedId
     ) {
         socialFacade.congratulateFeed(loginUser.getId(), feedId);
-        return ResponseEntity.noContent().build();
+        return ResponseEntity.status(HttpStatus.NO_CONTENT).build();
     }
 }

--- a/src/main/java/gravit/code/social/domain/UserFeed.java
+++ b/src/main/java/gravit/code/social/domain/UserFeed.java
@@ -1,5 +1,6 @@
 package gravit.code.social.domain;
 
+import gravit.code.global.consts.TimeZoneConst;
 import gravit.code.global.entity.BaseEntity;
 import jakarta.persistence.Column;
 import jakarta.persistence.Entity;
@@ -13,7 +14,6 @@ import lombok.Getter;
 import lombok.NoArgsConstructor;
 
 import java.time.LocalDateTime;
-import java.time.ZoneId;
 
 @Table(name = "user_feed")
 @Entity
@@ -62,7 +62,7 @@ public class UserFeed extends BaseEntity {
     }
 
     public void congratulate() {
-        this.congratulatedAt = LocalDateTime.now(ZoneId.of("Asia/Seoul"));
+        this.congratulatedAt = LocalDateTime.now(TimeZoneConst.KST);
         this.hidden = true;
     }
 }

--- a/src/main/java/gravit/code/social/dto/response/SocialFeedSliceResponse.java
+++ b/src/main/java/gravit/code/social/dto/response/SocialFeedSliceResponse.java
@@ -5,18 +5,19 @@ import io.swagger.v3.oas.annotations.media.Schema;
 import java.util.List;
 
 @Schema(description = "피드 슬라이스 응답")
-public class SocialFeedSliceResponse {
+public record SocialFeedSliceResponse(
 
-    @Schema(
-            description = "다음 페이지 존재 여부",
-            example = "false",
-            requiredMode = Schema.RequiredMode.REQUIRED
-    )
-    public boolean hasNextPage;
+        @Schema(
+                description = "다음 페이지 존재 여부",
+                example = "false",
+                requiredMode = Schema.RequiredMode.REQUIRED
+        )
+        boolean hasNextPage,
 
-    @Schema(
-            description = "피드 목록",
-            requiredMode = Schema.RequiredMode.REQUIRED
-    )
-    public List<SocialFeedResponse> contents;
+        @Schema(
+                description = "피드 목록",
+                requiredMode = Schema.RequiredMode.REQUIRED
+        )
+        List<SocialFeedResponse> contents
+) {
 }

--- a/src/main/java/gravit/code/social/service/CongratulationService.java
+++ b/src/main/java/gravit/code/social/service/CongratulationService.java
@@ -1,5 +1,6 @@
 package gravit.code.social.service;
 
+import gravit.code.global.consts.TimeZoneConst;
 import gravit.code.global.exception.domain.RestApiException;
 import gravit.code.social.domain.Congratulation;
 import gravit.code.social.repository.CongratulationRepository;
@@ -10,7 +11,6 @@ import org.springframework.transaction.annotation.Transactional;
 
 import java.time.LocalDate;
 import java.time.LocalDateTime;
-import java.time.ZoneId;
 
 import static gravit.code.global.exception.domain.CustomErrorCode.ALREADY_CONGRATULATED;
 import static gravit.code.global.exception.domain.CustomErrorCode.CONGRATULATE_LIMIT_EXCEEDED;
@@ -20,7 +20,6 @@ import static gravit.code.global.exception.domain.CustomErrorCode.CONGRATULATE_L
 public class CongratulationService {
 
     private static final int DAILY_LIMIT = 3;
-    private static final ZoneId SEOUL = ZoneId.of("Asia/Seoul");
 
     private final CongratulationRepository congratulationRepository;
 
@@ -33,7 +32,7 @@ public class CongratulationService {
         if (congratulationRepository.existsByUserIdAndFeedId(userId, feedId)) {
             throw new RestApiException(ALREADY_CONGRATULATED);
         }
-        LocalDateTime startOfDay = LocalDate.now(SEOUL).atStartOfDay();
+        LocalDateTime startOfDay = LocalDate.now(TimeZoneConst.KST).atStartOfDay();
         long todayCount = congratulationRepository.countTodayByUserIdAndActorId(userId, actorId, startOfDay);
         if (todayCount >= DAILY_LIMIT) {
             throw new RestApiException(CONGRATULATE_LIMIT_EXCEEDED);

--- a/src/main/java/gravit/code/social/service/SocialFeedService.java
+++ b/src/main/java/gravit/code/social/service/SocialFeedService.java
@@ -1,5 +1,6 @@
 package gravit.code.social.service;
 
+import gravit.code.global.consts.TimeZoneConst;
 import gravit.code.global.dto.response.SliceResponse;
 import gravit.code.global.exception.domain.CustomErrorCode;
 import gravit.code.global.exception.domain.RestApiException;
@@ -19,7 +20,6 @@ import org.springframework.transaction.annotation.Transactional;
 
 import java.time.LocalDate;
 import java.time.LocalDateTime;
-import java.time.ZoneId;
 import java.util.HashSet;
 import java.util.List;
 import java.util.Set;
@@ -29,7 +29,6 @@ import java.util.Set;
 public class SocialFeedService {
 
     private static final int PAGE_SIZE = 4;
-    private static final ZoneId SEOUL = ZoneId.of("Asia/Seoul");
 
     private final SocialFeedRepository socialFeedRepository;
     private final UserFeedRepository userFeedRepository;
@@ -70,7 +69,7 @@ public class SocialFeedService {
         if (actorIds.isEmpty()) {
             return Set.of();
         }
-        LocalDateTime startOfDay = LocalDate.now(SEOUL).atStartOfDay();
+        LocalDateTime startOfDay = LocalDate.now(TimeZoneConst.KST).atStartOfDay();
         return new HashSet<>(congratulationRepository.findActorIdsWithLimitReached(userId, actorIds, startOfDay));
     }
 

--- a/src/main/java/gravit/code/test/notification/controller/TestNotificationController.java
+++ b/src/main/java/gravit/code/test/notification/controller/TestNotificationController.java
@@ -5,6 +5,7 @@ import gravit.code.notification.facade.NotificationFacade;
 import gravit.code.test.notification.controller.docs.TestNotificationDocs;
 import lombok.RequiredArgsConstructor;
 import org.springframework.context.annotation.Profile;
+import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
 import org.springframework.security.core.annotation.AuthenticationPrincipal;
 import org.springframework.web.bind.annotation.PostMapping;
@@ -27,7 +28,7 @@ public class TestNotificationController implements TestNotificationDocs {
     ) {
         notificationFacade.sendConsecutiveLearningWarningToUser(loginUser.getId(), consecutiveDays);
 
-        return ResponseEntity.ok(loginUser.getId());
+        return ResponseEntity.status(HttpStatus.OK).body(loginUser.getId());
     }
 
     @PostMapping("/daily-incomplete")
@@ -36,7 +37,7 @@ public class TestNotificationController implements TestNotificationDocs {
     ) {
         notificationFacade.sendDailyIncompleteToUser(loginUser.getId());
 
-        return ResponseEntity.ok(loginUser.getId());
+        return ResponseEntity.status(HttpStatus.OK).body(loginUser.getId());
     }
 
     @PostMapping("/inactivity")
@@ -46,7 +47,7 @@ public class TestNotificationController implements TestNotificationDocs {
     ) {
         notificationFacade.sendInactivityToUser(loginUser.getId(), inactiveDays);
 
-        return ResponseEntity.ok(loginUser.getId());
+        return ResponseEntity.status(HttpStatus.OK).body(loginUser.getId());
     }
 
     @PostMapping("/new-content")
@@ -56,6 +57,6 @@ public class TestNotificationController implements TestNotificationDocs {
     ) {
         notificationFacade.sendNewContentToUser(loginUser.getId(), unitId);
 
-        return ResponseEntity.ok(loginUser.getId());
+        return ResponseEntity.status(HttpStatus.OK).body(loginUser.getId());
     }
 }

--- a/src/main/java/gravit/code/test/qa/TestScenarioController.java
+++ b/src/main/java/gravit/code/test/qa/TestScenarioController.java
@@ -14,6 +14,7 @@ import gravit.code.user.domain.User;
 import gravit.code.user.repository.UserRepository;
 import lombok.RequiredArgsConstructor;
 import org.springframework.context.annotation.Profile;
+import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.RequestMapping;
@@ -66,7 +67,7 @@ public class TestScenarioController {
             submitLesson(userId, lesson.getId());
         }
 
-        return ResponseEntity.ok(userId);
+        return ResponseEntity.status(HttpStatus.OK).body(userId);
     }
 
     private void submitLesson(Long userId, Long lessonId) {
@@ -106,6 +107,6 @@ public class TestScenarioController {
 
         learningRepository.save(learning);
 
-        return ResponseEntity.ok(user.getId());
+        return ResponseEntity.status(HttpStatus.OK).body(user.getId());
     }
 }

--- a/src/main/java/gravit/code/test/season/SeasonCleanController.java
+++ b/src/main/java/gravit/code/test/season/SeasonCleanController.java
@@ -6,6 +6,7 @@ import jakarta.persistence.PersistenceContext;
 import lombok.RequiredArgsConstructor;
 import org.springframework.context.annotation.Profile;
 import org.springframework.data.redis.core.RedisTemplate;
+import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
 import org.springframework.transaction.annotation.Transactional;
 import org.springframework.web.bind.annotation.PostMapping;
@@ -50,7 +51,7 @@ public class SeasonCleanController {
 
         userLeagueHistoryRepository.deleteAll();
 
-        return ResponseEntity.ok().build();
+        return ResponseEntity.status(HttpStatus.OK).build();
     }
 
     private void cleanSeasonRelatedCache() {

--- a/src/main/java/gravit/code/test/user/UserCheatCreateController.java
+++ b/src/main/java/gravit/code/test/user/UserCheatCreateController.java
@@ -72,7 +72,7 @@ public class UserCheatCreateController {
         AccessToken accessToken = authTokenProvider.generateAccessToken(user);
         RefreshToken refreshToken = authTokenProvider.generateRefreshToken(user);
 
-        return ResponseEntity.ok().body(LoginResponse.of(accessToken,refreshToken,true, user.getRole()));
+        return ResponseEntity.status(HttpStatus.OK).body(LoginResponse.of(accessToken,refreshToken,true, user.getRole()));
     }
 
     // cheat 전용 검증이라 운영 카탈로그(CustomErrorCode)를 오염시키지 않도록 ResponseStatusException으로 400을 던진다.
@@ -117,7 +117,7 @@ public class UserCheatCreateController {
         AccessToken accessToken = authTokenProvider.generateAccessToken(user);
         RefreshToken refreshToken = authTokenProvider.generateRefreshToken(user);
 
-        return ResponseEntity.ok().body(LoginResponse.of(accessToken,refreshToken,true, user.getRole()));
+        return ResponseEntity.status(HttpStatus.OK).body(LoginResponse.of(accessToken,refreshToken,true, user.getRole()));
     }
 
     @PostMapping("/tokens/custom")
@@ -127,7 +127,7 @@ public class UserCheatCreateController {
     ){
         User user = authTokenProvider.parseUser(accessToken);
         AccessToken newAccessToken = createNewCustomAccessToken(user, newExpirationMinutes);
-        return ResponseEntity.ok().body(LoginResponse.of(newAccessToken,new RefreshToken("refresh"),true, user.getRole()));
+        return ResponseEntity.status(HttpStatus.OK).body(LoginResponse.of(newAccessToken,new RefreshToken("refresh"),true, user.getRole()));
     }
 
     private AccessToken createNewCustomAccessToken(User user, Long newExpirationMinutes) {
@@ -160,7 +160,7 @@ public class UserCheatCreateController {
         for (long i = 11; i <= 19; i++) {
             follow(i, 1L);
         }
-        return ResponseEntity.ok().build();
+        return ResponseEntity.status(HttpStatus.OK).build();
     }
 
     @PostMapping("/events/notice-created")
@@ -169,7 +169,7 @@ public class UserCheatCreateController {
             @RequestParam String title
     ) {
         publisher.publishEvent(new NoticeCreatedEvent(noticeId, title));
-        return ResponseEntity.ok().build();
+        return ResponseEntity.status(HttpStatus.OK).build();
     }
 
     @PostMapping("/events/season-rolled-over")
@@ -177,7 +177,7 @@ public class UserCheatCreateController {
             @RequestParam String newSeasonKey
     ) {
         publisher.publishEvent(new SeasonRolledOverEvent(newSeasonKey));
-        return ResponseEntity.ok().build();
+        return ResponseEntity.status(HttpStatus.OK).build();
     }
 
     private void follow(long followerId, long followeeId) {

--- a/src/main/java/gravit/code/test/user/UserDataCleanController.java
+++ b/src/main/java/gravit/code/test/user/UserDataCleanController.java
@@ -4,6 +4,7 @@ import jakarta.persistence.EntityManager;
 import jakarta.persistence.PersistenceContext;
 import lombok.RequiredArgsConstructor;
 import org.springframework.context.annotation.Profile;
+import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
 import org.springframework.transaction.annotation.Transactional;
 import org.springframework.web.bind.annotation.PostMapping;
@@ -33,7 +34,7 @@ public class UserDataCleanController {
                 .getResultList();
 
         if(userIds.isEmpty()){
-            return ResponseEntity.notFound().build();
+            return ResponseEntity.status(HttpStatus.NOT_FOUND).build();
         }
 
         // 각 userId에 대해 삭제 실행
@@ -43,7 +44,7 @@ public class UserDataCleanController {
             deletedCount++;
         }
 
-        return ResponseEntity.ok(deletedCount + " user(s) deleted");
+        return ResponseEntity.status(HttpStatus.OK).body(deletedCount + " user(s) deleted");
     }
 
     private void deleteUserData(Long userId) {

--- a/src/main/java/gravit/code/unit/service/UnitQueryService.java
+++ b/src/main/java/gravit/code/unit/service/UnitQueryService.java
@@ -1,5 +1,6 @@
 package gravit.code.unit.service;
 
+import gravit.code.global.consts.TimeZoneConst;
 import gravit.code.global.exception.domain.CustomErrorCode;
 import gravit.code.global.exception.domain.RestApiException;
 import gravit.code.unit.dto.internal.UnitProgressRowDto;
@@ -13,15 +14,12 @@ import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
 import java.time.LocalDate;
-import java.time.ZoneId;
 import java.util.List;
 
 @Service
 @RequiredArgsConstructor
 @Transactional(readOnly = true)
 public class UnitQueryService {
-
-    private static final ZoneId KST = ZoneId.of("Asia/Seoul");
 
     private final UnitRepository unitRepository;
 
@@ -56,7 +54,7 @@ public class UnitQueryService {
             throw new RestApiException(CustomErrorCode.UNIT_NOT_FOUND);
         }
 
-        long seed = userId * 31L + LocalDate.now(KST).toEpochDay();
+        long seed = userId * 31L + LocalDate.now(TimeZoneConst.KST).toEpochDay();
 
         int[] indexes = RandomUnitIdGenerator.pickTwoDistinctIndexes(seed, allUnitIds.size());
 

--- a/src/main/java/gravit/code/user/controller/MainPageController.java
+++ b/src/main/java/gravit/code/user/controller/MainPageController.java
@@ -15,6 +15,7 @@ import gravit.code.user.dto.response.ProfileSummaryResponse;
 import gravit.code.user.facade.UserFacade;
 import gravit.code.userLeague.service.UserLeagueService;
 import lombok.RequiredArgsConstructor;
+import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
 import org.springframework.security.core.annotation.AuthenticationPrincipal;
 import org.springframework.web.bind.annotation.GetMapping;
@@ -37,31 +38,31 @@ public class MainPageController implements MainPageControllerDocs {
 
     @GetMapping("/profile")
     public ResponseEntity<ProfileSummaryResponse> getProfile(@AuthenticationPrincipal LoginUser loginUser) {
-        return ResponseEntity.ok(userFacade.getProfileSummary(loginUser.getId()));
+        return ResponseEntity.status(HttpStatus.OK).body(userFacade.getProfileSummary(loginUser.getId()));
     }
 
     @GetMapping("/league")
     public ResponseEntity<LeagueDetailResponse> getLeague(@AuthenticationPrincipal LoginUser loginUser) {
-        return ResponseEntity.ok(userLeagueService.getUserLeagueDetail(loginUser.getId()));
+        return ResponseEntity.status(HttpStatus.OK).body(userLeagueService.getUserLeagueDetail(loginUser.getId()));
     }
 
     @GetMapping("/learning")
     public ResponseEntity<LearningDetailResponse> getLearning(@AuthenticationPrincipal LoginUser loginUser) {
-        return ResponseEntity.ok(learningFacade.getLearningDetail(loginUser.getId()));
+        return ResponseEntity.status(HttpStatus.OK).body(learningFacade.getLearningDetail(loginUser.getId()));
     }
 
     @GetMapping("/units")
     public ResponseEntity<List<RecommendedUnitResponse>> getUnits(@AuthenticationPrincipal LoginUser loginUser) {
-        return ResponseEntity.ok(unitQueryService.getRecommendedUnits(loginUser.getId()));
+        return ResponseEntity.status(HttpStatus.OK).body(unitQueryService.getRecommendedUnits(loginUser.getId()));
     }
 
     @GetMapping("/weekly-record")
     public ResponseEntity<WeeklyLearningRecordResponse> getWeeklyRecord(@AuthenticationPrincipal LoginUser loginUser) {
-        return ResponseEntity.ok(dailyLearningRecordService.getWeeklyLearningRecord(loginUser.getId()));
+        return ResponseEntity.status(HttpStatus.OK).body(dailyLearningRecordService.getWeeklyLearningRecord(loginUser.getId()));
     }
 
     @GetMapping("/mission")
     public ResponseEntity<MissionDetailResponse> getMission(@AuthenticationPrincipal LoginUser loginUser) {
-        return ResponseEntity.ok(missionService.getMissionDetail(loginUser.getId()));
+        return ResponseEntity.status(HttpStatus.OK).body(missionService.getMissionDetail(loginUser.getId()));
     }
 }

--- a/src/main/java/gravit/code/user/controller/MyPageController.java
+++ b/src/main/java/gravit/code/user/controller/MyPageController.java
@@ -11,6 +11,7 @@ import gravit.code.user.facade.UserFacade;
 import jakarta.validation.constraints.Max;
 import jakarta.validation.constraints.Min;
 import lombok.RequiredArgsConstructor;
+import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
 import org.springframework.security.core.annotation.AuthenticationPrincipal;
 import org.springframework.validation.annotation.Validated;
@@ -30,17 +31,17 @@ public class MyPageController implements MyPageControllerDocs {
 
     @GetMapping("/banners")
     public ResponseEntity<MyPageBannerResponse> getMyPageBanner(@AuthenticationPrincipal LoginUser loginUser) {
-        return ResponseEntity.ok(userFacade.getMyPageBanner(loginUser.getId()));
+        return ResponseEntity.status(HttpStatus.OK).body(userFacade.getMyPageBanner(loginUser.getId()));
     }
 
     @GetMapping("/summaries")
     public ResponseEntity<MyPageSummaryResponse> getMyPageSummary(@AuthenticationPrincipal LoginUser loginUser){
-        return ResponseEntity.ok(learningFacade.getMyPageSummary(loginUser.getId()));
+        return ResponseEntity.status(HttpStatus.OK).body(learningFacade.getMyPageSummary(loginUser.getId()));
     }
 
     @GetMapping("/learning")
     public ResponseEntity<MyPageLearningResponse> getMyPageLearning(@AuthenticationPrincipal LoginUser loginUser){
-        return ResponseEntity.ok(learningFacade.getMyPageLearning(loginUser.getId()));
+        return ResponseEntity.status(HttpStatus.OK).body(learningFacade.getMyPageLearning(loginUser.getId()));
     }
 
     @GetMapping("/learning/history")
@@ -48,6 +49,6 @@ public class MyPageController implements MyPageControllerDocs {
             @AuthenticationPrincipal LoginUser loginUser,
             @RequestParam("year") @Min(2025) @Max(2099)int year
     ){
-        return ResponseEntity.ok(learningFacade.getMyPageLearningHistory(loginUser.getId(), year));
+        return ResponseEntity.status(HttpStatus.OK).body(learningFacade.getMyPageLearningHistory(loginUser.getId(), year));
     }
 }

--- a/src/main/java/gravit/code/user/controller/UserController.java
+++ b/src/main/java/gravit/code/user/controller/UserController.java
@@ -35,7 +35,7 @@ public class UserController implements UserControllerDocs {
     @GetMapping
     public ResponseEntity<UserResponse> getUser(@AuthenticationPrincipal LoginUser loginUser) {
         UserResponse userResponse = userService.findById(loginUser.getId());
-        return ResponseEntity.ok(userResponse);
+        return ResponseEntity.status(HttpStatus.OK).body(userResponse);
     }
 
     @PostMapping("/onboarding")
@@ -44,7 +44,7 @@ public class UserController implements UserControllerDocs {
             @Valid @RequestBody OnboardingRequest request
     ) {
         UserResponse userResponse = userService.onboarding(loginUser.getId(), request);
-        return ResponseEntity.ok(userResponse);
+        return ResponseEntity.status(HttpStatus.OK).body(userResponse);
     }
 
     @PatchMapping
@@ -53,19 +53,19 @@ public class UserController implements UserControllerDocs {
             @Valid @RequestBody UserProfileUpdateRequest request
     ) {
         UserResponse userResponse = userService.updateUserProfile(loginUser.getId(), request);
-        return ResponseEntity.ok(userResponse);
+        return ResponseEntity.status(HttpStatus.OK).body(userResponse);
     }
 
     @GetMapping("/my-page")
     public ResponseEntity<MyPageResponse> getMyPage(@AuthenticationPrincipal LoginUser loginUser) {
         MyPageResponse myPageResponse = userService.getMyPage(loginUser.getId());
-        return ResponseEntity.ok(myPageResponse);
+        return ResponseEntity.status(HttpStatus.OK).body(myPageResponse);
     }
 
     @PatchMapping("/restore")
     public ResponseEntity<Void> restoreUser(@RequestParam("providerId") String providerId) {
         userService.restoreUser(providerId);
-        return ResponseEntity.ok().build();
+        return ResponseEntity.status(HttpStatus.OK).build();
     }
 
     @Deprecated(forRemoval = true)

--- a/src/main/java/gravit/code/user/controller/UserDeletionController.java
+++ b/src/main/java/gravit/code/user/controller/UserDeletionController.java
@@ -4,6 +4,7 @@ import gravit.code.auth.domain.LoginUser;
 import gravit.code.user.controller.docs.UserDeletionControllerDocs;
 import gravit.code.user.service.UserDeletionService;
 import lombok.RequiredArgsConstructor;
+import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
 import org.springframework.security.core.annotation.AuthenticationPrincipal;
 import org.springframework.web.bind.annotation.PostMapping;
@@ -25,12 +26,12 @@ public class UserDeletionController implements UserDeletionControllerDocs {
     ){
         Long userId = loginUser.getId();
         userDeleteWithMailService.requestDeleteMailWithMailAuthCode(userId, dest);
-        return ResponseEntity.accepted().build();
+        return ResponseEntity.status(HttpStatus.ACCEPTED).build();
     }
 
     @PostMapping("/confirm")
     public ResponseEntity<Void> confirm(@RequestParam String mailAuthCode){
         userDeleteWithMailService.confirmDeleteByMailAuthCode(mailAuthCode);
-        return ResponseEntity.ok().build();
+        return ResponseEntity.status(HttpStatus.OK).build();
     }
 }

--- a/src/main/java/gravit/code/user/domain/User.java
+++ b/src/main/java/gravit/code/user/domain/User.java
@@ -82,7 +82,7 @@ public class User extends BaseEntity {
         this.nickname = nickname;
         this.handle = handle;
         this.profileImgNumber = profileImgNumber;
-        this.level = new UserLevel(1, 0);
+        this.level = UserLevel.create(1, 0);
         this.role = role;
         this.deletedAt = null;
         this.isOnboarded = false;

--- a/src/main/java/gravit/code/user/domain/User.java
+++ b/src/main/java/gravit/code/user/domain/User.java
@@ -68,7 +68,7 @@ public class User extends BaseEntity {
     @Column(name = "last_accessed_at")
     private LocalDateTime lastAccessedAt;
 
-    @Builder
+    @Builder(access = AccessLevel.PRIVATE)
     private User(
             String email,
             String providerId,

--- a/src/main/java/gravit/code/user/domain/UserLevel.java
+++ b/src/main/java/gravit/code/user/domain/UserLevel.java
@@ -3,11 +3,13 @@ package gravit.code.user.domain;
 import gravit.code.user.dto.response.UserLevelDetailResponse;
 import jakarta.persistence.Column;
 import jakarta.persistence.Embeddable;
+import lombok.AccessLevel;
+import lombok.Builder;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
 
 @Embeddable
-@NoArgsConstructor
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
 @Getter
 public class UserLevel {
 
@@ -17,12 +19,23 @@ public class UserLevel {
     @Column(name = "xp", nullable = false)
     private int xp;
 
-    public UserLevel(
+    @Builder(access = AccessLevel.PRIVATE)
+    private UserLevel(
             int level,
             int xp
     ) {
         this.level = level;
         this.xp = xp;
+    }
+
+    public static UserLevel create(
+            int level,
+            int xp
+    ) {
+        return UserLevel.builder()
+                .level(level)
+                .xp(xp)
+                .build();
     }
 
     public void updateXp(int xp){

--- a/src/main/java/gravit/code/user/dto/response/UserLevelResponse.java
+++ b/src/main/java/gravit/code/user/dto/response/UserLevelResponse.java
@@ -1,9 +1,10 @@
 package gravit.code.user.dto.response;
 
 import io.swagger.v3.oas.annotations.media.Schema;
+import lombok.AccessLevel;
 import lombok.Builder;
 
-@Builder
+@Builder(access = AccessLevel.PRIVATE)
 @Schema(description = "유저 레벨 정보 Response(학습 종료 후)")
 public record UserLevelResponse(
         @Schema(

--- a/src/main/java/gravit/code/user/dto/response/UserResponse.java
+++ b/src/main/java/gravit/code/user/dto/response/UserResponse.java
@@ -2,9 +2,10 @@ package gravit.code.user.dto.response;
 
 import gravit.code.user.domain.User;
 import io.swagger.v3.oas.annotations.media.Schema;
+import lombok.AccessLevel;
 import lombok.Builder;
 
-@Builder
+@Builder(access = AccessLevel.PRIVATE)
 public record UserResponse(
         @Schema(requiredMode = Schema.RequiredMode.REQUIRED)
         long userId,

--- a/src/main/java/gravit/code/userLeague/controller/UserLeagueController.java
+++ b/src/main/java/gravit/code/userLeague/controller/UserLeagueController.java
@@ -8,6 +8,7 @@ import gravit.code.userLeague.dto.response.MyLeagueRankWithProfileResponse;
 import gravit.code.userLeague.service.UserLeagueQueryService;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
+import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
 import org.springframework.security.core.annotation.AuthenticationPrincipal;
 import org.springframework.web.bind.annotation.GetMapping;
@@ -28,7 +29,7 @@ public class UserLeagueController implements UserLeagueControllerDocs {
         Long userId = loginUser.getId();
         MyLeagueRankWithProfileResponse myLeagueRankWithProfile = userLeagueQueryService.getMyLeagueRankWithProfile(userId);
 
-        return ResponseEntity.ok(myLeagueRankWithProfile);
+        return ResponseEntity.status(HttpStatus.OK).body(myLeagueRankWithProfile);
     }
 
     @GetMapping("/leagues/{leagueId}/page/{pageNum}")
@@ -37,7 +38,7 @@ public class UserLeagueController implements UserLeagueControllerDocs {
             @PathVariable("pageNum") int pageNum
     ){
         SliceResponse<LeagueRankRowDto> sliceResponse = userLeagueQueryService.findLeagueRanking(leagueId, pageNum);
-        return ResponseEntity.ok(sliceResponse);
+        return ResponseEntity.status(HttpStatus.OK).body(sliceResponse);
     }
 
     @GetMapping("/user-leagues/page/{pageNum}")
@@ -47,6 +48,6 @@ public class UserLeagueController implements UserLeagueControllerDocs {
     ){
         Long userId = loginUser.getId();
         SliceResponse<LeagueRankRowDto> sliceResponse = userLeagueQueryService.findLeagueRankingByUser(userId, pageNum);
-        return ResponseEntity.ok(sliceResponse);
+        return ResponseEntity.status(HttpStatus.OK).body(sliceResponse);
     }
 }

--- a/src/main/java/gravit/code/userLeague/domain/UserLeague.java
+++ b/src/main/java/gravit/code/userLeague/domain/UserLeague.java
@@ -48,7 +48,7 @@ public class UserLeague extends BaseEntity {
     @Column(name = "league_point", columnDefinition = "integer", nullable = false)
     private int lp;
 
-    @Builder
+    @Builder(access = AccessLevel.PRIVATE)
     private UserLeague(
             User user,
             Season season,

--- a/src/main/java/gravit/code/userLeagueHistory/controller/LeagueHistoryController.java
+++ b/src/main/java/gravit/code/userLeagueHistory/controller/LeagueHistoryController.java
@@ -5,6 +5,7 @@ import gravit.code.league.dto.response.LeagueHistoryResponse;
 import gravit.code.userLeagueHistory.controller.docs.LeagueHistoryControllerDocs;
 import gravit.code.userLeagueHistory.service.LeagueHistoryService;
 import lombok.RequiredArgsConstructor;
+import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
 import org.springframework.security.core.annotation.AuthenticationPrincipal;
 import org.springframework.web.bind.annotation.GetMapping;
@@ -21,11 +22,11 @@ public class LeagueHistoryController implements LeagueHistoryControllerDocs {
 
     @GetMapping("/me")
     public ResponseEntity<LeagueHistoryResponse> getMyLeagueHistory(@AuthenticationPrincipal LoginUser loginUser) {
-        return ResponseEntity.ok(leagueHistoryService.getMyLeagueHistory(loginUser.getId()));
+        return ResponseEntity.status(HttpStatus.OK).body(leagueHistoryService.getMyLeagueHistory(loginUser.getId()));
     }
 
     @GetMapping("/{userId}")
     public ResponseEntity<LeagueHistoryResponse> getUserLeagueHistory(@PathVariable long userId) {
-        return ResponseEntity.ok(leagueHistoryService.getUserLeagueHistory(userId));
+        return ResponseEntity.status(HttpStatus.OK).body(leagueHistoryService.getUserLeagueHistory(userId));
     }
 }

--- a/src/main/java/gravit/code/userLeagueHistory/domain/UserLeagueHistory.java
+++ b/src/main/java/gravit/code/userLeagueHistory/domain/UserLeagueHistory.java
@@ -49,7 +49,7 @@ public class UserLeagueHistory extends BaseEntity {
     @Column(name = "final_lp", nullable = false)
     private int finalLp;
 
-    @Builder
+    @Builder(access = AccessLevel.PRIVATE)
     private UserLeagueHistory(
             Season season,
             User user,

--- a/src/main/java/gravit/code/wrongAnsweredNote/controller/WrongAnsweredNoteController.java
+++ b/src/main/java/gravit/code/wrongAnsweredNote/controller/WrongAnsweredNoteController.java
@@ -39,6 +39,6 @@ public class WrongAnsweredNoteController implements WrongAnsweredNoteControllerD
             @Valid @RequestBody WrongAnsweredNoteDeleteRequest request
     ){
         wrongAnsweredNoteService.deleteWrongAnsweredProblem(loginUser.getId(), request.problemId());
-        return ResponseEntity.noContent().build();
+        return ResponseEntity.status(HttpStatus.NO_CONTENT).build();
     }
 }

--- a/src/test/java/gravit/code/admin/service/AdminDashboardServiceIntegrationTest.java
+++ b/src/test/java/gravit/code/admin/service/AdminDashboardServiceIntegrationTest.java
@@ -41,12 +41,7 @@ class AdminDashboardServiceIntegrationTest {
             long problemId,
             boolean resolved
     ) {
-        Report report = Report.builder()
-                .reportType(type)
-                .content("내용")
-                .problemId(problemId)
-                .userId(100L)
-                .build();
+        Report report = Report.of(type, "내용", problemId, 100L);
         if (resolved) {
             report.changeResolved(true);
         }

--- a/src/test/java/gravit/code/admin/service/AdminReportServiceIntegrationTest.java
+++ b/src/test/java/gravit/code/admin/service/AdminReportServiceIntegrationTest.java
@@ -30,12 +30,7 @@ class AdminReportServiceIntegrationTest {
             long problemId,
             boolean resolved
     ) {
-        Report report = Report.builder()
-                .reportType(type)
-                .content("신고 내용")
-                .problemId(problemId)
-                .userId(100L)
-                .build();
+        Report report = Report.of(type, "신고 내용", problemId, 100L);
         if (resolved) {
             report.changeResolved(true);
         }

--- a/src/test/java/gravit/code/report/fixture/ReportFixture.java
+++ b/src/test/java/gravit/code/report/fixture/ReportFixture.java
@@ -10,12 +10,7 @@ public class ReportFixture {
             long problemId,
             long userId
     ) {
-        Report report = Report.builder()
-                .reportType(ReportType.CONTENT_ERROR)
-                .content("문제 내용이 잘못되었습니다.")
-                .problemId(problemId)
-                .userId(userId)
-                .build();
+        Report report = Report.of(ReportType.CONTENT_ERROR, "문제 내용이 잘못되었습니다.", problemId, userId);
         ReflectionTestUtils.setField(report, "id", 1L);
         return report;
     }
@@ -26,12 +21,7 @@ public class ReportFixture {
             long problemId,
             long userId
     ) {
-        Report report = Report.builder()
-                .reportType(reportType)
-                .content("신고 내용" + id)
-                .problemId(problemId)
-                .userId(userId)
-                .build();
+        Report report = Report.of(reportType, "신고 내용" + id, problemId, userId);
         ReflectionTestUtils.setField(report, "id", id);
         return report;
     }


### PR DESCRIPTION
### 1. 연관 이슈

---
 - close #419

<br>

### 2. 구현 사항

---
`.claude/rules/code-convention/`에 문서화된 규칙과 실제 코드 사이의 괴리를 카테고리별로 교정했다. 신규 기능이 아닌 기존 코드의 전수 교정이라 API 스펙(응답 상태·바디)은 그대로 유지된다.

**구현 사항 1 — Entity 생성자·시간대 상수 정리**
- 수정: `Bookmark`의 `@RequiredArgsConstructor` → `@NoArgsConstructor`로 표기 표준화 (final 필드가 없어 동작 변화 없음)
- 수정: 파일마다 흩어져 있던 로컬 `ZoneId` 상수(`SEOUL`, `KST` 등)와 `ZoneId.of("Asia/Seoul")` 인라인 호출 14곳을 `global/consts/TimeZoneConst.KST`로 통일

**구현 사항 2 — 포맷·응답 표기 정리**
- 수정: bookmark 도메인 3개 파일의 이중 공백, 중괄호 앞 공백 누락(`){` → `) {`), `@Valid@RequestBody` 공백 누락 정리
- 수정: 컨트롤러 34개·93개 호출부의 `ResponseEntity.ok()/noContent()/badRequest()/notFound()/accepted()/internalServerError()` 축약형을 `ResponseEntity.status(HttpStatus.XXX)` 형식으로 통일 (상태 코드·바디 불변)

**구현 사항 3 — DTO record 전환**
- 수정: Swagger 전용 stub 5종(`FollowerSliceResponse` 등)과 OAuth `UserInfo` 구현체 6종(`KakaoUserInfo` 등)을 class → record로 전환. 생성자 시그니처가 유지되어 호출부 변경 없음

**구현 사항 4 — Builder 접근 제어**
- 수정: 외부에서 직접 `.builder()`를 호출하지 않는 16개 Entity·Response DTO에 `@Builder(access = AccessLevel.PRIVATE)` 적용
- 수정: `ErrorResponse`·`Report`는 외부(프로덕션 5곳/테스트 4곳)에서 빌더를 직접 호출하고 있어 정적 팩토리(`of()`)를 추가한 뒤 호출부를 교체하고 private화. Report는 "테스트 코드 수정 제외" 원칙의 승인된 예외로 테스트 3개 파일도 함께 수정

**구현 사항 5 — 예외 처리·어노테이션 정리**
- 수정: `Season.validateStatus()`가 던지던 `RuntimeException`(HTTP 500)을 `CustomErrorCode.INVALID_SEASON_STATUS_TRANSITION`(HTTP 409) 기반 `RestApiException`으로 교체해 구조화된 에러 응답을 반환하도록 변경 — 유일하게 API 에러 응답 계약이 바뀌는 지점
- 수정: `AuthTokenProvider`의 `@Component` → `@Service`로 스테레오타입 교정
- 수정: `UserLevel`의 public 생성자를 private + `@Builder(access = AccessLevel.PRIVATE)` + `create()` 정적 팩토리로 전환, 유일한 호출부(`User.java`) 교체

`compileJava`/`compileTestJava` 통과 확인 완료.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * API 응답 상태 표기가 전반적으로 통일되어, 성공/빈 응답/오류 응답이 더 일관되게 반환됩니다.
  * 일부 오류 응답 생성 방식이 정리되어, 예외 처리 결과가 더 안정적으로 구성됩니다.
  * 시간 관련 데이터 기준이 하나의 공통 시간대로 맞춰져, 생성/표시 시각의 일관성이 개선되었습니다.
  * 시즌 상태 전이 관련 검증 오류가 추가되어, 잘못된 상태 변경을 더 명확하게 처리합니다.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->