### PR TITLE
chore: Claude Code 훅 안전장치·알림 개선(#424)

### DIFF
--- a/.claude/hooks/block-dangerous-commands.sh
+++ b/.claude/hooks/block-dangerous-commands.sh
@@ -1,33 +1,79 @@
 #!/bin/bash
-# PreToolUse hook: 위험한 Bash 명령 차단
+# PreToolUse hook: 위험한 Bash 명령 차단/확인 요청
 # settings.json의 deny와 중복되는 패턴은 제외 (deny가 먼저 차단하므로)
-# 이 hook은 deny에서 커버하지 못하는 추가 패턴을 차단한다
-# exit 0 = 허용, exit 2 = 차단
+# 이 hook은 deny에서 커버하지 못하는 추가 패턴을 처리한다.
+#
+# 두 단계로 나뉜다:
+#   DENY : 되돌릴 수 없이 파괴적인 명령 -> stderr 사유 + exit 2 (즉시 차단)
+#   ASK  : 맥락상 위험하지만 정당한 사용도 있는 명령 -> JSON permissionDecision:"ask" (사용자 확인)
+# exit 0(사유 없음) = 허용
+
+command -v jq >/dev/null 2>&1 || { echo "차단됨: jq가 없어 안전 검사를 수행할 수 없습니다." >&2; exit 2; }
 
 INPUT=$(cat)
 COMMAND=$(echo "$INPUT" | jq -r '.tool_input.command // empty')
 
-if [ -z "$COMMAND" ]; then
+[ -z "$COMMAND" ] && exit 0
+
+deny() {
+  echo "차단됨: $1" >&2
+  exit 2
+}
+
+ask() {
+  jq -n --arg reason "$1" \
+    '{hookSpecificOutput: {hookEventName: "PreToolUse", permissionDecision: "ask", permissionDecisionReason: $reason}}'
   exit 0
+}
+
+# 공백을 정규화해 "DROP   DATABASE" 같은 다중 공백 우회를 방지
+NORM=$(printf '%s' "$COMMAND" | tr '[:upper:]' '[:lower:]' | tr -s '[:space:]' ' ')
+
+# ── DENY: 무조건 파괴적인 명령 ──────────────────────────────
+
+echo "$NORM" | grep -qF ':(){ :|:& };:' && deny "포크밤으로 의심되는 명령입니다."
+
+echo "$NORM" | grep -qE '(>|of=) *\/dev\/(sd[a-z]|nvme|r?disk)' \
+  && deny "디스크 디바이스에 직접 쓰는 명령입니다."
+
+echo "$NORM" | grep -qE 'mkfs(\.| )' && deny "파일시스템을 새로 생성(mkfs)하는 명령입니다."
+
+echo "$NORM" | grep -qE 'rm +-[a-z]*r[a-z]* +(-[a-z]+ +)*(/|~/?|\$home/?)(\*|[[:space:]]|$)' \
+  && deny "루트/홈 디렉터리를 재귀 삭제하는 것으로 의심되는 명령입니다."
+
+# ── ASK: 맥락상 위험 — 사용자 확인 필요 ──────────────────────
+
+if echo "$NORM" | grep -qE '(psql|mysql|mariadb|docker exec)'; then
+  echo "$NORM" | grep -qE 'drop +(database|table|schema)|truncate table' \
+    && ask "DB 클라이언트 컨텍스트에서 DDL 파괴 명령(DROP/TRUNCATE)이 감지되었습니다."
 fi
 
-BLOCKED_PATTERNS=(
-  "drop database"
-  "drop table"
-  "truncate table"
-  "chmod -R 777"
-  "> /dev/sda"
-  "mkfs\."
-  ":(){ :|:& };:"
-)
+if echo "$NORM" | grep -q 'chmod' && echo "$NORM" | grep -q '777'; then
+  ask "권한을 777로 변경하는 명령입니다."
+fi
 
-COMMAND_LOWER=$(echo "$COMMAND" | tr '[:upper:]' '[:lower:]')
+echo "$NORM" | grep -qE 'rm +-[a-z]*r[a-z]*( |$)|rm +--recursive' \
+  && ask "재귀 삭제(rm -r 계열) 명령입니다. 대상 경로를 확인하세요."
 
-for pattern in "${BLOCKED_PATTERNS[@]}"; do
-  if echo "$COMMAND_LOWER" | grep -qE "$pattern"; then
-    echo "차단됨: '$pattern' 패턴에 매칭되는 위험한 명령입니다." >&2
-    exit 2
-  fi
-done
+echo "$NORM" | grep -qE 'find .*-delete|xargs .*rm' \
+  && ask "find/xargs를 통한 일괄 삭제 명령입니다."
+
+echo "$NORM" | grep -qE 'git push .*[[:space:]]\+[a-z0-9]' \
+  && ask "refspec force-push(+) 패턴이 감지되었습니다."
+
+echo "$NORM" | grep -qE 'git clean' \
+  && ask "git clean은 추적되지 않는 파일/디렉터리를 삭제합니다."
+
+echo "$NORM" | grep -qE 'flyway ?(clean|repair)' \
+  && ask "Flyway 파괴적 태스크(clean/repair)가 감지되었습니다."
+
+if echo "$NORM" | grep -q 'db/migration'; then
+  echo "$NORM" | grep -qE 'sed -i|mv |rm |cp |tee |>>|>' \
+    && ask "적용된 마이그레이션은 불변입니다 — 새 버전 파일로 추가하세요."
+fi
+
+echo "$COMMAND" | grep -qE '\.claude/(hooks|settings)' \
+  && echo "$COMMAND" | grep -qE 'sed -i|tee|>>|>|mv |rm |chmod ' \
+  && ask ".claude 훅/설정 파일을 변경하는 명령입니다. 사용자 승인이 필요합니다."
 
 exit 0

--- a/.claude/hooks/notify-permission.sh
+++ b/.claude/hooks/notify-permission.sh
@@ -1,17 +1,14 @@
 #!/bin/bash
-# Notification(permission_prompt) hook: 권한 승인 요청 알림
+# Notification(permission_prompt|idle_prompt) hook: 권한 승인·입력 대기 알림
+# stdin의 .message를 60자로 잘라 전달해 어떤 도구가 왜 멈췄는지 알 수 있게 한다.
 
-MSG="권한 승인이 필요합니다."
-TITLE="Claude Code"
+DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
 
-OS=$(uname -s)
-if [ "$OS" = "Darwin" ]; then
-  osascript -e "display notification \"$MSG\" with title \"$TITLE\"" 2>/dev/null
-elif grep -qi microsoft /proc/version 2>/dev/null; then
-  powershell.exe -Command "[void](New-BurntToastNotification -Text '$TITLE','$MSG')" 2>/dev/null \
-    || powershell.exe -Command "Add-Type -AssemblyName System.Windows.Forms; [System.Windows.Forms.MessageBox]::Show('$MSG','$TITLE')" 2>/dev/null
-else
-  notify-send "$TITLE" "$MSG" 2>/dev/null
-fi
+INPUT=$(cat)
+MSG=$(echo "$INPUT" | jq -r '(.message // "권한 승인이 필요합니다.")
+  | gsub("\\s+"; " ")
+  | if length > 60 then .[:60] + "…" else . end')
+
+"$DIR/notify.sh" "Claude Code" "$MSG"
 
 exit 0

--- a/.claude/hooks/notify-stop.sh
+++ b/.claude/hooks/notify-stop.sh
@@ -1,17 +1,21 @@
 #!/bin/bash
 # Stop hook: 작업 완료 알림
+# transcript의 마지막 assistant 응답을 60자로 요약해 전달한다.
 
-MSG="작업이 완료되었습니다."
-TITLE="Claude Code"
+DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
 
-OS=$(uname -s)
-if [ "$OS" = "Darwin" ]; then
-  osascript -e "display notification \"$MSG\" with title \"$TITLE\"" 2>/dev/null
-elif grep -qi microsoft /proc/version 2>/dev/null; then
-  powershell.exe -Command "[void](New-BurntToastNotification -Text '$TITLE','$MSG')" 2>/dev/null \
-    || powershell.exe -Command "Add-Type -AssemblyName System.Windows.Forms; [System.Windows.Forms.MessageBox]::Show('$MSG','$TITLE')" 2>/dev/null
-else
-  notify-send "$TITLE" "$MSG" 2>/dev/null
+INPUT=$(cat)
+TRANSCRIPT=$(echo "$INPUT" | jq -r '.transcript_path // empty')
+
+# 마지막 assistant 텍스트 블록 전체를 집계한 뒤 공백을 접고 60자에서 자른다.
+# (jq는 UTF-8 코드포인트 단위로 세므로 한글이 중간에서 깨지지 않는다)
+SUMMARY=""
+if [ -n "$TRANSCRIPT" ] && [ -f "$TRANSCRIPT" ]; then
+  SUMMARY=$(jq -r -s '[.[] | select(.type=="assistant") | .message.content[]? | select(.type=="text") | .text] | last // ""
+    | gsub("\\s+"; " ")
+    | if length > 60 then .[:60] + "…" else . end' "$TRANSCRIPT" 2>/dev/null)
 fi
+
+"$DIR/notify.sh" "Claude Code" "${SUMMARY:-작업이 완료되었습니다.}"
 
 exit 0

--- a/.claude/hooks/notify.sh
+++ b/.claude/hooks/notify.sh
@@ -1,0 +1,36 @@
+#!/bin/bash
+# 공통 알림 발송: notify.sh <title> <message>
+# macOS: terminal-notifier가 있으면 사용 — 클릭 시 IDE 활성화(-activate),
+#        같은 그룹 알림은 치환(-group)되어 알림센터에 쌓이지 않는다.
+#        없으면 osascript 폴백 — argv 전달로 따옴표/특수문자 인젝션 방지.
+
+TITLE="${1:-Claude Code}"
+MSG="${2:-알림}"
+
+# 클릭 시 활성화할 앱 번들 ID (기본: IntelliJ IDEA)
+ACTIVATE_APP="${CLAUDE_NOTIFY_ACTIVATE:-com.jetbrains.intellij}"
+
+OS=$(uname -s)
+if [ "$OS" = "Darwin" ]; then
+  TN=$(command -v terminal-notifier)
+  [ -z "$TN" ] && [ -x /opt/homebrew/bin/terminal-notifier ] && TN=/opt/homebrew/bin/terminal-notifier
+  if [ -n "$TN" ]; then
+    "$TN" -title "$TITLE" -message "$MSG" -activate "$ACTIVATE_APP" \
+      -group claude-code -sound Glass >/dev/null 2>&1
+  else
+    osascript - "$TITLE" "$MSG" <<'EOF' 2>/dev/null
+on run argv
+  display notification (item 2 of argv) with title (item 1 of argv) sound name "Glass"
+end run
+EOF
+  fi
+elif grep -qi microsoft /proc/version 2>/dev/null; then
+  PS_TITLE=$(printf '%s' "$TITLE" | sed "s/'/''/g")
+  PS_MSG=$(printf '%s' "$MSG" | sed "s/'/''/g")
+  powershell.exe -Command "[void](New-BurntToastNotification -Text '$PS_TITLE','$PS_MSG')" 2>/dev/null \
+    || powershell.exe -Command "Add-Type -AssemblyName System.Windows.Forms; [System.Windows.Forms.MessageBox]::Show('$PS_MSG','$PS_TITLE')" 2>/dev/null
+else
+  notify-send "$TITLE" "$MSG" 2>/dev/null
+fi
+
+exit 0

--- a/.claude/hooks/protect-claude-config.sh
+++ b/.claude/hooks/protect-claude-config.sh
@@ -1,0 +1,20 @@
+#!/bin/bash
+# PreToolUse hook: 훅 스크립트·권한 설정 파일 자기보호
+# .claude/hooks/** 또는 .claude/settings(.local).json을 Edit/Write하려는 시도를
+# 사용자 확인으로 승격한다. 훅 스크립트는 매 호출마다 fresh 실행되므로,
+# 이 훅 자체가 없으면 세션 중 Edit 한 번으로 다른 모든 안전장치가 무력화될 수 있다.
+# exit 0 = 허용, JSON permissionDecision:"ask" = 사용자 확인
+
+command -v jq >/dev/null 2>&1 || { echo "차단됨: jq가 없어 안전 검사를 수행할 수 없습니다." >&2; exit 2; }
+
+INPUT=$(cat)
+FILE_PATH=$(echo "$INPUT" | jq -r '.tool_input.file_path // empty')
+
+[ -z "$FILE_PATH" ] && exit 0
+
+if echo "$FILE_PATH" | grep -qE '\.claude/hooks/|\.claude/settings(\.local)?\.json$'; then
+  jq -n '{hookSpecificOutput: {hookEventName: "PreToolUse", permissionDecision: "ask", permissionDecisionReason: "훅·권한 설정 변경은 사용자 승인이 필요합니다."}}'
+  exit 0
+fi
+
+exit 0

--- a/.claude/hooks/protect-migrations.sh
+++ b/.claude/hooks/protect-migrations.sh
@@ -21,6 +21,18 @@ deny() {
   exit 0
 }
 
+# CLAUDE_PROJECT_DIR가 비어있으면 REL 계산과 git -C 대상이 모두 어긋나
+# origin/main 대조가 실패한 뒤 그대로 통과(fail-open)할 수 있다. 보수적으로 차단한다.
+if [ -z "$CLAUDE_PROJECT_DIR" ]; then
+  if [ "$TOOL_NAME" = "Edit" ]; then
+    deny "CLAUDE_PROJECT_DIR가 비어있어 origin/main 기준을 확인할 수 없어 보수적으로 차단합니다."
+  fi
+  if [ "$TOOL_NAME" = "Write" ] && [ -f "$FILE_PATH" ]; then
+    deny "CLAUDE_PROJECT_DIR가 비어있어 origin/main 기준을 확인할 수 없어 보수적으로 차단합니다."
+  fi
+  exit 0
+fi
+
 REL="${FILE_PATH#"$CLAUDE_PROJECT_DIR"/}"
 
 if git -C "$CLAUDE_PROJECT_DIR" rev-parse --verify -q origin/main >/dev/null 2>&1; then

--- a/.claude/hooks/protect-migrations.sh
+++ b/.claude/hooks/protect-migrations.sh
@@ -1,31 +1,46 @@
 #!/bin/bash
 # PreToolUse hook: 기존 Flyway 마이그레이션 파일 수정 차단
-# 새 마이그레이션 파일 생성(Write)은 허용, 기존 파일 수정(Edit)은 차단
-# exit 0 = 허용, exit 2 = 차단
+# origin/main에 존재하는(배포됐을 수 있는) 마이그레이션만 불변으로 취급한다.
+# 이 브랜치에서 새로 만든 V파일은 자유롭게 Edit/Write 할 수 있다.
+# exit 0 = 허용, JSON permissionDecision:"deny" = 차단
+
+command -v jq >/dev/null 2>&1 || { echo "차단됨: jq가 없어 안전 검사를 수행할 수 없습니다." >&2; exit 2; }
 
 INPUT=$(cat)
 TOOL_NAME=$(echo "$INPUT" | jq -r '.tool_name // empty')
 FILE_PATH=$(echo "$INPUT" | jq -r '.tool_input.file_path // empty')
 
-if [ -z "$FILE_PATH" ]; then
-  exit 0
-fi
+[ -z "$FILE_PATH" ] && exit 0
 
 # 마이그레이션 파일이 아니면 허용
-if ! echo "$FILE_PATH" | grep -q "db/migration/V.*\.sql"; then
+echo "$FILE_PATH" | grep -qE 'db/migration/V[0-9]+__.*\.sql' || exit 0
+
+deny() {
+  jq -n --arg reason "$1" \
+    '{hookSpecificOutput: {hookEventName: "PreToolUse", permissionDecision: "deny", permissionDecisionReason: $reason}}'
+  exit 0
+}
+
+REL="${FILE_PATH#"$CLAUDE_PROJECT_DIR"/}"
+
+if git -C "$CLAUDE_PROJECT_DIR" rev-parse --verify -q origin/main >/dev/null 2>&1; then
+  if git -C "$CLAUDE_PROJECT_DIR" cat-file -e "origin/main:$REL" 2>/dev/null; then
+    if [ "$TOOL_NAME" = "Edit" ]; then
+      deny "이미 origin/main에 존재하는(배포되었을 수 있는) Flyway 마이그레이션은 수정할 수 없습니다. 새 버전 파일을 추가하세요."
+    fi
+    if [ "$TOOL_NAME" = "Write" ]; then
+      deny "이미 origin/main에 존재하는 Flyway 마이그레이션을 덮어쓸 수 없습니다. 새 버전 파일을 추가하세요."
+    fi
+  fi
   exit 0
 fi
 
-# Edit(수정)이면 차단, Write(새 파일 생성)이면 허용
+# origin/main 참조를 확인할 수 없을 때: 기존 방식대로 보수적으로 차단
 if [ "$TOOL_NAME" = "Edit" ]; then
-  echo "차단됨: 기존 Flyway 마이그레이션 파일은 수정할 수 없습니다. 새 버전 파일을 추가하세요." >&2
-  exit 2
+  deny "origin/main 기준을 확인할 수 없어 보수적으로 차단합니다. 기존 Flyway 마이그레이션은 수정할 수 없습니다."
 fi
-
-# Write인데 파일이 이미 존재하면 차단
 if [ "$TOOL_NAME" = "Write" ] && [ -f "$FILE_PATH" ]; then
-  echo "차단됨: 기존 Flyway 마이그레이션 파일을 덮어쓸 수 없습니다. 새 버전 파일을 추가하세요." >&2
-  exit 2
+  deny "origin/main 기준을 확인할 수 없어 보수적으로 차단합니다. 기존 파일을 덮어쓸 수 없습니다."
 fi
 
 exit 0

--- a/.claude/hooks/test-hooks.sh
+++ b/.claude/hooks/test-hooks.sh
@@ -1,0 +1,99 @@
+#!/bin/bash
+# 훅 자가 테스트: 픽스처 JSON을 각 훅에 파이프해 exit code·JSON 출력을 검증한다.
+# 사용: bash .claude/hooks/test-hooks.sh
+#
+# expect_decision:
+#   "ask"/"deny" = 해당 permissionDecision JSON이 있어야 통과
+#   "none"       = decision이 없어야 통과 (allow 케이스가 ask로 새는 것을 잡는다)
+
+HOOKS_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+export CLAUDE_PROJECT_DIR="${CLAUDE_PROJECT_DIR:-$(cd "$HOOKS_DIR/../.." && pwd)}"
+
+PASS=0
+FAIL=0
+
+assert_case() {
+  local desc="$1" hook="$2" input="$3" expect_exit="$4" expect_decision="$5"
+
+  local out exit_code decision
+  out=$(printf '%s' "$input" | bash "$HOOKS_DIR/$hook" 2>/dev/null)
+  exit_code=$?
+  decision=$(printf '%s' "$out" | jq -r '.hookSpecificOutput.permissionDecision // empty' 2>/dev/null)
+
+  local ok=1
+  [ "$exit_code" = "$expect_exit" ] || ok=0
+  if [ "$expect_decision" = "none" ]; then
+    [ -z "$decision" ] || ok=0
+  elif [ -n "$expect_decision" ]; then
+    [ "$decision" = "$expect_decision" ] || ok=0
+  fi
+
+  if [ "$ok" = "1" ]; then
+    PASS=$((PASS + 1))
+    echo "PASS: $desc"
+  else
+    FAIL=$((FAIL + 1))
+    echo "FAIL: $desc (exit=$exit_code expect_exit=$expect_exit decision=${decision:-none} expect_decision=$expect_decision)"
+  fi
+}
+
+bash_input() {
+  jq -n --arg cmd "$1" '{tool_name: "Bash", tool_input: {command: $cmd}}'
+}
+
+edit_input() {
+  jq -n --arg path "$1" '{tool_name: "Edit", tool_input: {file_path: $path}}'
+}
+
+write_input() {
+  jq -n --arg path "$1" '{tool_name: "Write", tool_input: {file_path: $path}}'
+}
+
+echo "=== block-dangerous-commands.sh: DENY 티어 ==="
+assert_case "dd of=/dev/sda 차단" block-dangerous-commands.sh "$(bash_input 'dd if=/dev/zero of=/dev/sda')" 2 "none"
+assert_case "포크밤 차단" block-dangerous-commands.sh "$(bash_input ':(){ :|:& };:')" 2 "none"
+assert_case "rm -rf ~ (홈 자체) 차단" block-dangerous-commands.sh "$(bash_input 'rm -rf ~')" 2 "none"
+assert_case "rm -rf ~/ (홈 자체, 슬래시) 차단" block-dangerous-commands.sh "$(bash_input 'rm -rf ~/')" 2 "none"
+
+echo ""
+echo "=== block-dangerous-commands.sh: ASK 티어 ==="
+assert_case "DROP  DATABASE(공백2) 확인요청" block-dangerous-commands.sh "$(bash_input 'psql -c "DROP  DATABASE gravit"')" 0 "ask"
+assert_case "psql DROP SCHEMA 확인요청" block-dangerous-commands.sh "$(bash_input 'psql -c "DROP SCHEMA public CASCADE"')" 0 "ask"
+assert_case "chmod -R 0777 확인요청" block-dangerous-commands.sh "$(bash_input 'chmod -R 0777 /')" 0 "ask"
+assert_case "chmod 777 -R 확인요청" block-dangerous-commands.sh "$(bash_input 'chmod 777 -R /')" 0 "ask"
+assert_case "rm -rf ~/하위경로는 deny 아닌 ask" block-dangerous-commands.sh "$(bash_input 'rm -rf ~/some/project/node_modules')" 0 "ask"
+assert_case "rm -rf /tmp/build 확인요청" block-dangerous-commands.sh "$(bash_input 'rm -rf /tmp/build')" 0 "ask"
+assert_case "flywayClean 확인요청" block-dangerous-commands.sh "$(bash_input './gradlew flywayClean')" 0 "ask"
+assert_case "flywayRepair 확인요청" block-dangerous-commands.sh "$(bash_input './gradlew flywayRepair')" 0 "ask"
+assert_case "flyway repair(공백 변형) 확인요청" block-dangerous-commands.sh "$(bash_input 'flyway repair -url=jdbc:postgresql://localhost/db')" 0 "ask"
+assert_case "cp로 마이그레이션 덮어쓰기 확인요청" block-dangerous-commands.sh "$(bash_input 'cp /tmp/evil.sql src/main/resources/db/migration/V1__init_tables.sql')" 0 "ask"
+assert_case "git push refspec force(+) 확인요청" block-dangerous-commands.sh "$(bash_input 'git push origin +main')" 0 "ask"
+assert_case ".claude 훅 자기수정 확인요청" block-dangerous-commands.sh "$(bash_input 'sed -i "" "s/exit 2/exit 0/" .claude/hooks/block-dangerous-commands.sh')" 0 "ask"
+
+echo ""
+echo "=== block-dangerous-commands.sh: 통과(오탐 해소) ==="
+assert_case "rg DROP TABLE 검색 통과" block-dangerous-commands.sh "$(bash_input 'rg "DROP TABLE" src/main/resources/db/migration/')" 0 "none"
+assert_case "git log --grep truncate 통과" block-dangerous-commands.sh "$(bash_input 'git log --grep="truncate table"')" 0 "none"
+assert_case "일반 git push 통과" block-dangerous-commands.sh "$(bash_input 'git push -u origin HEAD')" 0 "none"
+
+echo ""
+echo "=== protect-migrations.sh ==="
+EXISTING_MIGRATION=$(git -C "$CLAUDE_PROJECT_DIR" ls-tree -r --name-only origin/main -- src/main/resources/db/migration 2>/dev/null | grep -E 'V[0-9]+__.*\.sql' | head -1)
+if [ -n "$EXISTING_MIGRATION" ]; then
+  assert_case "origin/main 존재 마이그레이션 Edit 차단" protect-migrations.sh "$(edit_input "$CLAUDE_PROJECT_DIR/$EXISTING_MIGRATION")" 0 "deny"
+  assert_case "origin/main 존재 마이그레이션 Write 차단" protect-migrations.sh "$(write_input "$CLAUDE_PROJECT_DIR/$EXISTING_MIGRATION")" 0 "deny"
+else
+  echo "SKIP: origin/main 마이그레이션을 찾지 못해 케이스 생략"
+fi
+assert_case "신규 V파일 Edit 허용" protect-migrations.sh "$(edit_input "$CLAUDE_PROJECT_DIR/src/main/resources/db/migration/V9999__test_never_exists.sql")" 0 "none"
+assert_case "신규 V파일 Write 허용" protect-migrations.sh "$(write_input "$CLAUDE_PROJECT_DIR/src/main/resources/db/migration/V9999__test_never_exists.sql")" 0 "none"
+
+echo ""
+echo "=== protect-claude-config.sh ==="
+assert_case "훅 스크립트 Edit 확인요청" protect-claude-config.sh "$(edit_input "$CLAUDE_PROJECT_DIR/.claude/hooks/block-dangerous-commands.sh")" 0 "ask"
+assert_case "settings.json Edit 확인요청" protect-claude-config.sh "$(edit_input "$CLAUDE_PROJECT_DIR/.claude/settings.json")" 0 "ask"
+assert_case "일반 파일 Edit 허용" protect-claude-config.sh "$(edit_input "$CLAUDE_PROJECT_DIR/src/main/java/gravit/Foo.java")" 0 "none"
+
+echo ""
+echo "결과: PASS=$PASS FAIL=$FAIL"
+[ "$FAIL" -eq 0 ]

--- a/.claude/hooks/test-hooks.sh
+++ b/.claude/hooks/test-hooks.sh
@@ -87,6 +87,17 @@ else
 fi
 assert_case "신규 V파일 Edit 허용" protect-migrations.sh "$(edit_input "$CLAUDE_PROJECT_DIR/src/main/resources/db/migration/V9999__test_never_exists.sql")" 0 "none"
 assert_case "신규 V파일 Write 허용" protect-migrations.sh "$(write_input "$CLAUDE_PROJECT_DIR/src/main/resources/db/migration/V9999__test_never_exists.sql")" 0 "none"
+if [ -n "$EXISTING_MIGRATION" ]; then
+  out=$(printf '%s' "$(edit_input "$CLAUDE_PROJECT_DIR/$EXISTING_MIGRATION")" | (unset CLAUDE_PROJECT_DIR; bash "$HOOKS_DIR/protect-migrations.sh") 2>/dev/null)
+  decision=$(printf '%s' "$out" | jq -r '.hookSpecificOutput.permissionDecision // empty' 2>/dev/null)
+  if [ "$decision" = "deny" ]; then
+    PASS=$((PASS + 1))
+    echo "PASS: CLAUDE_PROJECT_DIR 미설정 시 기존 마이그레이션 Edit 보수적 차단"
+  else
+    FAIL=$((FAIL + 1))
+    echo "FAIL: CLAUDE_PROJECT_DIR 미설정 시 기존 마이그레이션 Edit 보수적 차단 (decision=${decision:-none})"
+  fi
+fi
 
 echo ""
 echo "=== protect-claude-config.sh ==="

--- a/.claude/resources/plans/PLAN-424.md
+++ b/.claude/resources/plans/PLAN-424.md
@@ -1,0 +1,122 @@
+# [PLAN-424] Claude Code 훅 안전장치·알림 개선
+
+> 이슈: #424
+> 브랜치: chore/424-claude-hooks
+
+## 목표
+`.claude/hooks/`의 위험 명령 차단이 오탐(문자열 언급만으로 차단)과 우회(공백·플래그 변형, Bash 경유 마이그레이션 수정, 훅 자기수정, `flywayClean`)를 동시에 가진 문제를 해소한다. 차단 로직을 deny/ask 2단 구조로 재설계하고, notify 훅이 프로젝트·권한 요청 내용·마지막 응답 요약을 전달하게 한다.
+
+## 영향 범위
+### 신규 파일
+- `.claude/hooks/notify.sh` — OS별 알림 발송 공통 스크립트 (osascript argv 전달로 인젝션 방지)
+- `.claude/hooks/protect-claude-config.sh` — `.claude/hooks/**`·`settings*.json` 대상 Edit/Write를 ask로 승격하는 자기보호 훅
+- `.claude/hooks/test-hooks.sh` — 픽스처 JSON을 각 훅에 파이프해 exit code·JSON 출력을 검증하는 자가 테스트
+
+### 수정 파일
+- `.claude/hooks/block-dangerous-commands.sh` — 공백 정규화 + 컨텍스트 기반 매칭 + deny/ask 2단 구조 + fail-closed 가드로 재설계
+- `.claude/hooks/protect-migrations.sh` — origin/main에 존재하는 마이그레이션만 불변 처리, JSON deny 출력으로 전환
+- `.claude/hooks/notify-permission.sh` — stdin JSON의 `.message`·`.cwd` 활용, notify.sh 호출로 축소
+- `.claude/hooks/notify-stop.sh` — transcript에서 마지막 assistant 응답 요약 추출, 브랜치명 표시
+- `.claude/settings.json` — deny 변형 보강, `permissions.ask` 신설, protect-claude-config.sh 훅 등록
+
+## 구현 계획
+> Java 코드 미변경 이슈로, 레이어(Entity~Controller) 대신 파일 단위로 기술한다. Facade: 불필요 — Java 코드 미변경.
+
+### 1. `block-dangerous-commands.sh` 재설계
+- **fail-closed 가드**: 스크립트 첫머리에 `command -v jq >/dev/null 2>&1 || { echo "jq 미설치: 안전 훅 실행 불가" >&2; exit 2; }`. 현재는 jq 부재 시 COMMAND가 빈 문자열이 되어 전부 통과(fail-open).
+- **정규화**: `NORM=$(printf '%s' "$COMMAND" | tr '[:upper:]' '[:lower:]' | tr -s '[:space:]' ' ')` — `DROP  DATABASE`(공백 2개) 류 우회 봉쇄.
+- **출력 함수 2개**:
+  - `deny()` — stderr 사유 + `exit 2` (즉시 차단, 사유가 모델에 전달됨)
+  - `ask()` — stdout에 `{"hookSpecificOutput":{"hookEventName":"PreToolUse","permissionDecision":"ask","permissionDecisionReason":"<사유>"}}` + `exit 0` (사용자 확인으로 에스컬레이션 — 오탐이 차단 대신 확인으로 흡수됨)
+- **DENY 티어** (무조건 파괴적):
+  - 포크밤: `grep -qF ':(){ :|:& };:'` (fixed-string 매칭으로 정규식 의미론 불안정 제거)
+  - 디스크 디바이스 쓰기: `(>|of=) ?/dev/(sd[a-z]|nvme|r?disk)` — 기존 `> /dev/sda`는 `dd of=/dev/sda`를 놓침(세션 실증)
+  - `mkfs\.`
+  - 루트/홈 재귀 삭제: rm + 재귀 플래그 + 대상이 `/`·`~`·`$home`인 경우
+- **ASK 티어** (맥락상 위험, 사용자 판단 필요):
+  - SQL DDL은 DB 클라이언트 컨텍스트에서만: NORM에 `(psql|mysql|mariadb|docker exec)` 존재 AND `(drop (database|table|schema)|truncate table)` 매칭 시 ask. 검색 명령(`rg "DROP TABLE"`, `git log --grep`)은 클라이언트가 없으므로 통과 → 세션에서 실증한 오탐 2건 해소
+  - chmod 변형: `chmod`와 `777` 동시 존재 (기존 `chmod -R 777` 고정 문자열은 `-R 0777`·`777 -R` 순서 변형을 놓침 — 실증)
+  - rm 재귀 변형: `\brm -[a-z]*r` (`-fr`, `-Rf`, `--recursive`) — settings deny(`rm -rf *`·`rm -r *`)가 못 잡는 변형을 ask로 수용
+  - `find … -delete`, `xargs … rm`
+  - git 강제/파괴: `git push … +{ref}`(refspec force — `--force*` deny 우회 경로), `git clean`
+  - Flyway 파괴 태스크: `flyway ?clean|flywayrepair` (gradle 외 flyway CLI 대비 벨트앤서스펜더)
+  - 마이그레이션 Bash 우회: NORM에 `db/migration` 존재 AND 쓰기 동사(`sed -i|mv |rm |tee |>>|>`) 매칭 → ask, 사유 "적용된 마이그레이션은 불변 — 새 V파일로 추가하라"
+  - `.claude` 자기수정: 원본 COMMAND에 `\.claude/(hooks|settings)` AND (`sed -i|tee|>>|>|mv |rm |chmod `) → ask
+- **평가 순서**: settings.json deny(정확 표기 변형)가 먼저 차단 → 훅 DENY → 훅 ASK → 통과.
+
+### 2. `protect-migrations.sh` 정밀화
+- 경로 매칭 엄격화: `db/migration/V.*\.sql` → `db/migration/V[0-9]+__.*\.sql`
+- 상대경로 변환: `REL=${FILE_PATH#"$CLAUDE_PROJECT_DIR"/}`
+- **main 기준 불변 판정**: `git -C "$CLAUDE_PROJECT_DIR" cat-file -e "origin/main:$REL" 2>/dev/null`
+  - 존재(배포됐을 수 있음) → JSON `permissionDecision:"deny"` + 사유 (exit 2 방식에서 전환 — 사유가 모델에 전달돼 새 버전 파일 생성으로 스스로 경로 변경 가능)
+  - 미존재(이 브랜치에서 만든 신규 파일) → Edit/Write 허용. 현재는 방금 만든 파일의 오타 수정도 차단되는 오탐(실증)
+- **폴백**: git 실패·origin/main 부재 시 기존 로직(Edit 차단, Write는 기존 파일만 차단) 유지 — 보수적 동작 보존. `.claude/rules/migration.md`의 "적용된 파일은 절대 수정·삭제 금지" 규칙과 의미론 일치.
+
+### 3. `protect-claude-config.sh` 신설
+- 입력: `.tool_input.file_path`. 매칭: `*/.claude/hooks/*`, `*/.claude/settings.json`, `*/.claude/settings.local.json`
+- 매칭 시 ask JSON 출력 (사유: "훅·권한 설정 변경은 사용자 승인 필요"). 그 외 exit 0
+- 배경: settings.json의 훅 *설정*은 ConfigChange로 감지되지만 훅 스크립트 *본문*은 매 호출 fresh 실행이라 세션 중 Edit 한 번으로 무력화 가능(구조적 공백)
+- settings.json의 기존 `Edit|Write` matcher 그룹에 command로 추가 등록
+
+### 4. `notify.sh` 신설 (공통 발송)
+- 시그니처: `notify.sh <title> <message>`
+- macOS: heredoc `on run argv` 방식으로 osascript에 **argv 전달** — 현재 문자열 보간 방식은 메시지에 `"` 포함 시 조용히 실패(인젝션 취약)
+  ```
+  osascript - "$TITLE" "$MSG" <<'EOF'
+  on run argv
+    display notification (item 2 of argv) with title (item 1 of argv) sound name "Glass"
+  end run
+  EOF
+  ```
+- WSL: powershell 인자 single-quote escape(`'`→`''`) 후 기존 BurntToast/MessageBox 폴백 유지
+- Linux: `notify-send "$TITLE" "$MSG"`
+- notify-permission.sh·notify-stop.sh의 중복 OS 분기 15줄이 이 파일로 수렴
+
+### 5. `notify-permission.sh` 개선
+- stdin JSON 파싱: `MSG=$(jq -r '.message // "권한 승인이 필요합니다."' <<<"$INPUT")`, `CWD=$(jq -r '.cwd // ""')`
+- 제목: `Claude Code — $(basename "$CWD")` — 멀티 세션 시 어느 프로젝트인지 식별
+- 본문: `.message` 원문("Claude needs your permission to use Bash" 류) — 어떤 도구가 왜 멈췄는지 전달
+- 호출: `"$(cd "$(dirname "$0")" && pwd)/notify.sh" "$TITLE" "$MSG"`
+
+### 6. `notify-stop.sh` 개선
+- stdin에서 `.transcript_path`·`.cwd` 추출
+- 마지막 응답 요약 (이 세션에서 실제 transcript로 검증 완료):
+  ```
+  jq -r 'select(.type=="assistant") | .message.content[]? | select(.type=="text") | .text' "$TRANSCRIPT" | tail -1 | tr '\n' ' ' | cut -c1-100
+  ```
+- 브랜치: `git -C "$CWD" branch --show-current 2>/dev/null`
+- 제목 `Claude Code — {project} ({branch})`, 본문은 요약(비어 있으면 "작업이 완료되었습니다." 폴백)
+
+### 7. `settings.json` 보강
+- `permissions.deny` 추가: `Bash(rm -fr *)`, `Bash(rm -Rf *)`, `Bash(rm -rF *)`, `Bash(rm -R *)`, `Bash(./gradlew flywayClean*)`, `Bash(./gradlew *flywayClean*)`
+- `permissions.ask` 신설: `Bash(git clean*)` (+ 결정 필요 1 결과에 따라 `Bash(git push*)`)
+- `hooks.PreToolUse`의 `Edit|Write` matcher 그룹에 `protect-claude-config.sh` 추가
+- (결정 필요 2 결과에 따라) `Notification` matcher를 `permission_prompt|idle_prompt`로 확장
+- 참고: `settings.local.json`의 `Bash(git *)` allow보다 deny/ask가 우선 평가되므로 로컬 설정 변경 불요
+
+### 8. `test-hooks.sh` 신설 (자가 테스트)
+- 픽스처 JSON(`{"tool_name":"Bash","tool_input":{"command":"…"}}`)을 heredoc으로 생성해 각 훅에 파이프, 기대 exit code와 stdout의 `permissionDecision`을 assert
+- 케이스: 세션 실증 우회 5종(dd of=/dev/sda, DROP␣␣DATABASE, chmod -R 0777, chmod 777 -R, psql DROP SCHEMA) → 전부 deny/ask, 오탐 2종(rg "DROP TABLE", git log --grep) → 통과, 포크밤 → deny, flywayClean → ask, `.claude` 자기수정 → ask, 마이그레이션 3케이스(main 존재 Edit → deny / 신규 V파일 Edit → 허용 / 신규 Write → 허용)
+- 패턴 문자열이 Bash 명령 인자에 노출되지 않도록 스크립트 파일 실행형으로 작성 (이 세션에서 겪은 훅 자기차단 회피)
+
+## 결정 필요 (Decisions needed)
+- [x] `git push` ask 승격 여부 — **B 확정**: 일반 push는 현행 유지. force 계열은 deny(기존), refspec `+` force만 훅 ask로 통제. `permissions.ask`에는 `Bash(git clean*)`만 추가.
+- [x] Notification matcher 확장 — **A 확정**: `permission_prompt|idle_prompt`로 확장. 입력 대기(60초+) 알림 추가.
+- [x] `.claude` 자기보호 수위 — **A 확정**: ask 승격. 정당한 훅 수정은 사용자 승인으로 진행.
+
+## 검증
+- `bash .claude/hooks/test-hooks.sh` 전 케이스 통과
+- 수동 확인: ① `rg "DROP TABLE" src/main/resources/db/migration/` 정상 실행(오탐 해소) ② 신규 V파일 생성 후 Edit 허용, 기존 V1 Edit 시 deny 사유 표시 ③ 따옴표 포함 메시지로 notify.sh 호출 시 알림 정상 표시 ④ Stop 알림에 브랜치·요약 표시
+- `./gradlew test` 불요 — Java 코드 미변경
+
+## Deviation Log
+- `settings.json`: 계획서상 순서(7번)보다 늦춰 test-hooks.sh(8번) 작성 이후 마지막에 적용 — 이유: protect-claude-config.sh 등록이 활성화되면 이후 `.claude/hooks/**` Edit이 ask로 승격되어, 같은 구현 세션에서 남은 훅 파일 작성이 매번 사용자 확인을 요구하게 됨. 모든 훅 파일을 먼저 완성한 뒤 마지막에 settings.json을 갱신해 불필요한 중단을 피함. 로직·범위는 계획과 동일.
+
+### 검수 후 수정 (구현 검수에서 발견)
+- `block-dangerous-commands.sh`: 루트/홈 rm deny 정규식의 트레일링 클래스에서 `/` 제거, `~/?`·`\$home/?`로 교체 — 이유: `rm -rf ~/하위경로`가 계획 의도(ask)와 달리 deny로 과잉 차단됨. 홈 자체(`~`, `~/`)는 여전히 deny.
+- `block-dangerous-commands.sh`: 마이그레이션 쓰기 동사에 `cp ` 추가, flyway 패턴을 `flyway ?(clean|repair)`로 통합 — 이유: `cp`로 V파일 덮어쓰기와 `flyway repair`(공백 변형)가 통과함. 계획서 목록 자체의 누락.
+- `protect-migrations.sh`·`protect-claude-config.sh`: jq fail-closed 가드 추가 — 이유: jq 부재 시 FILE_PATH가 빈 값이 되어 보호가 조용히 꺼짐(fail-open). block-dangerous와 일관성 확보.
+- `notify-stop.sh`: 요약 추출을 jq slurp(`-s`) 방식으로 교체해 마지막 텍스트 블록 전체를 집계 — 이유: 계획서의 `tail -1` 파이프라인은 마지막 '줄'만 추출해 알림에 마크다운 꼬리표가 노출됨.
+- `notify-stop.sh`·`notify-permission.sh`: 알림 본문을 공백 정리 후 60자 + `…`로 절단 — 이유: 사용자 피드백(알림 본문 과다). jq 코드포인트 단위 절단으로 한글 바이트 깨짐 방지(`cut -c` 대체).
+- `test-hooks.sh`: `expect_decision`에 "none" 센티널 도입, 검수 발견 케이스를 회귀 테스트로 추가해 26케이스로 확장 — 이유: 기존 allow 케이스는 훅이 ask를 뱉어도 PASS되어 오탐 해소 검증이 무력했음.
+- `notify.sh`: macOS 발송을 terminal-notifier 우선(-activate로 클릭 시 IntelliJ 활성화, -group으로 알림 치환)으로 전환, osascript는 폴백 유지. 알림 제목은 프로젝트·브랜치 없이 "Claude Code"로 고정 — 이유: 사용자 요청(제목 간소화 + 클릭 시 IDE 이동). 활성화 앱은 `CLAUDE_NOTIFY_ACTIVATE` 환경변수로 교체 가능.

--- a/.claude/settings.json
+++ b/.claude/settings.json
@@ -17,6 +17,10 @@
     "deny": [
       "Bash(rm -rf *)",
       "Bash(rm -r *)",
+      "Bash(rm -fr *)",
+      "Bash(rm -Rf *)",
+      "Bash(rm -rF *)",
+      "Bash(rm -R *)",
       "Bash(git push --force*)",
       "Bash(git push -f*)",
       "Bash(git reset --hard*)",
@@ -25,7 +29,12 @@
       "Bash(docker system prune*)",
       "Bash(docker image prune*)",
       "Bash(docker container prune*)",
-      "Bash(docker volume prune*)"
+      "Bash(docker volume prune*)",
+      "Bash(./gradlew flywayClean*)",
+      "Bash(./gradlew *flywayClean*)"
+    ],
+    "ask": [
+      "Bash(git clean*)"
     ]
   },
   "hooks": {
@@ -47,13 +56,18 @@
             "type": "command",
             "command": "\"$CLAUDE_PROJECT_DIR\"/.claude/hooks/protect-migrations.sh",
             "timeout": 5
+          },
+          {
+            "type": "command",
+            "command": "\"$CLAUDE_PROJECT_DIR\"/.claude/hooks/protect-claude-config.sh",
+            "timeout": 5
           }
         ]
       }
     ],
     "Notification": [
       {
-        "matcher": "permission_prompt",
+        "matcher": "permission_prompt|idle_prompt",
         "hooks": [
           {
             "type": "command",

--- a/.claude/skills/commit-push/SKILL.md
+++ b/.claude/skills/commit-push/SKILL.md
@@ -6,6 +6,8 @@ description: |
   Do NOT use for: 이슈·브랜치 생성(→ open-issue), PR 생성(→ open-pr), 코드 구현(→ implement), 코드 리뷰
   Boundary: 커밋 생성과 원격 push까지만 수행한다. PR 생성·머지·리뷰는 범위 밖이다.
 allowed-tools: Bash(git *), Read
+model: sonnet
+effort: xhigh
 ---
 
 # 커밋·푸시

--- a/.claude/skills/conversation-feedback/SKILL.md
+++ b/.claude/skills/conversation-feedback/SKILL.md
@@ -6,6 +6,8 @@ description: |
   Do NOT use for: 코드 리뷰(→ code-review), 테스트/요구사항 등 작업 수행, 외부 파일 저장
   Boundary: 화면 출력까지만 수행한다. 결과를 파일이나 메모리에 저장하지 않는다(누적 추적 미지원).
 allowed-tools:
+model: opus
+effort: xhigh
 ---
 
 # 대화 피드백

--- a/.claude/skills/implement/SKILL.md
+++ b/.claude/skills/implement/SKILL.md
@@ -6,6 +6,8 @@ description: |
   Do NOT use for: 계획 수립(→ write-plan), 이슈 발의(→ open-issue), 테스트 작성(→ write-test), PR 생성(→ open-pr)
   Boundary: 계획서대로 코드를 구현한다. 계획을 새로 짜지 않는다. 테스트 코드 작성은 이 스킬 범위 밖이다.
 allowed-tools: Read, Grep, Glob, Edit, Write, Bash
+model: sonnet
+effort: xhigh
 ---
 
 # 기능 구현 (계획서 기반)

--- a/.claude/skills/open-issue/SKILL.md
+++ b/.claude/skills/open-issue/SKILL.md
@@ -6,6 +6,8 @@ description: |
   Do NOT use for: 작업 계획 수립(→ write-plan), 구현(→ implement), 이미 열린 이슈에 브랜치만 파는 경우(직접 git)
   Boundary: 이슈 생성과 브랜치 생성·체크아웃까지만 수행한다. 작업 계획과 구현은 이 스킬 범위 밖이다.
 allowed-tools: Read, Grep, Glob, Bash
+model: sonnet
+effort: xhigh
 ---
 
 # 작업 발의 (이슈 + 브랜치)

--- a/.claude/skills/open-pr/SKILL.md
+++ b/.claude/skills/open-pr/SKILL.md
@@ -6,6 +6,8 @@ description: |
   Do NOT use for: 커밋 생성(직접 git commit), 브랜치 생성, 코드 리뷰
   Boundary: PR 생성까지만 수행한다. 머지, 리뷰 요청, 라벨 설정은 범위 밖이다.
 allowed-tools: Bash(git *), Bash(gh *), Read
+model: sonnet
+effort: xhigh
 ---
 
 # PR 생성

--- a/.claude/skills/run-test/SKILL.md
+++ b/.claude/skills/run-test/SKILL.md
@@ -6,6 +6,8 @@ description: |
   Do NOT use for: 테스트 코드 작성(→ write-test), 테스트 코드 수정(직접 Edit), 빌드 설정 변경
   Boundary: 테스트 실행과 결과 분석까지만 수행한다. 실패한 테스트의 코드 수정은 사용자 확인 후 별도로 진행한다.
 allowed-tools: Bash(./gradlew *), Read, Grep
+model: sonnet
+effort: xhigh
 ---
 
 # 테스트 실행

--- a/.claude/skills/write-api-docs/SKILL.md
+++ b/.claude/skills/write-api-docs/SKILL.md
@@ -6,6 +6,8 @@ description: |
   Do NOT use for: DTO에 @Schema만 추가하는 작업(직접 Edit), Controller 로직 수정, 기존 Docs 인터페이스의 단순 오타 수정
   Boundary: Controller 자체의 구현 변경은 이 스킬 범위 밖이다. Docs 인터페이스 생성과 Controller의 implements 연결까지만 수행한다.
 allowed-tools: Read, Grep, Glob, Edit, Write
+model: sonnet
+effort: xhigh
 ---
 
 # API 문서 작성

--- a/.claude/skills/write-plan/SKILL.md
+++ b/.claude/skills/write-plan/SKILL.md
@@ -6,6 +6,8 @@ description: |
   Do NOT use for: 이슈 발의(→ open-issue), 실제 구현(→ implement), 계획서 없이 바로 코딩
   Boundary: 계획서(.claude/resources/plans/PLAN-{번호}.md) 작성까지만 수행한다. 실제 코드 수정은 이 스킬 범위 밖이다.
 allowed-tools: Read, Grep, Glob, Bash, Write, Edit
+model: opus
+effort: xhigh
 ---
 
 # 작업 계획 수립

--- a/.claude/skills/write-test/SKILL.md
+++ b/.claude/skills/write-test/SKILL.md
@@ -6,6 +6,8 @@ description: |
   Do NOT use for: 테스트 실행/결과 확인(→ run-test), 기존 테스트 수정만 필요한 경우(직접 Edit), 코드 리뷰
   Boundary: 테스트 대상 코드의 버그 수정은 이 스킬 범위 밖이다. 테스트 작성 중 버그를 발견하면 사용자에게 보고만 하라.
 allowed-tools: Read, Grep, Glob, Edit, Write, Bash
+model: opus
+effort: xhigh
 ---
 
 # 테스트 코드 작성


### PR DESCRIPTION
### 1. 연관 이슈

---
 - close #424

<br>

### 2. 구현 사항

---
**구현 사항 1 — 위험 명령·마이그레이션 보호 훅 재설계**

- 추가: `block-dangerous-commands.sh`를 DENY(즉시 차단)/ASK(사용자 확인) 2단 구조로 재설계 — 기존엔 문자열 포함 여부만 봐서 `rg "DROP TABLE"` 같은 검색도 차단되고, `chmod 777 -R`처럼 플래그 순서만 바꿔도 우회됐음
- 수정: `protect-migrations.sh`가 로컬 파일 존재 여부 대신 `origin/main` 기준으로 마이그레이션 불변 여부를 판단 — 현재 브랜치에서 새로 만든 V파일은 자유롭게 수정 가능, 배포됐을 수 있는 파일만 차단
- 추가: `protect-claude-config.sh` — `.claude/hooks/**`·`settings.json` 수정 시 사용자 확인을 거치도록 하는 자기보호 훅. 훅 스크립트는 매 호출 fresh 실행이라, 이 훅이 없으면 세션 중 Edit 한 번으로 다른 모든 안전장치가 무력화될 수 있었음
- 추가: `test-hooks.sh` — 픽스처 JSON을 각 훅에 파이프해 26개 케이스(우회 패턴·오탐 해소·마이그레이션 판정)를 검증하는 자가 테스트
- 수정: `settings.json` — `rm` 재귀 변형·`flywayClean` deny 추가, `git clean` ask 추가, 위 훅들 등록

**구현 사항 2 — 알림 훅 정보 강화**

- 추가: `notify.sh` — OS별 알림 발송 공통 스크립트. macOS는 `terminal-notifier`를 우선 사용해 클릭 시 IntelliJ IDEA를 활성화하고(`-activate`), 알림을 그룹으로 묶어 알림센터에 중복 적재되지 않게 함(`-group`). 미설치 환경은 기존 `osascript` argv 방식으로 폴백
- 수정: `notify-permission.sh`·`notify-stop.sh` — 고정 문구 대신 실제 권한 요청 메시지, transcript의 마지막 응답 요약을 전달. 공백을 접고 60자로 잘라 알림 본문이 과도하게 길어지지 않도록 함
- 수정: `settings.json`의 Notification matcher를 `permission_prompt|idle_prompt`로 확장해 입력 대기 상태도 알림 대상에 포함


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * 위험 명령 처리가 즉시 차단(DENY)과 사용자 확인요청(ASK)으로 분리되어 더 정교해졌습니다.
  * 훅/설정 파일 및 마이그레이션 변경이 강화되어 위반 시 권한 거부/요청이 더 명확히 표시됩니다.
  * 작업 중단 및 권한 알림이 공통 방식으로 통합되어 더 짧고 일관된 메시지로 전달됩니다.
* **Tests**
  * 훅의 차단/승인 동작과 엣지 케이스를 자동 검증하는 테스트가 추가되었습니다.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->