### PR TITLE
docs: analysis 이슈 템플릿 추가 및 컨벤션 반영(#430)

### DIFF
--- a/.claude/skills/open-issue/SKILL.md
+++ b/.claude/skills/open-issue/SKILL.md
@@ -16,7 +16,7 @@ effort: xhigh
 '어떻게(구현)'은 본 스킬에서 담당하지 않는다.
 
 작업은 기능 구현(feat), 수정(fix), 리펙토링(refactor), 긴급 수정(hotfix), 문서화(docs),
-테스트 관련(test), CI/CD(cicd), 기타(chore)로 분류되며 작업 종류를 먼저 판별한 뒤, 그에 맞는
+테스트 관련(test), CI/CD(cicd), 기타(chore), 분석(analysis)로 분류되며 작업 종류를 먼저 판별한 뒤, 그에 맞는
 템플릿, 라벨, 브랜치 접두사를 사용한다.
 
 ## Phase 1: 작업 구체화 (대화)
@@ -29,7 +29,7 @@ effort: xhigh
    - 왜(배경, 문제 상황)
    - 제약사항(있는 경우에)
 3. 아래 다섯 요소가 확정되면 다음 Phase로 이동하라
-   - 종류: feat / fix / refactor / hotfix / docs / test / cicd 중 하나
+   - 종류: feat / fix / refactor / hotfix / docs / test / cicd / analysis 중 하나
    - 제목: 작업을 한 줄로 표현하는 명사형
    - 설명: 이 작업이 왜 필요한지 1~3문장
    - 작업 항목: 체크리스트로 쪼갠 하위 작업 목록

--- a/.claude/spec/git-convention.md
+++ b/.claude/spec/git-convention.md
@@ -8,16 +8,17 @@ description: 커밋, 브랜치, PR 등 Git 작업 시 적용되는 규칙
 
 형식: `{type}: 커밋 내용(#{이슈번호})`
 
-| type | 용도 | 이슈 라벨 |
-|---|---|---|
-| feat | 새로운 기능 | 🌼 Feat |
-| hotfix | 긴급 수정 | 🔥 HotFix |
-| fix | 버그 수정 | 🔨 Fix |
-| docs | 문서 변경 | 📚 Docs |
+| type | 용도 | 이슈 라벨        |
+|---|---|--------------|
+| feat | 새로운 기능 | 🌼 Feat      |
+| hotfix | 긴급 수정 | 🔥 HotFix    |
+| fix | 버그 수정 | 🔨 Fix       |
+| docs | 문서 변경 | 📚 Docs      |
 | test | 테스트 추가/수정 | 🙆🏻‍♂️ Test |
-| cicd | CI/CD 설정 변경 | 🚦CICD |
-| refactor | 리팩토링 | 🧹Refactor |
-| chore | 빌드·설정 등 기타 | ⚡️Chore |
+| cicd | CI/CD 설정 변경 | 🚦CICD       |
+| refactor | 리팩토링 | 🧹Refactor   |
+| chore | 빌드·설정 등 기타 | ⚡️Chore      |
+| analysis | 코드 동작 분석·조사 | 🧪 Analysis  |
 
 > `type`은 커밋 접두사(`{type}:`), 브랜치 접두사(`{type}/`), GitHub 이슈 라벨에 공통으로 쓰인다.
 

--- a/.github/ISSUE_TEMPLATE/analysis-issue-template.md
+++ b/.github/ISSUE_TEMPLATE/analysis-issue-template.md
@@ -1,0 +1,21 @@
+---
+name: Analysis issue template
+about: For analysis issue 
+title: 'analysis: '
+labels: "\U0001F9EA Analysis"
+assignees:
+---
+
+### 1.  Analysis Description
+
+---
+
+분석에 대한 설명을 작성해주세요.
+
+<br>
+
+### 2. Analysis For
+
+---
+
+어떤 것에 대한 연구인지 작성해주세요.


### PR DESCRIPTION
### 1. 연관 이슈

---
 - close #430

<br>

### 2. 구현 사항

---
**구현 사항 1 — analysis 이슈 템플릿 추가**

- 추가: `analysis-issue-template.md` — `.github/ISSUE_TEMPLATE/`
- 본문은 `1. Analysis Description`, `2. Analysis For` 두 섹션으로만 구성했습니다. 코드 동작을 조사·연구하는 이슈는 작업 항목을 미리 쪼갤 수 없고 특정 도메인에 매이지도 않아서, 다른 템플릿의 `Issue Task`·`Related Domain` 섹션은 넣지 않았습니다.
- front matter는 `title: 'analysis: '`, `labels: "🧪 Analysis"`로 지정해 이슈 생성 시 제목 접두사와 라벨이 자동으로 붙도록 했습니다.

<br>

**구현 사항 2 — git 컨벤션에 analysis 타입 반영**

- 추가: 커밋 타입 표에 `analysis | 코드 동작 분석·조사 | 🧪 Analysis` 행 — `.claude/spec/git-convention.md`
- 표 아래 주석이 "`type`은 커밋 접두사·브랜치 접두사·GitHub 이슈 라벨에 공통으로 쓰인다"고 규정하고 있어, 이 행 하나로 `analysis: ...(#번호)` 커밋과 `analysis/{번호}-{slug}` 브랜치까지 함께 컨벤션에 편입됩니다.
- 수정: 표의 파이프 정렬 (내용 변경 없음)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **문서**
  - 커밋 메시지 규칙에 `analysis` 유형과 🧪 Analysis 라벨 기준을 추가했습니다.
  - 분석 및 조사 작업을 위한 GitHub 이슈 템플릿을 새로 제공합니다.
  - 템플릿에서 분석 설명과 연구 대상을 체계적으로 작성할 수 있습니다.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->