### PR TITLE
analysis: @TransactionalEventListener phase-propagation-동기/비동기 조합 동작 검증

### DIFF
--- a/.claude/resources/plans/PLAN-432.md
+++ b/.claude/resources/plans/PLAN-432.md
@@ -1,0 +1,487 @@
+# [PLAN-432] 트랜잭션 이벤트 리스너 phase × propagation × 동기/비동기 조합 동작 실증
+
+> 이슈: #432
+> 브랜치: analysis/432-tx-event-listener-combination
+
+## 목표
+
+`@TransactionalEventListener`의 `phase` × `@Transactional`의 `propagation` × `@Async` 사용 여부 5개 조합이 실제로 어떤 트랜잭션·스레드 경계에서 실행되는지를, 테스트 전용 fixture로 재현해 **데이터 잔존 / 트랜잭션 경계 / 스레드 경계 / 예외 전파 방향** 네 축으로 관찰한다.
+권장 3조합이 설명대로 동작하는지, 안티패턴 2조합이 실제로 부작용을 내는지를 실행 가능한 증거로 남긴다. 프로덕션 코드는 변경하지 않는다.
+
+## 영향 범위
+
+### 신규 파일
+
+모두 `src/test/java/gravit/code/experiment/txevent/` 하위. 프로덕션 소스는 한 줄도 건드리지 않는다.
+
+| 경로 | 역할 |
+| --- | --- |
+| `fixture/ExperimentRecord.java` | 실험용 `@Entity`. `id`(IDENTITY) + `tag`. 쓰기가 실제로 커밋됐는지 판별하는 유일한 관찰 대상 |
+| `fixture/ExperimentRecordRepository.java` | `JpaRepository<ExperimentRecord, Long>`. `existsByTag` |
+| `fixture/ExperimentEvent.java` | 이벤트 계약 인터페이스 + 조합별 중첩 `record` 5종 |
+| `fixture/ExperimentPublisher.java` | `@Transactional` 원본 트랜잭션 보유자. 원본 행 저장 후 이벤트 발행 |
+| `fixture/ExecutionTrace.java` | 실행 시점의 스레드명·트랜잭션명·활성 여부 스냅샷 `record` |
+| `fixture/TraceRecorder.java` | 스레드 안전 관찰 수집기 (trace / error / flag) |
+| `fixture/ExperimentGate.java` | 안티패턴 2 전용. 원본 트랜잭션을 미커밋 상태로 붙잡아 두는 래치 |
+| `listener/BeforeCommitSyncRequiredListener.java` | 권장 ① |
+| `listener/AfterCommitSyncNewTxListener.java` | 권장 ② |
+| `listener/AfterCommitAsyncNewTxListener.java` | 권장 ③ |
+| `listener/AfterCommitSyncRequiredListener.java` | 안티패턴 ④ |
+| `listener/BeforeCommitAsyncNewTxListener.java` | 안티패턴 ⑤ (+ 게이트 리스너) |
+| `ExperimentFixtureConfig.java` | `@TestConfiguration`. 위 빈들 + `experimentAsync` Executor 등록 |
+| `RecommendedCombinationIntegrationTest.java` | 권장 3조합 검증 |
+| `AntiPatternCombinationIntegrationTest.java` | 안티패턴 2조합 검증 |
+
+### 수정 파일
+
+- `build.gradle` (112~114행) — `test` 태스크에 `excludeTags 'experiment'` 추가, `experimentTest` 태스크 신설
+- `.github/workflows/ci-common.yml` — **수정 불필요**. `./gradlew --info test`가 태그 제외로 자동 스킵된다
+
+## 구현 계획
+
+### 1. Entity / Flyway
+
+**Flyway 마이그레이션 불필요.** test 프로파일이 `ddl-auto: create` + `flyway.enabled: false`이므로(`src/test/resources/application-test.yml:9,22`) 엔티티만 정의하면 `experiment_record` 테이블이 컨텍스트 기동 시 생성된다. `DatabaseCleaner`가 `pg_tables`를 동적으로 훑어 TRUNCATE하므로 정리도 자동이다.
+
+```java
+@Entity
+@Table(name = "experiment_record")
+@Getter
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+public class ExperimentRecord {
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Long id;
+
+    @Column(nullable = false)
+    private String tag;
+
+    private ExperimentRecord(String tag) { this.tag = tag; }
+
+    public static ExperimentRecord create(String tag) { return new ExperimentRecord(tag); }
+}
+```
+
+`GenerationType.IDENTITY`로 고정한다 (프로덕션 엔티티 29곳 전부 IDENTITY). IDENTITY는 `persist()` 시점에 INSERT를 즉시 발행하므로, 안티패턴 ④에서 "INSERT는 실행됐는데 커밋되지 않아 유실"되는 경로가 그대로 재현된다.
+
+> **부작용 (수용)**: `gravit.code` 하위 `@Entity`·`Repository`는 엔티티/리포지토리 스캔 대상이라 모든 통합 테스트 컨텍스트에 등록된다. `ddl-auto: create`라 빈 테이블 하나가 더 생길 뿐이고, 테스트 소스는 jar에 포함되지 않으므로 프로덕션 영향은 없다.
+
+### 2. Repository
+
+```java
+public interface ExperimentRecordRepository extends JpaRepository<ExperimentRecord, Long> {
+    boolean existsByTag(String tag);
+}
+```
+
+### 3. 이벤트 — 조합별로 타입을 분리한다
+
+5개 리스너가 한 이벤트를 공유하면 전부 발화해 조합을 격리할 수 없다. 인터페이스 + 중첩 record로 한 파일에 모은다.
+
+```java
+public interface ExperimentEvent {
+
+    String originTag();
+    String listenerTag();
+    boolean listenerThrows();
+
+    record BeforeCommitSyncRequired(String originTag, String listenerTag, boolean listenerThrows) implements ExperimentEvent {}
+    record AfterCommitSyncNewTx(String originTag, String listenerTag, boolean listenerThrows) implements ExperimentEvent {}
+    record AfterCommitAsyncNewTx(String originTag, String listenerTag, boolean listenerThrows) implements ExperimentEvent {}
+    record AfterCommitSyncRequired(String originTag, String listenerTag, boolean listenerThrows) implements ExperimentEvent {}
+    record BeforeCommitAsyncNewTx(String originTag, String listenerTag, boolean listenerThrows) implements ExperimentEvent {}
+}
+```
+
+### 4. 관찰 하니스
+
+`ExecutionTrace` — 실행 시점 스냅샷. **`getCurrentTransactionName()`이 조합을 가르는 핵심 신호**다. 원본 트랜잭션에 참여하면 발행자 메서드의 FQN이, 신규 트랜잭션이면 리스너 메서드의 FQN이 담긴다.
+
+```java
+public record ExecutionTrace(
+        String label,
+        String threadName,
+        String transactionName,
+        boolean actualTransactionActive,
+        boolean synchronizationActive
+) {
+    public static ExecutionTrace here(String label) {
+        return new ExecutionTrace(
+                label,
+                Thread.currentThread().getName(),
+                TransactionSynchronizationManager.getCurrentTransactionName(),
+                TransactionSynchronizationManager.isActualTransactionActive(),
+                TransactionSynchronizationManager.isSynchronizationActive()
+        );
+    }
+}
+```
+
+`TraceRecorder` — 비동기 리스너가 다른 스레드에서 쓰므로 전부 동시성 컬렉션.
+
+```java
+public class TraceRecorder {
+
+    private final Map<String, ExecutionTrace> traces = new ConcurrentHashMap<>();
+    private final Map<String, Throwable> errors = new ConcurrentHashMap<>();
+    private final Map<String, Boolean> flags = new ConcurrentHashMap<>();
+
+    public void capture(String label);              // traces.put(label, ExecutionTrace.here(label))
+    public void captureError(String label, Throwable error);
+    public void putFlag(String key, boolean value);
+
+    public ExecutionTrace trace(String label);
+    public Optional<Throwable> error(String label);
+    public boolean flag(String key);
+    public void reset();
+}
+```
+
+`ExperimentGate` — 안티패턴 ⑤ 전용. `CountDownLatch`를 `volatile`로 들고 `reset()`에서 새로 만든다.
+
+```java
+public class ExperimentGate {
+    private volatile CountDownLatch listenerRead = new CountDownLatch(1);
+
+    public void signalListenerRead();
+    public boolean awaitListenerRead(long timeout, TimeUnit unit);   // InterruptedException 삼키고 false 반환
+    public void reset();
+}
+```
+
+### 5. 원본 트랜잭션 보유자
+
+```java
+public class ExperimentPublisher {
+
+    private final ExperimentRecordRepository repository;
+    private final ApplicationEventPublisher eventPublisher;
+    private final TraceRecorder recorder;
+
+    @Transactional
+    public void publish(ExperimentEvent event) {
+        recorder.capture("origin");
+
+        repository.save(ExperimentRecord.create(event.originTag()));
+
+        eventPublisher.publishEvent(event);
+    }
+}
+```
+
+원본 행을 **먼저 저장**해야 안티패턴 ⑤에서 비동기 리스너가 "커밋 전이라 안 보이는" 것을 관찰할 수 있다.
+
+### 6. 리스너 5종
+
+모든 리스너는 `recorder.capture("listener")` → `repository.save(listenerTag)` → `listenerThrows`면 `IllegalStateException`을 던지는 동일 골격이다. 조합마다 **어노테이션만 다르다.** 이게 조합 외 변수를 통제한다는 뜻이다.
+
+| # | 클래스 | 어노테이션 |
+| --- | --- | --- |
+| ① | `BeforeCommitSyncRequiredListener` | `@TransactionalEventListener(BEFORE_COMMIT)` + `@Transactional(REQUIRED)` |
+| ② | `AfterCommitSyncNewTxListener` | `@TransactionalEventListener(AFTER_COMMIT)` + `@Transactional(REQUIRES_NEW)` |
+| ③ | `AfterCommitAsyncNewTxListener` | `@Async("experimentAsync")` + `@TransactionalEventListener(AFTER_COMMIT)` + `@Transactional(REQUIRES_NEW)` |
+| ④ | `AfterCommitSyncRequiredListener` | `@TransactionalEventListener(AFTER_COMMIT)` + `@Transactional(REQUIRED)` |
+| ⑤ | `BeforeCommitAsyncNewTxListener` | `@Async("experimentAsync")` + `@TransactionalEventListener(BEFORE_COMMIT)` + `@Transactional(REQUIRES_NEW)` |
+
+비동기(③⑤)는 예외가 `@Async`에 삼켜져 사라지므로, **기록 후 재던지기**로 삼켜지는 경로 자체를 보존한다.
+
+```java
+try {
+    ...
+    if (event.listenerThrows()) throw new IllegalStateException("listener failed");
+} catch (Exception e) {
+    recorder.captureError("listener", e);
+    throw e;
+}
+```
+
+⑤는 리스너 한 개로는 부족하다. `@Async`가 즉시 반환하면 원본은 곧장 커밋해버려 "커밋 전"이라는 창이 사라진다. **같은 클래스에 게이트 리스너를 하나 더 둔다.**
+
+```java
+public class BeforeCommitAsyncNewTxListener {
+
+    @Order(1)
+    @Async("experimentAsync")
+    @TransactionalEventListener(phase = TransactionPhase.BEFORE_COMMIT)
+    @Transactional(propagation = Propagation.REQUIRES_NEW)
+    public void handle(ExperimentEvent.BeforeCommitAsyncNewTx event) {
+        try {
+            recorder.capture("listener");
+            recorder.putFlag("originVisibleToListener", repository.existsByTag(event.originTag()));
+            repository.save(ExperimentRecord.create(event.listenerTag()));
+
+            if (event.listenerThrows()) throw new IllegalStateException("listener failed");
+        } catch (Exception e) {
+            recorder.captureError("listener", e);
+            throw e;
+        } finally {
+            gate.signalListenerRead();
+        }
+    }
+
+    // @Order(1)이 비동기 위임 후 즉시 반환하므로, 원본 스레드를 여기서 붙잡아
+    // 비동기 리스너가 "원본 미커밋 상태"를 관찰할 창을 연다.
+    @Order(2)
+    @TransactionalEventListener(phase = TransactionPhase.BEFORE_COMMIT)
+    public void holdOriginUncommitted(ExperimentEvent.BeforeCommitAsyncNewTx event) {
+        gate.awaitListenerRead(2, TimeUnit.SECONDS);
+    }
+}
+```
+
+- `@Order`는 메서드에 붙이면 `ApplicationListenerMethodAdapter`가 읽어 리스너 순서를 정한다.
+- `@Async`는 메서드 단위이므로 `holdOriginUncommitted`는 원본 스레드에서 동기 실행된다.
+- `signalListenerRead()`를 `finally`에 두어 예외 케이스에서도 게이트가 반드시 풀린다. `awaitListenerRead`는 타임아웃을 둬 데드락을 막는다.
+- `originVisibleToListener`는 **false**여야 한다. 별도 스레드의 `REQUIRES_NEW`는 별도 커넥션이고, 원본 INSERT는 아직 미커밋이라 READ_COMMITTED에서 보이지 않는다.
+
+### 7. `@TestConfiguration`
+
+```java
+@TestConfiguration(proxyBeanMethods = false)
+public class ExperimentFixtureConfig {
+
+    @Bean TraceRecorder traceRecorder();
+    @Bean ExperimentGate experimentGate();
+    @Bean ExperimentPublisher experimentPublisher(...);
+    @Bean BeforeCommitSyncRequiredListener ...;   // 5종
+    ...
+
+    @Bean(name = "experimentAsync")
+    public Executor experimentAsyncExecutor() {   // corePoolSize 2 / maxPoolSize 4 / prefix "ExperimentAsync-"
+    }
+}
+```
+
+- `@TestConfiguration`은 Spring Boot의 `TypeExcludeFilter`가 컴포넌트 스캔에서 제외하므로, **`@Import`한 테스트에서만** 리스너가 등록된다. 다른 통합 테스트 컨텍스트를 오염시키지 않는다.
+- `@Async`는 프로덕션 `AsyncConfig`의 `@EnableAsync`가 이미 켜두었다. 전용 Executor를 따로 두는 이유는 ⑤의 게이트 핸드셰이크가 프로덕션 풀 포화에 걸려 굶지 않게 하고, 스레드명 접두사로 스레드 경계를 명확히 assert하기 위함이다.
+- `@Transactional`/`@Async` 프록시가 CGLIB로 걸리므로 fixture 클래스·메서드를 `final`로 두지 마라.
+
+### 8. 테스트
+
+두 클래스 모두 `@TCSpringBootTest` + `@Import(ExperimentFixtureConfig.class)` + `@Tag("experiment")`.
+**테스트 메서드에 `@Transactional`을 절대 붙이지 마라.** 붙이면 롤백되어 `AFTER_COMMIT`이 발화하지 않고, 검증 조회도 같은 트랜잭션 안에서 이뤄져 "실제로 커밋됐는가"를 판별할 수 없다. 검증 조회(`existsByTag`)는 테스트에 트랜잭션이 없으므로 각각 새 트랜잭션에서 실행되어 커밋된 상태만 본다.
+
+`@BeforeEach`에서 `recorder.reset()` / `gate.reset()`.
+
+#### `RecommendedCombinationIntegrationTest`
+
+| `@Nested` | 시나리오 | 핵심 assert |
+| --- | --- | --- |
+| ① BEFORE_COMMIT + 동기 + REQUIRED | 정상 | 원본·리스너 행 **둘 다 존재** / `listener.transactionName() == origin.transactionName()` (동일 tx 참여) / 스레드 동일 |
+| | 리스너 예외 | `publish()`가 예외를 던짐 / 원본·리스너 행 **둘 다 부재** (원자적 롤백) |
+| ② AFTER_COMMIT + 동기 + REQUIRES_NEW | 정상 | 둘 다 존재 / `transactionName` **다름** (신규 tx) / 스레드 동일 |
+| | 리스너 예외 | ~~`publish()`가 예외를 던짐(요청 스레드로 전파)~~ → **실측 결과 전파되지 않음**. 아래 "관측 결과 ②" 참조 |
+| ③ AFTER_COMMIT + 비동기 + REQUIRES_NEW | 정상 | Awaitility로 대기 후 둘 다 존재 / `transactionName` 다름 / 스레드명이 `ExperimentAsync-` 로 시작 |
+| | 리스너 예외 | `publish()`가 **예외를 던지지 않음** / 원본 행 생존 / `recorder.error("listener")` 존재 (삼켜짐 증명) |
+
+#### `AntiPatternCombinationIntegrationTest`
+
+| `@Nested` | 핵심 assert |
+| --- | --- |
+| ④ AFTER_COMMIT + 동기 + REQUIRED | `publish()` 예외 없음 / **원본 행 존재 + 리스너 행 부재** (조용한 유실) / `listener.actualTransactionActive() == true` 이면서 `listener.transactionName() == origin.transactionName()` → **이미 커밋된 원본 트랜잭션에 참여했다는 직접 증거** |
+| ⑤ BEFORE_COMMIT + 비동기 + REQUIRES_NEW (정상) | 스레드 다름 / `transactionName` 다름 / `flag("originVisibleToListener") == false` → **"커밋 전 실행"이 무의미함** |
+| ⑤ (리스너 예외) | `publish()` 예외 없음 / **원본 행 생존** → ①과 대조되어 **"원본 개입" 보장이 사라졌음** |
+
+> ④는 DB·드라이버 거동에 따라 "조용한 유실"이 아니라 예외로 나타날 수도 있다. 계획 단계에서 결과를 단정하지 말고, **먼저 실행해 실제 거동을 관찰한 뒤 그 거동을 assert로 고정**하고 분석에 기록한다. 어느 쪽이든 "리스너 행이 남지 않는다"는 결론은 동일하므로, 행 부재를 1차 단언으로 두고 예외 발생 여부는 `recorder.error("listener")`로 부수 기록한다.
+
+### 9. CI 제외 — `build.gradle`
+
+```groovy
+tasks.named('test') {
+    useJUnitPlatform {
+        excludeTags 'experiment'
+    }
+}
+
+tasks.register('experimentTest', Test) {
+    group = 'verification'
+    description = '트랜잭션 이벤트 리스너 조합 실증 테스트 (CI 기본 실행 제외)'
+
+    testClassesDirs = sourceSets.test.output.classesDirs
+    classpath = sourceSets.test.runtimeClasspath
+
+    useJUnitPlatform {
+        includeTags 'experiment'
+    }
+
+    shouldRunAfter tasks.named('test')
+    testLogging { showStandardStreams = true }
+}
+```
+
+`experimentTest`는 `check`/`build`에 연결하지 않는다. CI(`ci-common.yml:25`)는 `./gradlew --info test`를 그대로 돌리므로 태그 제외만으로 스킵된다 — 워크플로 수정 불필요. 로컬 실행은 `./gradlew experimentTest`.
+
+## 결정 필요 (Decisions needed)
+
+- [x] **fixture 빈 등록 방식** — `@TestConfiguration` + `@Import` (`@Component` 스캔 아님).
+  `@Component`면 모든 통합 테스트 컨텍스트에 안티패턴 리스너가 상주한다. `@Import`는 컨텍스트를 포크시켜 Testcontainer가 하나 더 뜨지만, CI에서 제외되는 실험이라 비용은 로컬에 한정된다. 격리를 택한다.
+- [x] **`excludeTags`를 `test` 태스크에 건다** — 로컬 `./gradlew test`에서도 제외된다. CI에만 거는 방식(`-P` 플래그)보다 단순하고, 실험은 명시적으로 `experimentTest`로만 돌리는 게 의도에 맞다.
+- [x] **테스트 클래스 분리** — 권장/안티패턴 2개로 나눈다. 이슈의 표 구조와 1:1 대응하고, PR 분석 본문에서 인용하기 쉽다.
+- [x] **ID 생성 전략** — `IDENTITY` 한 케이스 (이슈 확정 사항).
+
+## 검증
+
+- 대상 테스트: `RecommendedCombinationIntegrationTest` (3조합 × 정상/예외 = 6 시나리오), `AntiPatternCombinationIntegrationTest` (3 시나리오)
+- 실행: `./gradlew experimentTest --info`
+- CI 제외 확인: `./gradlew test --dry-run`에 실험 테스트가 포함되지 않아야 한다
+- 프로덕션 무변경 확인: `git diff --stat`이 `src/main/` 을 건드리지 않아야 한다
+- 관찰 결과(스레드명·트랜잭션명·행 잔존·예외 방향)를 조합별로 정리해 PR 본문 분석의 근거로 남긴다
+
+## 관측 결과
+
+### 관측 결과 ② — AFTER_COMMIT 리스너의 예외는 요청 스레드로 전파되지 않는다 (이슈 본문 표 정정)
+
+이슈 본문과 계획서 모두 "AFTER_COMMIT + 동기 + REQUIRES_NEW는 예외 발생 시 요청 스레드로 전파되어 응답에 반영된다"고 적었으나, **실측 결과 거짓이다.** 예외는 삼켜지고 ERROR 로그만 남는다.
+
+```
+ERROR o.s.t.s.TransactionSynchronizationUtils : TransactionSynchronization.afterCompletion threw exception
+java.lang.IllegalStateException: listener failed
+```
+
+근거 (spring-tx 6.0.13 바이트코드 확인):
+
+1. `TransactionalApplicationListenerSynchronization`이 구현하는 메서드는 `beforeCommit(boolean)`과 `afterCompletion(int)` 둘뿐이다. **`afterCommit()`은 구현하지 않는다.**
+   따라서 `@TransactionalEventListener(AFTER_COMMIT)`은 `afterCommit()`이 아니라 `afterCompletion(STATUS_COMMITTED)` 경로로 실행된다.
+2. `TransactionSynchronizationUtils.invokeAfterCommit`에는 예외 테이블(catch 블록)이 **0개** → 예외가 그대로 전파된다.
+   `TransactionSynchronizationUtils.invokeAfterCompletion`에는 `catch (Throwable)`이 있어 **로깅 후 삼킨다.**
+
+즉 `afterCommit()`에 직접 등록한 raw `TransactionSynchronization`이라면 전파되지만, `@TransactionalEventListener(AFTER_COMMIT)`은 그 경로를 타지 않는다.
+
+**따라야 할 결론**
+
+- "후속 작업의 성패를 사용자 응답에 반영" 이라는 상황은 **AFTER_COMMIT으로는 달성할 수 없다.** 응답에 반영하려면 BEFORE_COMMIT을 쓰거나, 리스너가 아니라 원본 트랜잭션 이후의 명시적 호출로 처리해야 한다.
+- 동기 AFTER_COMMIT과 비동기 AFTER_COMMIT의 실질적 차이는 "예외가 응답에 반영되는가"가 아니라 **요청 스레드 점유 여부(= 응답 지연)와 리스너 간 실행 순서 보장**이다.
+- 프로덕션 영향: `NotificationEventListener`(AFTER_COMMIT + 동기 + REQUIRES_NEW)의 실패는 **요청에 드러나지 않고 ERROR 로그로만 남는다.** 알림 유실을 인지하려면 로그 알람이나 재처리 경로가 필요하다.
+
+또한 이 발견으로 **안티패턴 ④의 판별 지표를 재검토해야 한다.** `triggerAfterCompletion`은 `invokeAfterCompletion` 호출 직전에 `TransactionSynchronizationManager.clearSynchronization()`을 부른다. 따라서 AFTER_COMMIT 리스너 실행 시점에는 동기화가 이미 해제되어 있어, ④(`REQUIRED`)에서도 `isNewSynchronization()`이 참이 되어 `transactionName`이 리스너 메서드명으로 갱신될 가능성이 높다.
+계획서 §8의 "④는 `transactionName`이 원본과 같다"는 지표는 ④ 구현 시 **실측으로 재확인**하고, 어긋나면 다른 판별 지표(예: 리스너가 쓴 행의 유실 여부, `EntityManager` 동일성)로 교체한다.
+
+### 관측 결과 ④ — Spring이 이 안티패턴의 "순진한 형태"는 아예 막는다 (그러나 실전 형태는 못 막는다)
+
+리스너 메서드에 `@TransactionalEventListener(AFTER_COMMIT)` + `@Transactional(propagation = REQUIRED)`를 붙이면 **컨텍스트가 기동조차 하지 않는다.**
+
+```
+IllegalStateException: @TransactionalEventListener method must not be annotated with
+@Transactional unless when declared as REQUIRES_NEW or NOT_SUPPORTED
+  at RestrictedTransactionalEventListenerFactory.createApplicationListener
+```
+
+`RestrictedTransactionalEventListenerFactory` (Spring 6.1+, `AbstractTransactionManagementConfiguration`이 항상 등록):
+
+```java
+if (adapter.getTransactionPhase() != TransactionPhase.BEFORE_COMMIT) {
+    Transactional txAnn = findMergedAnnotation(method, Transactional.class);
+    if (txAnn == null) txAnn = findMergedAnnotation(type, Transactional.class);
+    if (txAnn != null) {
+        Propagation propagation = txAnn.propagation();
+        if (propagation != REQUIRES_NEW && propagation != NOT_SUPPORTED) {
+            throw new IllegalStateException(...);
+        }
+    }
+}
+```
+
+읽어낼 것:
+
+1. **BEFORE_COMMIT은 가드에서 통째로 제외된다.** 그래서 조합 ①(BEFORE_COMMIT + REQUIRED)은 정상 기동한다. Spring이 ①을 정당한 조합으로 인정한다는 뜻이다.
+2. AFTER_COMMIT / AFTER_ROLLBACK / AFTER_COMPLETION에서 `@Transactional`을 쓰려면 `REQUIRES_NEW` 아니면 `NOT_SUPPORTED`여야 한다. 즉 **권장 조합 ②③은 Spring이 강제하는 유일한 선택지**다.
+3. **그러나 가드는 리스너 메서드·클래스의 어노테이션만 검사한다.** 리스너가 *무엇을 호출하는지*는 보지 못한다.
+   `@TransactionalEventListener(AFTER_COMMIT)` (무 `@Transactional`) → `@Transactional(REQUIRED)` 서비스 호출은 가드를 그냥 통과하며, 안티패턴 ④가 그대로 성립한다.
+   **이 레포의 프로덕션 리스너들이 정확히 이 모양이다** (`LearningEventListener` → `LearningCommandService`). 현재는 전부 BEFORE_COMMIT이라 안전하지만, phase만 AFTER_COMMIT으로 바꾸면 컴파일도 기동도 정상인 채로 쓰기가 유실된다.
+   `SimpleJpaRepository`의 메서드들도 `@Transactional`이므로, 리스너에서 리포지토리를 직접 호출하기만 해도 같은 일이 벌어진다.
+
+따라서 ④의 재현은 `@Transactional(REQUIRED)`를 리스너가 호출하는 `ExperimentRecordWriter`에 두는 방식으로 구성했다. 이게 실전에서 실제로 마주치는 형태다.
+
+부수적으로, 리스너 진입 시점(`listener-entry`)의 스레드 상태가 "죽은 트랜잭션"을 직접 보여준다.
+`triggerAfterCompletion`이 `invokeAfterCompletion` 직전에 `clearSynchronization()`을 부르지만 `cleanupAfterCompletion`은 그 뒤에 실행되므로,
+
+- `isSynchronizationActive()` → **false** (동기화는 이미 해제)
+- `isActualTransactionActive()` → **true** (트랜잭션은 살아있다고 보고)
+- `getCurrentTransactionName()` → 원본 그대로 (`clearSynchronization`은 이름을 지우지 않는다)
+- `EntityManagerHolder` → 여전히 바인딩됨
+
+이 어긋난 창이 REQUIRED가 올라타는 지점이다.
+
+### 관측 결과 ④-b — 유실의 실제 기전: INSERT는 롤백된 게 아니라 **발행조차 되지 않는다**
+
+`ExperimentRecordWriter.write()`가 자기 트랜잭션 안에서 방금 쓴 행을 재조회하게 해 확인했다(`listenerWriteVisibleInSameTx`).
+
+**예측**: 같은 커넥션이니 커밋 전이어도 자기가 쓴 행은 보일 것이다(`true`). → INSERT는 DB에 도달했고 커넥션 반납 시 롤백됐다.
+**실측**: **`false`.** 자기 커넥션에서조차 안 보인다. INSERT가 DB에 도달한 적이 없다.
+
+근본 원인은 **Spring과 Hibernate의 인식이 어긋나는 것**이다. AFTER_COMMIT 콜백 구간에서:
+
+| 층 | 판단 |
+| --- | --- |
+| Spring `TransactionSynchronizationManager.isActualTransactionActive()` | **true** (그래서 REQUIRED가 참여한다) |
+| Hibernate `SharedSessionContractImplementor.isTransactionInProgress()` | **false** (원본 `EntityTransaction`은 이미 commit됨) |
+
+Hibernate가 트랜잭션이 없다고 보면 두 가지가 연쇄한다 (hibernate-core 6.6.42 바이트코드 확인):
+
+1. `DefaultPersistEventListener`는 `saveWithGeneratedId(..., requiresImmediateIdAccess = false)`로 호출한다. `AbstractSaveEventListener`는 `EventSource.isTransactionInProgress()`를 물어 identity insert를 **지연**시키고(`EntityIdentityInsertAction.isDelayed`, `DelayedPostInsertIdentifier`), `ActionQueue`에만 넣는다.
+   → `em.persist()`가 INSERT를 즉시 발행하지 않는다. (JPA의 `persist`는 트랜잭션 밖 호출이 합법이라 예외도 없다.)
+2. `SessionImpl.autoFlushIfRequired`는 첫 줄이 `if (!isTransactionInProgress()) return false;` 다.
+   → 이어지는 `existsByTag` 조회가 auto-flush를 유발하지 못해, 큐에 든 INSERT가 실행되지 않는다.
+
+그리고 참여(non-new) 트랜잭션이라 두 번째 커밋도 flush도 없다. 결국 `EntityManager`가 닫히며 `ActionQueue`째로 증발한다.
+
+**세 지표가 함께 "조용한 유실"을 정의한다**
+
+- `listenerWriteVisibleInSameTx` → **false** (INSERT가 발행조차 되지 않았다)
+- 바깥 트랜잭션의 `existsByTag` → **false** (당연히 없다)
+- `traceRecorder.error(LISTENER)` → **비어있다** (그 과정에 예외가 하나도 없었다)
+
+`catch (Exception)`이 `write()`의 예외까지 잡으므로, error가 비어있다는 것은 프레임워크가 아무것도 던지지 않았다는 뜻이다.
+
+> **이것이 "죽은 트랜잭션"의 정확한 의미다.** 커넥션이 살아있어 쓰기가 실행됐다가 롤백되는 게 아니라, Hibernate 세션이 이미 트랜잭션 종료 상태라 **쓰기 명령이 메모리 큐에서 나가지도 못하고 폐기**된다. 롤백 로그조차 남지 않는다.
+
+## Deviation Log
+
+### 조합 ① (BEFORE_COMMIT + 동기 + REQUIRED)
+
+- `fixture/TraceRecorder.java`: `ORIGIN` / `LISTENER` 라벨을 `public static final` 상수로 선언 — 이유: 매직스트링 금지 컨벤션(`common.md`). 리스너·발행자·테스트 세 곳이 같은 라벨을 공유한다.
+- `fixture/ExperimentEvent.java`: `LISTENER_FAILURE_MESSAGE` 상수를 인터페이스에 선언 — 이유: 리스너 5종과 테스트가 같은 예외 메시지를 공유하므로 계약에 두는 게 맞다.
+- `fixture/TraceRecorder.java`: 계획에 없던 `traces()` 접근자 추가 — 이유: 이슈의 목적이 "내 눈으로 확인"이므로 테스트 `@AfterEach`에서 수집된 trace를 `[TRACE]` 로 출력한다.
+- 구현 순서: 사용자 요청에 따라 조합 ①→⑤를 한 단계씩 구현·관측한다. `ExperimentGate`, `experimentAsync` Executor, 나머지 리스너 4종은 해당 단계에서 추가한다 (계획 내용 변경 아님, 투입 시점만 분할).
+
+### 조합 ② (AFTER_COMMIT + 동기 + REQUIRES_NEW)
+
+- `listener/AfterCommitSyncNewTxListener.java`: 계획에서 ⑤ 전용이던 `originVisibleToListener` flag를 ②에도 기록 — 이유: ②는 `true`(원본 커밋 후 실행), ⑤는 `false`(원본 미커밋)로 정확히 대조된다. 같은 `REQUIRES_NEW`인데 phase만 달라 가시성이 갈린다는 걸 한 지표로 보여준다.
+- `fixture/TraceRecorder.java`: `ORIGIN_VISIBLE_TO_LISTENER` flag 키 상수와 `flags()` 접근자 추가 — 이유: 위 flag를 리스너·테스트가 공유하고, `@AfterEach`에서 `[FLAG ]` 로 출력하기 위함.
+- `listener/AfterCommitSyncNewTxListener.java`: 계획에 없던 `try/catch` + `captureError` + 재던지기 추가 — 이유: 예외가 `invokeAfterCompletion`에 삼켜져 테스트에서 관측 불가능하므로, 기록 후 재던져 삼켜지는 경로를 보존해야 한다.
+- `RecommendedCombinationIntegrationTest`: ②의 예외 케이스 단언을 `assertThatThrownBy` → `assertThatCode(...).doesNotThrowAnyException()` + `traceRecorder.error(LISTENER)` 검증으로 교체 — 이유: **계획의 예측이 실측과 달랐다.** 위 "관측 결과 ②" 참조.
+
+### 조합 ③ (AFTER_COMMIT + 비동기 + REQUIRES_NEW)
+
+- `ExperimentFixtureConfig`: `EXPERIMENT_ASYNC_EXECUTOR` / `EXPERIMENT_ASYNC_THREAD_PREFIX` 를 `public static final` 로 노출 — 이유: Executor 정의와 테스트의 스레드명 단언이 같은 문자열을 공유한다.
+- `listener/AfterCommitAsyncNewTxListener.java`: `originVisibleToListener` flag를 ③에도 기록 — 이유: ②(같은 스레드·다른 트랜잭션)와 ③(다른 스레드·다른 트랜잭션)이 모두 `true`임을 보여, ⑤의 `false`가 스레드 때문이 아니라 **phase 때문**임을 분리해낸다.
+- `fixture/TraceRecorder.java`: `errors()` 접근자 추가 — 이유: `@AfterEach`에서 `[ERROR]` 로 출력해 삼켜진 예외를 눈으로 확인한다.
+
+### 조합 ④ (AFTER_COMMIT + 동기 + REQUIRED, 안티패턴)
+
+- `fixture/ExecutionTrace.java`: `entityManagerId` 필드 추가, `here(label, EntityManagerFactory)` 로 시그니처 변경 — 이유: **"관측 결과 ②"에서 예고한 지표 교체.** `transactionName`은 ④에서 새 트랜잭션인 것처럼 갱신되어 판별에 쓸 수 없다. `TransactionSynchronizationManager.getResource(emf)`로 얻은 `EntityManagerHolder`의 `EntityManager` 인스턴스 동일성이 "같은 트랜잭션(=같은 커넥션)에 참여했는가"를 직접 말해준다. 계획서 §8이 예비해 둔 대안 그대로다.
+- `fixture/TraceRecorder.java`: `EntityManagerFactory` 주입 (`@RequiredArgsConstructor`) — 이유: 위 지표를 얻으려면 조회 키가 필요하다. 리스너 쪽 호출부(`capture(label)`)는 그대로다.
+- `RecommendedCombinationIntegrationTest`: ①에 `entityManagerId` 동일, ②③에 상이 단언 추가 — 이유: ④의 "동일"이 무엇과 대조되는지 없으면 증거가 되지 못한다.
+- `AntiPatternCombinationIntegrationTest`: ④는 예외를 던지지 않는 시나리오만 둔다 — 이유: 안티패턴의 핵심은 "정상 경로인데도 쓰기가 사라진다"이며, 예외 시나리오는 어차피 `invokeAfterCompletion`이 삼켜 ②와 구분되지 않는다.
+- **`fixture/ExperimentRecordWriter.java` 신규 추가, ④ 리스너에서 `@Transactional` 제거** — 이유: **계획대로 짜면 컨텍스트가 기동하지 않는다.** `RestrictedTransactionalEventListenerFactory`가 AFTER_COMMIT 리스너의 non-REQUIRES_NEW `@Transactional`을 거부한다. 위 "관측 결과 ④" 참조. REQUIRED를 리스너가 호출하는 서비스로 옮겨 프로덕션과 같은 형태로 재현한다.
+- `fixture/TraceRecorder.java`: `LISTENER_ENTRY` 라벨 추가 — 이유: `@Transactional` 진입 전 스레드 상태를 찍어야 "동기화는 해제됐는데 트랜잭션은 살아있다"는 죽은 트랜잭션 창이 드러난다.
+- `AntiPatternCombinationIntegrationTest`: `리스너_진입_시점의_스레드에는_커밋이_끝난_원본_트랜잭션이_그대로_남아있다()` 테스트 추가 — 이유: 위 창을 직접 단언한다.
+- `fixture/ExecutionTrace.java`: `hibernateTransactionInProgress` 필드 추가 (`em.unwrap(SharedSessionContractImplementor.class).isTransactionInProgress()`) — 이유: **`listenerWriteVisibleInSameTx`가 예측(true)과 달리 false로 나왔다.** 그 원인이 "Spring은 트랜잭션이 살아있다 하고 Hibernate는 끝났다 한다"는 층간 불일치임을 드러내는 단일 설명 변수다. ①②③에서는 `true`, ④에서만 `false`. 위 "관측 결과 ④-b" 참조.
+- `AntiPatternCombinationIntegrationTest`: 테스트명을 `리스너의_INSERT가_DB에_도달하고도_...` → `리스너의_쓰기가_INSERT조차_발행되지_못한_채_예외_하나_없이_사라진다` 로 변경 — 이유: 실측이 기전을 뒤집었다.
+
+### 조합 ⑤ (BEFORE_COMMIT + 비동기 + REQUIRES_NEW, 안티패턴)
+
+- `fixture/ExperimentGate.java`, `listener/BeforeCommitAsyncNewTxListener.java`: 계획서 §6 설계 그대로 구현. `@Order(1)` 비동기 리스너 + `@Order(2)` 게이트 리스너.
+  `@Order`가 실제로 콜백 순서를 지배함을 확인했다: `ApplicationListenerMethodAdapter.resolveOrder(Method)`가 메서드의 `@Order`를 읽고, `TransactionSynchronizationManager.getSynchronizations()`가 `OrderComparator.sort()`로 정렬해 반환한다.
+- 게이트 타임아웃을 계획서의 2초 → **5초**로 상향 — 이유: 타임아웃이 먼저 끝나면 원본이 커밋되어 `originVisibleToListener`가 true로 뒤집히는 위양성(flaky)이 난다. 넉넉히 잡아도 정상 경로에서는 즉시 통과한다.
+- `AntiPatternCombinationIntegrationTest.setUp()`에 `experimentGate.reset()` 추가 — 이유: 래치가 열린 채로 다음 테스트에 넘어가면 게이트가 즉시 통과되어 관찰 창이 닫힌다.
+- ⑤는 `@Transactional(REQUIRES_NEW)`를 리스너 메서드에 직접 붙여도 된다 — `RestrictedTransactionalEventListenerFactory`의 가드는 BEFORE_COMMIT을 건너뛰고, REQUIRES_NEW는 애초에 허용 목록이다. **Spring은 ⑤를 막지 못한다.**
+- `TraceRecorder.GATE_HELD_UNTIL_LISTENER_READ` flag 추가, `holdOriginUncommitted`가 `awaitListenerRead`의 반환값을 기록 — 이유: 실험의 **전제 자체를 검증되지 않은 채로 두고 있었다.** 게이트가 신호가 아니라 타임아웃으로 풀리면 원본이 먼저 커밋되어 `originVisibleToListener`가 true로 뒤집힐 수 있다. 두 테스트 모두 이 flag를 `isTrue()`로 먼저 단언한다.
+
+> **⑤의 시간 순서는 `await`가 아니라 래치가 만든다.**
+> `publish()`는 동기 호출이라 반환 시점에 원본은 이미 커밋되어 있다. 그러나 `holdOriginUncommitted`는 `triggerBeforeCommit` 안에서 실행되므로 `doCommit`보다 앞서고, 여기서 대기하는 동안 원본은 확실히 미커밋이다.
+> 비동기 리스너는 그 창에서 조회·기록하고 `finally`에서 래치를 내린다. 따라서 `originVisibleToListener`가 **기록되는 순간**이 원본 커밋 이전임이 보장된다.
+> 테스트의 `await(...)`는 순서를 만들지 않는다. 비동기 리스너의 *자기 트랜잭션*이 커밋됐는지(`existsByTag(LISTENER_TAG)`)를 기다리는 별개의 관심사다.
+>
+> 예외 케이스에서도 게이트가 필요하다. 게이트가 없으면 원본이 먼저 커밋된 뒤 리스너가 실패할 수 있고, 그러면 "커밋 전에 실패했는데도 원본이 커밋된다"는 명제가 성립하지 않는다.

--- a/.claude/resources/plans/PLAN-432.md
+++ b/.claude/resources/plans/PLAN-432.md
@@ -94,7 +94,7 @@ public interface ExperimentEvent {
 }
 ```
 
-### 4. 관찰 하니스
+### 4. 관찰용 fixture
 
 `ExecutionTrace` — 실행 시점 스냅샷. **`getCurrentTransactionName()`이 조합을 가르는 핵심 신호**다. 원본 트랜잭션에 참여하면 발행자 메서드의 FQN이, 신규 트랜잭션이면 리스너 메서드의 FQN이 담긴다.
 
@@ -279,11 +279,11 @@ public class ExperimentFixtureConfig {
 
 | `@Nested` | 핵심 assert |
 | --- | --- |
-| ④ AFTER_COMMIT + 동기 + REQUIRED | `publish()` 예외 없음 / **원본 행 존재 + 리스너 행 부재** (조용한 유실) / `listener.actualTransactionActive() == true` 이면서 `listener.transactionName() == origin.transactionName()` → **이미 커밋된 원본 트랜잭션에 참여했다는 직접 증거** |
+| ④ AFTER_COMMIT + 동기 + REQUIRED | `publish()` 예외 없음 / **원본 행 존재 + 리스너 행 부재** (예외 없이 쓰기 유실) / `listener.actualTransactionActive() == true` 이면서 `listener.transactionName() == origin.transactionName()` → **이미 커밋된 원본 트랜잭션에 참여했다는 직접 증거** |
 | ⑤ BEFORE_COMMIT + 비동기 + REQUIRES_NEW (정상) | 스레드 다름 / `transactionName` 다름 / `flag("originVisibleToListener") == false` → **"커밋 전 실행"이 무의미함** |
 | ⑤ (리스너 예외) | `publish()` 예외 없음 / **원본 행 생존** → ①과 대조되어 **"원본 개입" 보장이 사라졌음** |
 
-> ④는 DB·드라이버 거동에 따라 "조용한 유실"이 아니라 예외로 나타날 수도 있다. 계획 단계에서 결과를 단정하지 말고, **먼저 실행해 실제 거동을 관찰한 뒤 그 거동을 assert로 고정**하고 분석에 기록한다. 어느 쪽이든 "리스너 행이 남지 않는다"는 결론은 동일하므로, 행 부재를 1차 단언으로 두고 예외 발생 여부는 `recorder.error("listener")`로 부수 기록한다.
+> ④는 DB·드라이버 거동에 따라 예외 없는 쓰기 유실이 아니라 예외로 나타날 수도 있다. 계획 단계에서 결과를 단정하지 말고, **먼저 실행해 실제 거동을 관찰한 뒤 그 거동을 assert로 고정**하고 분석에 기록한다. 어느 쪽이든 "리스너 행이 남지 않는다"는 결론은 동일하므로, 행 부재를 1차 단언으로 두고 예외 발생 여부는 `recorder.error("listener")`로 부수 기록한다.
 
 ### 9. CI 제외 — `build.gradle`
 
@@ -339,7 +339,7 @@ ERROR o.s.t.s.TransactionSynchronizationUtils : TransactionSynchronization.after
 java.lang.IllegalStateException: listener failed
 ```
 
-근거 (spring-tx 6.0.13 바이트코드 확인):
+근거 (spring-tx 6.2.16 바이트코드 확인):
 
 1. `TransactionalApplicationListenerSynchronization`이 구현하는 메서드는 `beforeCommit(boolean)`과 `afterCompletion(int)` 둘뿐이다. **`afterCommit()`은 구현하지 않는다.**
    따라서 `@TransactionalEventListener(AFTER_COMMIT)`은 `afterCommit()`이 아니라 `afterCompletion(STATUS_COMMITTED)` 경로로 실행된다.
@@ -357,7 +357,7 @@ java.lang.IllegalStateException: listener failed
 또한 이 발견으로 **안티패턴 ④의 판별 지표를 재검토해야 한다.** `triggerAfterCompletion`은 `invokeAfterCompletion` 호출 직전에 `TransactionSynchronizationManager.clearSynchronization()`을 부른다. 따라서 AFTER_COMMIT 리스너 실행 시점에는 동기화가 이미 해제되어 있어, ④(`REQUIRED`)에서도 `isNewSynchronization()`이 참이 되어 `transactionName`이 리스너 메서드명으로 갱신될 가능성이 높다.
 계획서 §8의 "④는 `transactionName`이 원본과 같다"는 지표는 ④ 구현 시 **실측으로 재확인**하고, 어긋나면 다른 판별 지표(예: 리스너가 쓴 행의 유실 여부, `EntityManager` 동일성)로 교체한다.
 
-### 관측 결과 ④ — Spring이 이 안티패턴의 "순진한 형태"는 아예 막는다 (그러나 실전 형태는 못 막는다)
+### 관측 결과 ④ — Spring은 리스너 메서드에 직접 붙인 경우만 막는다 (호출하는 메서드까지는 못 막는다)
 
 리스너 메서드에 `@TransactionalEventListener(AFTER_COMMIT)` + `@Transactional(propagation = REQUIRED)`를 붙이면 **컨텍스트가 기동조차 하지 않는다.**
 
@@ -384,16 +384,16 @@ if (adapter.getTransactionPhase() != TransactionPhase.BEFORE_COMMIT) {
 
 읽어낼 것:
 
-1. **BEFORE_COMMIT은 가드에서 통째로 제외된다.** 그래서 조합 ①(BEFORE_COMMIT + REQUIRED)은 정상 기동한다. Spring이 ①을 정당한 조합으로 인정한다는 뜻이다.
+1. **BEFORE_COMMIT은 이 검증 대상에서 제외된다.** 그래서 조합 ①(BEFORE_COMMIT + REQUIRED)은 정상 기동한다. Spring이 ①을 정당한 조합으로 인정한다는 뜻이다.
 2. AFTER_COMMIT / AFTER_ROLLBACK / AFTER_COMPLETION에서 `@Transactional`을 쓰려면 `REQUIRES_NEW` 아니면 `NOT_SUPPORTED`여야 한다. 즉 **권장 조합 ②③은 Spring이 강제하는 유일한 선택지**다.
-3. **그러나 가드는 리스너 메서드·클래스의 어노테이션만 검사한다.** 리스너가 *무엇을 호출하는지*는 보지 못한다.
-   `@TransactionalEventListener(AFTER_COMMIT)` (무 `@Transactional`) → `@Transactional(REQUIRED)` 서비스 호출은 가드를 그냥 통과하며, 안티패턴 ④가 그대로 성립한다.
-   **이 레포의 프로덕션 리스너들이 정확히 이 모양이다** (`LearningEventListener` → `LearningCommandService`). 현재는 전부 BEFORE_COMMIT이라 안전하지만, phase만 AFTER_COMMIT으로 바꾸면 컴파일도 기동도 정상인 채로 쓰기가 유실된다.
-   `SimpleJpaRepository`의 메서드들도 `@Transactional`이므로, 리스너에서 리포지토리를 직접 호출하기만 해도 같은 일이 벌어진다.
+3. **그러나 이 검증은 리스너 메서드·클래스에 붙은 어노테이션만 본다.** 리스너가 *무엇을 호출하는지*는 보지 않는다.
+   `@TransactionalEventListener(AFTER_COMMIT)` (`@Transactional` 없음) → `@Transactional(REQUIRED)` 서비스 호출은 검증을 그대로 통과하며, 안티패턴 ④가 성립한다.
+   **이 레포의 프로덕션 리스너들이 정확히 이 형태다** (`LearningEventListener` → `LearningCommandService`). 현재는 전부 BEFORE_COMMIT이라 안전하지만, phase만 AFTER_COMMIT으로 바꾸면 컴파일도 기동도 정상인 채로 쓰기가 유실된다.
+   `SimpleJpaRepository`의 메서드에도 `@Transactional`이 붙어 있으므로, 리스너에서 리포지토리를 직접 호출하기만 해도 같은 일이 벌어진다.
 
 따라서 ④의 재현은 `@Transactional(REQUIRED)`를 리스너가 호출하는 `ExperimentRecordWriter`에 두는 방식으로 구성했다. 이게 실전에서 실제로 마주치는 형태다.
 
-부수적으로, 리스너 진입 시점(`listener-entry`)의 스레드 상태가 "죽은 트랜잭션"을 직접 보여준다.
+부수적으로, 리스너 진입 시점(`listener-entry`)의 스레드 상태가 "이미 커밋이 끝났는데도 남아 있는 원본 트랜잭션"을 직접 보여준다.
 `triggerAfterCompletion`이 `invokeAfterCompletion` 직전에 `clearSynchronization()`을 부르지만 `cleanupAfterCompletion`은 그 뒤에 실행되므로,
 
 - `isSynchronizationActive()` → **false** (동기화는 이미 해제)
@@ -401,7 +401,7 @@ if (adapter.getTransactionPhase() != TransactionPhase.BEFORE_COMMIT) {
 - `getCurrentTransactionName()` → 원본 그대로 (`clearSynchronization`은 이름을 지우지 않는다)
 - `EntityManagerHolder` → 여전히 바인딩됨
 
-이 어긋난 창이 REQUIRED가 올라타는 지점이다.
+REQUIRED는 바로 이 구간에서 "기존 트랜잭션이 있다"고 판단해 참여한다.
 
 ### 관측 결과 ④-b — 유실의 실제 기전: INSERT는 롤백된 게 아니라 **발행조차 되지 않는다**
 
@@ -410,9 +410,9 @@ if (adapter.getTransactionPhase() != TransactionPhase.BEFORE_COMMIT) {
 **예측**: 같은 커넥션이니 커밋 전이어도 자기가 쓴 행은 보일 것이다(`true`). → INSERT는 DB에 도달했고 커넥션 반납 시 롤백됐다.
 **실측**: **`false`.** 자기 커넥션에서조차 안 보인다. INSERT가 DB에 도달한 적이 없다.
 
-근본 원인은 **Spring과 Hibernate의 인식이 어긋나는 것**이다. AFTER_COMMIT 콜백 구간에서:
+근본 원인은 **Spring과 Hibernate가 트랜잭션 상태를 다르게 판단하는 것**이다. AFTER_COMMIT 콜백 구간에서:
 
-| 층 | 판단 |
+| | 판단 |
 | --- | --- |
 | Spring `TransactionSynchronizationManager.isActualTransactionActive()` | **true** (그래서 REQUIRED가 참여한다) |
 | Hibernate `SharedSessionContractImplementor.isTransactionInProgress()` | **false** (원본 `EntityTransaction`은 이미 commit됨) |
@@ -424,9 +424,9 @@ Hibernate가 트랜잭션이 없다고 보면 두 가지가 연쇄한다 (hibern
 2. `SessionImpl.autoFlushIfRequired`는 첫 줄이 `if (!isTransactionInProgress()) return false;` 다.
    → 이어지는 `existsByTag` 조회가 auto-flush를 유발하지 못해, 큐에 든 INSERT가 실행되지 않는다.
 
-그리고 참여(non-new) 트랜잭션이라 두 번째 커밋도 flush도 없다. 결국 `EntityManager`가 닫히며 `ActionQueue`째로 증발한다.
+그리고 참여(non-new) 트랜잭션이라 두 번째 커밋도 flush도 없다. 결국 `EntityManager`가 닫히면서 `ActionQueue`에 담긴 INSERT째로 사라진다.
 
-**세 지표가 함께 "조용한 유실"을 정의한다**
+**세 지표가 함께 "예외 없는 쓰기 유실"을 정의한다**
 
 - `listenerWriteVisibleInSameTx` → **false** (INSERT가 발행조차 되지 않았다)
 - 바깥 트랜잭션의 `existsByTag` → **false** (당연히 없다)
@@ -434,7 +434,7 @@ Hibernate가 트랜잭션이 없다고 보면 두 가지가 연쇄한다 (hibern
 
 `catch (Exception)`이 `write()`의 예외까지 잡으므로, error가 비어있다는 것은 프레임워크가 아무것도 던지지 않았다는 뜻이다.
 
-> **이것이 "죽은 트랜잭션"의 정확한 의미다.** 커넥션이 살아있어 쓰기가 실행됐다가 롤백되는 게 아니라, Hibernate 세션이 이미 트랜잭션 종료 상태라 **쓰기 명령이 메모리 큐에서 나가지도 못하고 폐기**된다. 롤백 로그조차 남지 않는다.
+> **유실의 정확한 의미는 이렇다.** 커넥션이 살아있어 쓰기가 실행됐다가 롤백되는 게 아니다. Hibernate 세션이 이미 트랜잭션 종료 상태라 **쓰기 명령이 메모리 큐에서 나가지도 못하고 폐기**된다. 롤백 로그조차 남지 않는다.
 
 ## Deviation Log
 
@@ -465,9 +465,9 @@ Hibernate가 트랜잭션이 없다고 보면 두 가지가 연쇄한다 (hibern
 - `RecommendedCombinationIntegrationTest`: ①에 `entityManagerId` 동일, ②③에 상이 단언 추가 — 이유: ④의 "동일"이 무엇과 대조되는지 없으면 증거가 되지 못한다.
 - `AntiPatternCombinationIntegrationTest`: ④는 예외를 던지지 않는 시나리오만 둔다 — 이유: 안티패턴의 핵심은 "정상 경로인데도 쓰기가 사라진다"이며, 예외 시나리오는 어차피 `invokeAfterCompletion`이 삼켜 ②와 구분되지 않는다.
 - **`fixture/ExperimentRecordWriter.java` 신규 추가, ④ 리스너에서 `@Transactional` 제거** — 이유: **계획대로 짜면 컨텍스트가 기동하지 않는다.** `RestrictedTransactionalEventListenerFactory`가 AFTER_COMMIT 리스너의 non-REQUIRES_NEW `@Transactional`을 거부한다. 위 "관측 결과 ④" 참조. REQUIRED를 리스너가 호출하는 서비스로 옮겨 프로덕션과 같은 형태로 재현한다.
-- `fixture/TraceRecorder.java`: `LISTENER_ENTRY` 라벨 추가 — 이유: `@Transactional` 진입 전 스레드 상태를 찍어야 "동기화는 해제됐는데 트랜잭션은 살아있다"는 죽은 트랜잭션 창이 드러난다.
+- `fixture/TraceRecorder.java`: `LISTENER_ENTRY` 라벨 추가 — 이유: `@Transactional` 진입 전 스레드 상태를 찍어야 "동기화는 해제됐는데 트랜잭션은 살아있다고 보고되는" 구간이 드러난다.
 - `AntiPatternCombinationIntegrationTest`: `리스너_진입_시점의_스레드에는_커밋이_끝난_원본_트랜잭션이_그대로_남아있다()` 테스트 추가 — 이유: 위 창을 직접 단언한다.
-- `fixture/ExecutionTrace.java`: `hibernateTransactionInProgress` 필드 추가 (`em.unwrap(SharedSessionContractImplementor.class).isTransactionInProgress()`) — 이유: **`listenerWriteVisibleInSameTx`가 예측(true)과 달리 false로 나왔다.** 그 원인이 "Spring은 트랜잭션이 살아있다 하고 Hibernate는 끝났다 한다"는 층간 불일치임을 드러내는 단일 설명 변수다. ①②③에서는 `true`, ④에서만 `false`. 위 "관측 결과 ④-b" 참조.
+- `fixture/ExecutionTrace.java`: `hibernateTransactionInProgress` 필드 추가 (`em.unwrap(SharedSessionContractImplementor.class).isTransactionInProgress()`) — 이유: **`listenerWriteVisibleInSameTx`가 예측(true)과 달리 false로 나왔다.** 그 원인이 "Spring은 트랜잭션이 살아있다고 보고, Hibernate는 끝났다고 본다"는 상태 불일치임을 드러내는 단일 설명 변수다. ①②③에서는 `true`, ④에서만 `false`. 위 "관측 결과 ④-b" 참조.
 - `AntiPatternCombinationIntegrationTest`: 테스트명을 `리스너의_INSERT가_DB에_도달하고도_...` → `리스너의_쓰기가_INSERT조차_발행되지_못한_채_예외_하나_없이_사라진다` 로 변경 — 이유: 실측이 기전을 뒤집었다.
 
 ### 조합 ⑤ (BEFORE_COMMIT + 비동기 + REQUIRES_NEW, 안티패턴)
@@ -476,7 +476,7 @@ Hibernate가 트랜잭션이 없다고 보면 두 가지가 연쇄한다 (hibern
   `@Order`가 실제로 콜백 순서를 지배함을 확인했다: `ApplicationListenerMethodAdapter.resolveOrder(Method)`가 메서드의 `@Order`를 읽고, `TransactionSynchronizationManager.getSynchronizations()`가 `OrderComparator.sort()`로 정렬해 반환한다.
 - 게이트 타임아웃을 계획서의 2초 → **5초**로 상향 — 이유: 타임아웃이 먼저 끝나면 원본이 커밋되어 `originVisibleToListener`가 true로 뒤집히는 위양성(flaky)이 난다. 넉넉히 잡아도 정상 경로에서는 즉시 통과한다.
 - `AntiPatternCombinationIntegrationTest.setUp()`에 `experimentGate.reset()` 추가 — 이유: 래치가 열린 채로 다음 테스트에 넘어가면 게이트가 즉시 통과되어 관찰 창이 닫힌다.
-- ⑤는 `@Transactional(REQUIRES_NEW)`를 리스너 메서드에 직접 붙여도 된다 — `RestrictedTransactionalEventListenerFactory`의 가드는 BEFORE_COMMIT을 건너뛰고, REQUIRES_NEW는 애초에 허용 목록이다. **Spring은 ⑤를 막지 못한다.**
+- ⑤는 `@Transactional(REQUIRES_NEW)`를 리스너 메서드에 직접 붙여도 된다 — `RestrictedTransactionalEventListenerFactory`의 검증은 BEFORE_COMMIT을 건너뛰고, REQUIRES_NEW는 애초에 허용 목록이다. **Spring은 ⑤를 막지 못한다.**
 - `TraceRecorder.GATE_HELD_UNTIL_LISTENER_READ` flag 추가, `holdOriginUncommitted`가 `awaitListenerRead`의 반환값을 기록 — 이유: 실험의 **전제 자체를 검증되지 않은 채로 두고 있었다.** 게이트가 신호가 아니라 타임아웃으로 풀리면 원본이 먼저 커밋되어 `originVisibleToListener`가 true로 뒤집힐 수 있다. 두 테스트 모두 이 flag를 `isTrue()`로 먼저 단언한다.
 
 > **⑤의 시간 순서는 `await`가 아니라 래치가 만든다.**

--- a/build.gradle
+++ b/build.gradle
@@ -110,5 +110,25 @@ tasks.named('bootJar') {
 }
 
 tasks.named('test') {
-    useJUnitPlatform()
+    useJUnitPlatform {
+        excludeTags 'experiment'
+    }
+}
+
+tasks.register('experimentTest', Test) {
+    group = 'verification'
+    description = '트랜잭션 이벤트 리스너 조합 실증 테스트 (CI 기본 실행 제외)'
+
+    testClassesDirs = sourceSets.test.output.classesDirs
+    classpath = sourceSets.test.runtimeClasspath
+
+    useJUnitPlatform {
+        includeTags 'experiment'
+    }
+
+    shouldRunAfter tasks.named('test')
+    testLogging {
+        showStandardStreams = true
+        events 'passed', 'failed', 'skipped'
+    }
 }

--- a/src/test/java/gravit/code/experiment/txevent/AntiPatternCombinationIntegrationTest.java
+++ b/src/test/java/gravit/code/experiment/txevent/AntiPatternCombinationIntegrationTest.java
@@ -95,12 +95,12 @@ class AntiPatternCombinationIntegrationTest {
                 // 그래서 identity insert가 지연되고 auto-flush도 없다 → INSERT 미발행
                 softly.assertThat(traceRecorder.flag(LISTENER_WRITE_VISIBLE_IN_SAME_TX)).isFalse();
 
-                // 롤백이 아니라 ActionQueue에서 증발. 예외조차 없다
+                // 롤백이 아니라 ActionQueue에 담긴 채 폐기된다. 예외조차 없다
                 softly.assertThat(experimentRecordRepository.existsByTag(ORIGIN_TAG)).isTrue();
                 softly.assertThat(experimentRecordRepository.existsByTag(LISTENER_TAG)).isFalse();
                 softly.assertThat(traceRecorder.error(LISTENER)).isEmpty();
 
-                // 새 트랜잭션이 아니라 죽은 원본에 올라탔다
+                // 새 트랜잭션이 아니라, 이미 커밋이 끝난 원본 트랜잭션에 참여했다
                 softly.assertThat(listener.entityManagerId()).isEqualTo(origin.entityManagerId());
                 softly.assertThat(listener.threadName()).isEqualTo(origin.threadName());
 
@@ -128,7 +128,7 @@ class AntiPatternCombinationIntegrationTest {
                 softly.assertThat(listenerEntry.synchronizationActive()).isFalse();
 
                 // 그런데 Spring은 트랜잭션이 아직 살아있다고 보고한다. cleanupAfterCompletion이 뒤에 실행되기 때문이다.
-                // 이 어긋난 창이 바로 REQUIRED가 올라타는 "죽은 트랜잭션"이다.
+                // REQUIRED는 이 구간에서 "기존 트랜잭션이 있다"고 판단해 참여한다.
                 softly.assertThat(listenerEntry.actualTransactionActive()).isTrue();
                 softly.assertThat(listenerEntry.transactionName()).isEqualTo(origin.transactionName());
                 softly.assertThat(listenerEntry.entityManagerId()).isEqualTo(origin.entityManagerId());

--- a/src/test/java/gravit/code/experiment/txevent/AntiPatternCombinationIntegrationTest.java
+++ b/src/test/java/gravit/code/experiment/txevent/AntiPatternCombinationIntegrationTest.java
@@ -1,0 +1,203 @@
+package gravit.code.experiment.txevent;
+
+import gravit.code.experiment.txevent.fixture.ExecutionTrace;
+import gravit.code.experiment.txevent.fixture.ExperimentEvent;
+import gravit.code.experiment.txevent.fixture.ExperimentGate;
+import gravit.code.experiment.txevent.fixture.ExperimentPublisher;
+import gravit.code.experiment.txevent.fixture.ExperimentRecordRepository;
+import gravit.code.experiment.txevent.fixture.ExperimentRecordWriter;
+import gravit.code.experiment.txevent.fixture.TraceRecorder;
+import gravit.code.support.TCSpringBootTest;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Nested;
+import org.junit.jupiter.api.Tag;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.context.annotation.Import;
+
+import java.time.Duration;
+
+import static gravit.code.experiment.txevent.ExperimentFixtureConfig.EXPERIMENT_ASYNC_THREAD_PREFIX;
+import static gravit.code.experiment.txevent.fixture.TraceRecorder.GATE_HELD_UNTIL_LISTENER_READ;
+import static gravit.code.experiment.txevent.fixture.TraceRecorder.LISTENER;
+import static gravit.code.experiment.txevent.fixture.TraceRecorder.LISTENER_ENTRY;
+import static gravit.code.experiment.txevent.fixture.TraceRecorder.LISTENER_WRITE_VISIBLE_IN_SAME_TX;
+import static gravit.code.experiment.txevent.fixture.TraceRecorder.ORIGIN;
+import static gravit.code.experiment.txevent.fixture.TraceRecorder.ORIGIN_VISIBLE_TO_LISTENER;
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatCode;
+import static org.assertj.core.api.SoftAssertions.assertSoftly;
+import static org.awaitility.Awaitility.await;
+
+/**
+ * 안티패턴 조합 검증. "부작용이 실제로 나는지"를 관찰한다.
+ */
+@Tag("experiment")
+@TCSpringBootTest
+@Import(ExperimentFixtureConfig.class)
+class AntiPatternCombinationIntegrationTest {
+
+    private static final String ORIGIN_TAG = "origin-record";
+    private static final String LISTENER_TAG = "listener-record";
+    private static final Duration AWAIT_TIMEOUT = Duration.ofSeconds(3);
+
+    @Autowired
+    private ExperimentPublisher experimentPublisher;
+
+    @Autowired
+    private ExperimentRecordRepository experimentRecordRepository;
+
+    @Autowired
+    private TraceRecorder traceRecorder;
+
+    @Autowired
+    private ExperimentGate experimentGate;
+
+    @BeforeEach
+    void setUp() {
+        traceRecorder.reset();
+
+        // 리셋하지 않으면 이전 테스트가 열어둔 래치 때문에 게이트가 즉시 통과되어 관찰 창이 닫힌다.
+        experimentGate.reset();
+    }
+
+    @AfterEach
+    void printTraces() {
+        traceRecorder.traces().values().forEach(trace -> System.out.println("[TRACE] " + trace));
+        traceRecorder.flags().forEach((key, value) -> System.out.println("[FLAG] " + key + " = " + value));
+        traceRecorder.errors().forEach((label, error) -> System.out.println("[ERROR] " + label + " -> " + error));
+    }
+
+    @Nested
+    @DisplayName("AFTER_COMMIT + 동기 + REQUIRED 조합에서 (안티패턴)")
+    class AfterCommitSyncRequired {
+
+        @Test
+        void 리스너의_쓰기가_INSERT조차_발행되지_못한_채_예외_하나_없이_사라진다() {
+            // given: 리스너는 예외를 던지지 않는다
+            ExperimentEvent event = new ExperimentEvent.AfterCommitSyncRequired(ORIGIN_TAG, LISTENER_TAG, false);
+
+            // when: 호출자는 아무 이상도 감지하지 못한다
+            assertThatCode(() -> experimentPublisher.publish(event)).doesNotThrowAnyException();
+
+            // then
+            ExecutionTrace origin = traceRecorder.trace(ORIGIN);
+            ExecutionTrace listener = traceRecorder.trace(LISTENER);
+
+            assertSoftly(softly -> {
+                // Spring은 트랜잭션이 살아있다 하고, Hibernate는 이미 끝났다 한다
+                softly.assertThat(listener.actualTransactionActive()).isTrue();
+                softly.assertThat(listener.hibernateTransactionInProgress()).isFalse();
+                softly.assertThat(origin.hibernateTransactionInProgress()).isTrue();
+
+                // 그래서 identity insert가 지연되고 auto-flush도 없다 → INSERT 미발행
+                softly.assertThat(traceRecorder.flag(LISTENER_WRITE_VISIBLE_IN_SAME_TX)).isFalse();
+
+                // 롤백이 아니라 ActionQueue에서 증발. 예외조차 없다
+                softly.assertThat(experimentRecordRepository.existsByTag(ORIGIN_TAG)).isTrue();
+                softly.assertThat(experimentRecordRepository.existsByTag(LISTENER_TAG)).isFalse();
+                softly.assertThat(traceRecorder.error(LISTENER)).isEmpty();
+
+                // 새 트랜잭션이 아니라 죽은 원본에 올라탔다
+                softly.assertThat(listener.entityManagerId()).isEqualTo(origin.entityManagerId());
+                softly.assertThat(listener.threadName()).isEqualTo(origin.threadName());
+
+                // 함정: 트랜잭션명만 새것처럼 갱신된다
+                softly.assertThat(listener.transactionName()).isNotEqualTo(origin.transactionName());
+                softly.assertThat(listener.transactionName()).contains(ExperimentRecordWriter.class.getSimpleName());
+                softly.assertThat(listener.synchronizationActive()).isTrue();
+            });
+        }
+
+        @Test
+        void 리스너_진입_시점의_스레드에는_커밋이_끝난_원본_트랜잭션이_그대로_남아있다() {
+            // given
+            ExperimentEvent event = new ExperimentEvent.AfterCommitSyncRequired(ORIGIN_TAG, LISTENER_TAG, false);
+
+            // when
+            experimentPublisher.publish(event);
+
+            // then: 아직 어떤 @Transactional도 거치지 않은, 리스너 메서드 진입 직후의 스레드 상태
+            ExecutionTrace origin = traceRecorder.trace(ORIGIN);
+            ExecutionTrace listenerEntry = traceRecorder.trace(LISTENER_ENTRY);
+
+            assertSoftly(softly -> {
+                // 동기화는 이미 해제됐다 (triggerAfterCompletion이 invokeAfterCompletion 직전에 clearSynchronization)
+                softly.assertThat(listenerEntry.synchronizationActive()).isFalse();
+
+                // 그런데 Spring은 트랜잭션이 아직 살아있다고 보고한다. cleanupAfterCompletion이 뒤에 실행되기 때문이다.
+                // 이 어긋난 창이 바로 REQUIRED가 올라타는 "죽은 트랜잭션"이다.
+                softly.assertThat(listenerEntry.actualTransactionActive()).isTrue();
+                softly.assertThat(listenerEntry.transactionName()).isEqualTo(origin.transactionName());
+                softly.assertThat(listenerEntry.entityManagerId()).isEqualTo(origin.entityManagerId());
+
+                // 정작 Hibernate는 이미 트랜잭션이 끝났다고 본다. 이 불일치가 쓰기 유실의 근본 원인이다.
+                softly.assertThat(listenerEntry.hibernateTransactionInProgress()).isFalse();
+            });
+        }
+    }
+
+    @Nested
+    @DisplayName("BEFORE_COMMIT + 비동기 + REQUIRES_NEW 조합에서 (안티패턴)")
+    class BeforeCommitAsyncNewTx {
+
+        @Test
+        void 커밋_전에_실행되지만_별도_트랜잭션이라_원본의_미커밋_데이터를_보지_못한다() {
+            // given
+            ExperimentEvent event = new ExperimentEvent.BeforeCommitAsyncNewTx(ORIGIN_TAG, LISTENER_TAG, false);
+
+            // when: 게이트 리스너가 원본 스레드를 doCommit 직전에 붙잡아, 비동기 리스너가 조회할 창을 연다.
+            // publish()는 동기 호출이라 반환 시점에 원본은 이미 커밋되어 있다.
+            experimentPublisher.publish(event);
+
+            // 리스너의 자기 트랜잭션이 커밋될 때까지 기다린다. 순서를 만드는 건 이 await가 아니라 게이트다.
+            await().atMost(AWAIT_TIMEOUT).untilAsserted(() ->
+                    assertThat(experimentRecordRepository.existsByTag(LISTENER_TAG)).isTrue());
+
+            // then
+            ExecutionTrace origin = traceRecorder.trace(ORIGIN);
+            ExecutionTrace listener = traceRecorder.trace(LISTENER);
+
+            assertSoftly(softly -> {
+                // 전제: 게이트가 타임아웃이 아니라 리스너 신호로 풀렸다 → 조회 시점에 원본은 미커밋이었다
+                softly.assertThat(traceRecorder.flag(GATE_HELD_UNTIL_LISTENER_READ)).isTrue();
+
+                // 핵심: BEFORE_COMMIT인데도 원본 행이 보이지 않는다 (②③에서는 true였다)
+                softly.assertThat(traceRecorder.flag(ORIGIN_VISIBLE_TO_LISTENER)).isFalse();
+
+                // 스레드도 트랜잭션도 커넥션도 전부 별개다
+                softly.assertThat(listener.threadName()).isNotEqualTo(origin.threadName());
+                softly.assertThat(listener.threadName()).startsWith(EXPERIMENT_ASYNC_THREAD_PREFIX);
+                softly.assertThat(listener.entityManagerId()).isNotEqualTo(origin.entityManagerId());
+
+                // 원본과 리스너가 각자 따로 커밋된다 (원자성 없음)
+                softly.assertThat(experimentRecordRepository.existsByTag(ORIGIN_TAG)).isTrue();
+            });
+        }
+
+        @Test
+        void 리스너가_예외를_던져도_원본_트랜잭션을_롤백시키지_못한다() {
+            // given
+            ExperimentEvent event = new ExperimentEvent.BeforeCommitAsyncNewTx(ORIGIN_TAG, LISTENER_TAG, true);
+
+            // when & then: 예외가 원본 스레드에 닿지 못한다 (①은 원본까지 롤백시켰다)
+            assertThatCode(() -> experimentPublisher.publish(event)).doesNotThrowAnyException();
+
+            await().atMost(AWAIT_TIMEOUT).untilAsserted(() ->
+                    assertThat(traceRecorder.error(LISTENER)).containsInstanceOf(IllegalStateException.class));
+
+            assertSoftly(softly -> {
+                // 전제: 예외는 원본이 커밋되기 전에 터졌다 (게이트가 리스너 신호로 풀렸으므로)
+                softly.assertThat(traceRecorder.flag(GATE_HELD_UNTIL_LISTENER_READ)).isTrue();
+
+                // 그런데도 원본은 그대로 커밋된다 → "원본 개입" 보장이 사라졌다
+                softly.assertThat(experimentRecordRepository.existsByTag(ORIGIN_TAG)).isTrue();
+
+                // 리스너의 새 트랜잭션만 롤백된다
+                softly.assertThat(experimentRecordRepository.existsByTag(LISTENER_TAG)).isFalse();
+            });
+        }
+    }
+}

--- a/src/test/java/gravit/code/experiment/txevent/ExperimentFixtureConfig.java
+++ b/src/test/java/gravit/code/experiment/txevent/ExperimentFixtureConfig.java
@@ -1,0 +1,123 @@
+package gravit.code.experiment.txevent;
+
+import gravit.code.experiment.txevent.fixture.ExperimentGate;
+import gravit.code.experiment.txevent.fixture.ExperimentPublisher;
+import gravit.code.experiment.txevent.fixture.ExperimentRecordRepository;
+import gravit.code.experiment.txevent.fixture.ExperimentRecordWriter;
+import gravit.code.experiment.txevent.fixture.TraceRecorder;
+import gravit.code.experiment.txevent.listener.AfterCommitAsyncNewTxListener;
+import gravit.code.experiment.txevent.listener.AfterCommitSyncNewTxListener;
+import gravit.code.experiment.txevent.listener.AfterCommitSyncRequiredListener;
+import gravit.code.experiment.txevent.listener.BeforeCommitAsyncNewTxListener;
+import gravit.code.experiment.txevent.listener.BeforeCommitSyncRequiredListener;
+import jakarta.persistence.EntityManagerFactory;
+import org.springframework.boot.test.context.TestConfiguration;
+import org.springframework.context.ApplicationEventPublisher;
+import org.springframework.context.annotation.Bean;
+import org.springframework.scheduling.concurrent.ThreadPoolTaskExecutor;
+
+import java.util.concurrent.Executor;
+
+/**
+ * {@code @TestConfiguration}은 컴포넌트 스캔에서 제외되므로, 이 설정을 {@code @Import}한 테스트에서만
+ * 실험용 리스너가 등록된다. 다른 통합 테스트 컨텍스트를 오염시키지 않는다.
+ */
+@TestConfiguration(proxyBeanMethods = false)
+public class ExperimentFixtureConfig {
+
+    public static final String EXPERIMENT_ASYNC_EXECUTOR = "experimentAsync";
+    public static final String EXPERIMENT_ASYNC_THREAD_PREFIX = "ExperimentAsync-";
+
+    private static final int CORE_POOL_SIZE = 2;
+    private static final int MAX_POOL_SIZE = 4;
+    private static final int QUEUE_CAPACITY = 20;
+
+    @Bean
+    public TraceRecorder traceRecorder(EntityManagerFactory entityManagerFactory) {
+        return new TraceRecorder(entityManagerFactory);
+    }
+
+    @Bean
+    public ExperimentGate experimentGate() {
+        return new ExperimentGate();
+    }
+
+    /**
+     * 프로덕션 풀이 아니라 전용 풀을 쓴다. 스레드명 접두사로 스레드 경계를 명확히 단언할 수 있고,
+     * ⑤의 래치 핸드셰이크가 프로덕션 풀 포화에 걸려 굶는 일을 막는다.
+     */
+    @Bean(name = EXPERIMENT_ASYNC_EXECUTOR)
+    public Executor experimentAsyncExecutor() {
+        ThreadPoolTaskExecutor executor = new ThreadPoolTaskExecutor();
+
+        executor.setCorePoolSize(CORE_POOL_SIZE);
+        executor.setMaxPoolSize(MAX_POOL_SIZE);
+        executor.setQueueCapacity(QUEUE_CAPACITY);
+        executor.setThreadNamePrefix(EXPERIMENT_ASYNC_THREAD_PREFIX);
+        executor.initialize();
+
+        return executor;
+    }
+
+    @Bean
+    public ExperimentPublisher experimentPublisher(
+            ExperimentRecordRepository experimentRecordRepository,
+            ApplicationEventPublisher eventPublisher,
+            TraceRecorder traceRecorder
+    ) {
+        return new ExperimentPublisher(experimentRecordRepository, eventPublisher, traceRecorder);
+    }
+
+    @Bean
+    public BeforeCommitSyncRequiredListener beforeCommitSyncRequiredListener(
+            ExperimentRecordRepository experimentRecordRepository,
+            TraceRecorder traceRecorder
+    ) {
+        return new BeforeCommitSyncRequiredListener(experimentRecordRepository, traceRecorder);
+    }
+
+    @Bean
+    public AfterCommitSyncNewTxListener afterCommitSyncNewTxListener(
+            ExperimentRecordRepository experimentRecordRepository,
+            TraceRecorder traceRecorder
+    ) {
+        return new AfterCommitSyncNewTxListener(experimentRecordRepository, traceRecorder);
+    }
+
+    @Bean
+    public AfterCommitAsyncNewTxListener afterCommitAsyncNewTxListener(
+            ExperimentRecordRepository experimentRecordRepository,
+            TraceRecorder traceRecorder
+    ) {
+        return new AfterCommitAsyncNewTxListener(experimentRecordRepository, traceRecorder);
+    }
+
+    /**
+     * ④의 {@code @Transactional(REQUIRED)}를 리스너가 아니라 이 빈에 둔다.
+     * 리스너에 직접 붙이면 {@code RestrictedTransactionalEventListenerFactory}가 컨텍스트 기동을 거부한다.
+     */
+    @Bean
+    public ExperimentRecordWriter experimentRecordWriter(
+            ExperimentRecordRepository experimentRecordRepository,
+            TraceRecorder traceRecorder
+    ) {
+        return new ExperimentRecordWriter(experimentRecordRepository, traceRecorder);
+    }
+
+    @Bean
+    public AfterCommitSyncRequiredListener afterCommitSyncRequiredListener(
+            ExperimentRecordWriter experimentRecordWriter,
+            TraceRecorder traceRecorder
+    ) {
+        return new AfterCommitSyncRequiredListener(experimentRecordWriter, traceRecorder);
+    }
+
+    @Bean
+    public BeforeCommitAsyncNewTxListener beforeCommitAsyncNewTxListener(
+            ExperimentRecordRepository experimentRecordRepository,
+            TraceRecorder traceRecorder,
+            ExperimentGate experimentGate
+    ) {
+        return new BeforeCommitAsyncNewTxListener(experimentRecordRepository, traceRecorder, experimentGate);
+    }
+}

--- a/src/test/java/gravit/code/experiment/txevent/RecommendedCombinationIntegrationTest.java
+++ b/src/test/java/gravit/code/experiment/txevent/RecommendedCombinationIntegrationTest.java
@@ -1,0 +1,249 @@
+package gravit.code.experiment.txevent;
+
+import gravit.code.experiment.txevent.fixture.ExecutionTrace;
+import gravit.code.experiment.txevent.fixture.ExperimentEvent;
+import gravit.code.experiment.txevent.fixture.ExperimentPublisher;
+import gravit.code.experiment.txevent.fixture.ExperimentRecordRepository;
+import gravit.code.experiment.txevent.fixture.TraceRecorder;
+import gravit.code.experiment.txevent.listener.AfterCommitAsyncNewTxListener;
+import gravit.code.experiment.txevent.listener.AfterCommitSyncNewTxListener;
+import gravit.code.support.TCSpringBootTest;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Nested;
+import org.junit.jupiter.api.Tag;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.context.annotation.Import;
+
+import java.time.Duration;
+
+import static gravit.code.experiment.txevent.ExperimentFixtureConfig.EXPERIMENT_ASYNC_THREAD_PREFIX;
+import static gravit.code.experiment.txevent.fixture.ExperimentEvent.LISTENER_FAILURE_MESSAGE;
+import static gravit.code.experiment.txevent.fixture.TraceRecorder.LISTENER;
+import static gravit.code.experiment.txevent.fixture.TraceRecorder.ORIGIN;
+import static gravit.code.experiment.txevent.fixture.TraceRecorder.ORIGIN_VISIBLE_TO_LISTENER;
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatCode;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static org.assertj.core.api.SoftAssertions.assertSoftly;
+import static org.awaitility.Awaitility.await;
+
+/**
+ * 권장 조합 검증.
+ * <p>
+ * 테스트 메서드에 {@code @Transactional}을 붙이면 롤백되어 AFTER_COMMIT이 발화하지 않고,
+ * 검증 조회도 같은 트랜잭션 안에서 이뤄져 "실제로 커밋됐는가"를 판별할 수 없다. 절대 붙이지 마라.
+ */
+@Tag("experiment")
+@TCSpringBootTest
+@Import(ExperimentFixtureConfig.class)
+class RecommendedCombinationIntegrationTest {
+
+    private static final String ORIGIN_TAG = "origin-record";
+    private static final String LISTENER_TAG = "listener-record";
+    private static final Duration AWAIT_TIMEOUT = Duration.ofSeconds(3);
+
+    @Autowired
+    private ExperimentPublisher experimentPublisher;
+
+    @Autowired
+    private ExperimentRecordRepository experimentRecordRepository;
+
+    @Autowired
+    private TraceRecorder traceRecorder;
+
+    @BeforeEach
+    void setUp() {
+        traceRecorder.reset();
+    }
+
+    @AfterEach
+    void printTraces() {
+        traceRecorder.traces().values().forEach(trace -> System.out.println("[TRACE] " + trace));
+        traceRecorder.flags().forEach((key, value) -> System.out.println("[FLAG] " + key + " = " + value));
+        traceRecorder.errors().forEach((label, error) -> System.out.println("[ERROR] " + label + " -> " + error));
+    }
+
+    @Nested
+    @DisplayName("BEFORE_COMMIT + 동기 + REQUIRED 조합에서")
+    class BeforeCommitSyncRequired {
+
+        @Test
+        void 리스너가_정상_동작하면_원본과_리스너의_쓰기가_같은_트랜잭션에서_함께_커밋된다() {
+            // given
+            ExperimentEvent event = new ExperimentEvent.BeforeCommitSyncRequired(ORIGIN_TAG, LISTENER_TAG, false);
+
+            // when
+            experimentPublisher.publish(event);
+
+            // then
+            ExecutionTrace origin = traceRecorder.trace(ORIGIN);
+            ExecutionTrace listener = traceRecorder.trace(LISTENER);
+
+            assertSoftly(softly -> {
+                // 데이터 잔존: 원본과 리스너의 쓰기가 모두 살아남는다
+                softly.assertThat(experimentRecordRepository.existsByTag(ORIGIN_TAG)).isTrue();
+                softly.assertThat(experimentRecordRepository.existsByTag(LISTENER_TAG)).isTrue();
+
+                // 트랜잭션 경계: 트랜잭션명이 원본 그대로 → 새 트랜잭션이 아니라 원본에 참여했다
+                softly.assertThat(listener.transactionName()).isEqualTo(origin.transactionName());
+                softly.assertThat(listener.actualTransactionActive()).isTrue();
+
+                // 같은 EntityManager를 공유한다 (④와 동일). 결정적 차이는 그 트랜잭션이 아직 살아있다는 것이다.
+                softly.assertThat(listener.entityManagerId()).isEqualTo(origin.entityManagerId());
+                softly.assertThat(listener.hibernateTransactionInProgress()).isTrue();
+
+                // 스레드 경계: 위임 없이 요청 스레드에서 그대로 실행된다
+                softly.assertThat(listener.threadName()).isEqualTo(origin.threadName());
+            });
+        }
+
+        @Test
+        void 리스너가_예외를_던지면_원본_트랜잭션까지_함께_롤백된다() {
+            // given
+            ExperimentEvent event = new ExperimentEvent.BeforeCommitSyncRequired(ORIGIN_TAG, LISTENER_TAG, true);
+
+            // when & then: 예외가 요청 스레드로 전파된다
+            assertThatThrownBy(() -> experimentPublisher.publish(event))
+                    .isInstanceOf(IllegalStateException.class)
+                    .hasMessage(LISTENER_FAILURE_MESSAGE);
+
+            // 데이터 잔존: 원본까지 함께 사라진다 (원자성)
+            assertSoftly(softly -> {
+                softly.assertThat(experimentRecordRepository.existsByTag(ORIGIN_TAG)).isFalse();
+                softly.assertThat(experimentRecordRepository.existsByTag(LISTENER_TAG)).isFalse();
+            });
+        }
+    }
+
+    @Nested
+    @DisplayName("AFTER_COMMIT + 동기 + REQUIRES_NEW 조합에서")
+    class AfterCommitSyncNewTx {
+
+        @Test
+        void 리스너가_정상_동작하면_원본과_별개인_새_트랜잭션에서_커밋된다() {
+            // given
+            ExperimentEvent event = new ExperimentEvent.AfterCommitSyncNewTx(ORIGIN_TAG, LISTENER_TAG, false);
+
+            // when
+            experimentPublisher.publish(event);
+
+            // then
+            ExecutionTrace origin = traceRecorder.trace(ORIGIN);
+            ExecutionTrace listener = traceRecorder.trace(LISTENER);
+
+            assertSoftly(softly -> {
+                // 데이터 잔존: 원본과 리스너의 쓰기가 모두 살아남는다
+                softly.assertThat(experimentRecordRepository.existsByTag(ORIGIN_TAG)).isTrue();
+                softly.assertThat(experimentRecordRepository.existsByTag(LISTENER_TAG)).isTrue();
+
+                // 트랜잭션 경계: 트랜잭션명이 리스너 메서드로 바뀐다 → 원본을 중단하고 새 트랜잭션이 열렸다
+                softly.assertThat(listener.transactionName()).isNotEqualTo(origin.transactionName());
+                softly.assertThat(listener.transactionName())
+                        .contains(AfterCommitSyncNewTxListener.class.getSimpleName());
+                softly.assertThat(listener.actualTransactionActive()).isTrue();
+
+                // 원본을 중단(suspend)하고 새 EntityManager를 바인딩했다 → ④와 갈리는 지점
+                softly.assertThat(listener.entityManagerId()).isNotEqualTo(origin.entityManagerId());
+                softly.assertThat(listener.hibernateTransactionInProgress()).isTrue();
+
+                // 원본이 이미 커밋된 뒤에 실행되므로, 별도 트랜잭션에서도 원본 행이 보인다
+                softly.assertThat(traceRecorder.flag(ORIGIN_VISIBLE_TO_LISTENER)).isTrue();
+
+                // 스레드 경계: 위임 없이 요청 스레드에서 그대로 실행된다
+                softly.assertThat(listener.threadName()).isEqualTo(origin.threadName());
+            });
+        }
+
+        @Test
+        void 리스너가_예외를_던져도_원본은_커밋된_채로_남고_예외는_요청_스레드에_닿지_않는다() {
+            // given
+            ExperimentEvent event = new ExperimentEvent.AfterCommitSyncNewTx(ORIGIN_TAG, LISTENER_TAG, true);
+
+            // when & then: AFTER_COMMIT 리스너는 afterCompletion 콜백에서 실행되고,
+            // TransactionSynchronizationUtils.invokeAfterCompletion이 Throwable을 잡아 ERROR 로그만 남긴다.
+            assertThatCode(() -> experimentPublisher.publish(event)).doesNotThrowAnyException();
+
+            assertSoftly(softly -> {
+                // 원본은 이미 커밋되어 되돌릴 수 없다 → 리스너 실패가 원본에 영향을 주지 못한다
+                softly.assertThat(experimentRecordRepository.existsByTag(ORIGIN_TAG)).isTrue();
+
+                // 리스너의 새 트랜잭션만 롤백된다
+                softly.assertThat(experimentRecordRepository.existsByTag(LISTENER_TAG)).isFalse();
+
+                // 예외는 분명히 발생했으나 호출자에게 전달되지 않았다 (조용히 삼켜짐)
+                softly.assertThat(traceRecorder.error(LISTENER))
+                        .containsInstanceOf(IllegalStateException.class);
+            });
+        }
+    }
+
+    @Nested
+    @DisplayName("AFTER_COMMIT + 비동기 + REQUIRES_NEW 조합에서")
+    class AfterCommitAsyncNewTx {
+
+        @Test
+        void 리스너가_정상_동작하면_별도_스레드의_새_트랜잭션에서_커밋된다() {
+            // given
+            ExperimentEvent event = new ExperimentEvent.AfterCommitAsyncNewTx(ORIGIN_TAG, LISTENER_TAG, false);
+
+            // when: 요청 스레드는 리스너를 기다리지 않고 즉시 반환한다
+            experimentPublisher.publish(event);
+
+            // then: 리스너 행이 보이면 리스너의 새 트랜잭션이 커밋된 것이다
+            await().atMost(AWAIT_TIMEOUT).untilAsserted(() ->
+                    assertThat(experimentRecordRepository.existsByTag(LISTENER_TAG)).isTrue());
+
+            ExecutionTrace origin = traceRecorder.trace(ORIGIN);
+            ExecutionTrace listener = traceRecorder.trace(LISTENER);
+
+            assertSoftly(softly -> {
+                // 데이터 잔존: 원본과 리스너의 쓰기가 모두 살아남는다
+                softly.assertThat(experimentRecordRepository.existsByTag(ORIGIN_TAG)).isTrue();
+
+                // 트랜잭션 경계: 별도 스레드에는 물려받을 트랜잭션이 없으므로 새 트랜잭션이 열린다
+                softly.assertThat(listener.transactionName()).isNotEqualTo(origin.transactionName());
+                softly.assertThat(listener.transactionName())
+                        .contains(AfterCommitAsyncNewTxListener.class.getSimpleName());
+                softly.assertThat(listener.actualTransactionActive()).isTrue();
+
+                // 스레드가 다르니 EntityManager도 커넥션도 별개다
+                softly.assertThat(listener.entityManagerId()).isNotEqualTo(origin.entityManagerId());
+                softly.assertThat(listener.hibernateTransactionInProgress()).isTrue();
+
+                // 원본이 이미 커밋된 뒤에 실행되므로, 다른 커넥션에서도 원본 행이 보인다
+                softly.assertThat(traceRecorder.flag(ORIGIN_VISIBLE_TO_LISTENER)).isTrue();
+
+                // 스레드 경계: @Async 어드바이저가 @Transactional보다 바깥이라 트랜잭션도 풀 스레드에서 열린다
+                softly.assertThat(listener.threadName()).isNotEqualTo(origin.threadName());
+                softly.assertThat(listener.threadName()).startsWith(EXPERIMENT_ASYNC_THREAD_PREFIX);
+            });
+        }
+
+        @Test
+        void 리스너가_예외를_던져도_원본은_커밋된_채로_남고_예외는_요청_스레드에_닿지_않는다() {
+            // given
+            ExperimentEvent event = new ExperimentEvent.AfterCommitAsyncNewTx(ORIGIN_TAG, LISTENER_TAG, true);
+
+            // when & then: 이미 스레드가 갈라졌으므로 예외가 호출자에게 닿을 길이 없다
+            assertThatCode(() -> experimentPublisher.publish(event)).doesNotThrowAnyException();
+
+            await().atMost(AWAIT_TIMEOUT).untilAsserted(() ->
+                    assertThat(traceRecorder.error(LISTENER)).containsInstanceOf(IllegalStateException.class));
+
+            assertSoftly(softly -> {
+                // 원본은 이미 커밋되어 리스너 실패의 영향을 받지 않는다
+                softly.assertThat(experimentRecordRepository.existsByTag(ORIGIN_TAG)).isTrue();
+
+                // 리스너의 새 트랜잭션만 롤백된다
+                softly.assertThat(experimentRecordRepository.existsByTag(LISTENER_TAG)).isFalse();
+
+                // 예외는 비동기 풀 스레드에서 발생했다
+                softly.assertThat(traceRecorder.trace(LISTENER).threadName())
+                        .startsWith(EXPERIMENT_ASYNC_THREAD_PREFIX);
+            });
+        }
+    }
+}

--- a/src/test/java/gravit/code/experiment/txevent/fixture/ExecutionTrace.java
+++ b/src/test/java/gravit/code/experiment/txevent/fixture/ExecutionTrace.java
@@ -1,0 +1,53 @@
+package gravit.code.experiment.txevent.fixture;
+
+import jakarta.persistence.EntityManager;
+import jakarta.persistence.EntityManagerFactory;
+import org.hibernate.engine.spi.SharedSessionContractImplementor;
+import org.springframework.orm.jpa.EntityManagerHolder;
+import org.springframework.transaction.support.TransactionSynchronizationManager;
+
+/**
+ * 실행 시점의 스레드·트랜잭션 경계 스냅샷.
+ * <p>
+ * {@code transactionName}은 조합을 가르는 신호이지만 <b>단독으로는 믿을 수 없다.</b>
+ * {@code prepareSynchronization}은 {@code isNewSynchronization()}일 때만 트랜잭션명을 갱신하는데,
+ * 이 값은 {@code newSynchronization && !isSynchronizationActive()}로 계산된다.
+ * AFTER_COMMIT 리스너는 {@code triggerAfterCompletion}이 {@code clearSynchronization()}을 부른 뒤에 실행되므로,
+ * 기존 트랜잭션에 참여(REQUIRED)해도 트랜잭션명이 새것처럼 갱신될 수 있다.
+ * <p>
+ * 따라서 "같은 트랜잭션에 올라탔는가"의 결정적 지표는 {@code entityManagerId}다.
+ * 현재 스레드에 바인딩된 {@code EntityManager} 인스턴스가 같으면 같은 트랜잭션(=같은 커넥션)에 참여한 것이다.
+ * <p>
+ * {@code actualTransactionActive}(Spring의 인식)와 {@code hibernateTransactionInProgress}(Hibernate의 인식)를
+ * 나란히 찍는 이유는, <b>두 층의 인식이 어긋나는 순간이 존재</b>하기 때문이다.
+ * Spring은 트랜잭션이 살아있다고 보고하는데 Hibernate는 이미 끝났다고 보는 창이 AFTER_COMMIT 콜백 구간이다.
+ * 그 창에서 {@code persist()}는 identity insert를 지연시키고 auto-flush도 건너뛴다.
+ */
+public record ExecutionTrace(
+        String label,
+        String threadName,
+        String transactionName,
+        boolean actualTransactionActive,
+        boolean synchronizationActive,
+        Integer entityManagerId,
+        Boolean hibernateTransactionInProgress
+) {
+
+    public static ExecutionTrace here(String label, EntityManagerFactory entityManagerFactory) {
+        EntityManagerHolder holder =
+                (EntityManagerHolder) TransactionSynchronizationManager.getResource(entityManagerFactory);
+        EntityManager entityManager = holder != null ? holder.getEntityManager() : null;
+
+        return new ExecutionTrace(
+                label,
+                Thread.currentThread().getName(),
+                TransactionSynchronizationManager.getCurrentTransactionName(),
+                TransactionSynchronizationManager.isActualTransactionActive(),
+                TransactionSynchronizationManager.isSynchronizationActive(),
+                entityManager != null ? System.identityHashCode(entityManager) : null,
+                entityManager != null
+                        ? entityManager.unwrap(SharedSessionContractImplementor.class).isTransactionInProgress()
+                        : null
+        );
+    }
+}

--- a/src/test/java/gravit/code/experiment/txevent/fixture/ExecutionTrace.java
+++ b/src/test/java/gravit/code/experiment/txevent/fixture/ExecutionTrace.java
@@ -19,7 +19,7 @@ import org.springframework.transaction.support.TransactionSynchronizationManager
  * 현재 스레드에 바인딩된 {@code EntityManager} 인스턴스가 같으면 같은 트랜잭션(=같은 커넥션)에 참여한 것이다.
  * <p>
  * {@code actualTransactionActive}(Spring의 인식)와 {@code hibernateTransactionInProgress}(Hibernate의 인식)를
- * 나란히 찍는 이유는, <b>두 층의 인식이 어긋나는 순간이 존재</b>하기 때문이다.
+ * 나란히 찍는 이유는, <b>두 프레임워크가 트랜잭션 상태를 다르게 판단하는 구간이 존재</b>하기 때문이다.
  * Spring은 트랜잭션이 살아있다고 보고하는데 Hibernate는 이미 끝났다고 보는 창이 AFTER_COMMIT 콜백 구간이다.
  * 그 창에서 {@code persist()}는 identity insert를 지연시키고 auto-flush도 건너뛴다.
  */

--- a/src/test/java/gravit/code/experiment/txevent/fixture/ExperimentEvent.java
+++ b/src/test/java/gravit/code/experiment/txevent/fixture/ExperimentEvent.java
@@ -1,0 +1,45 @@
+package gravit.code.experiment.txevent.fixture;
+
+/**
+ * 조합마다 이벤트 타입을 분리한다. 5개 리스너가 한 이벤트를 공유하면 전부 발화해 조합을 격리할 수 없다.
+ */
+public interface ExperimentEvent {
+
+    String LISTENER_FAILURE_MESSAGE = "listener failed";
+
+    String originTag();
+
+    String listenerTag();
+
+    boolean listenerThrows();
+
+    record BeforeCommitSyncRequired(
+            String originTag,
+            String listenerTag,
+            boolean listenerThrows
+    ) implements ExperimentEvent {}
+
+    record AfterCommitSyncNewTx(
+            String originTag,
+            String listenerTag,
+            boolean listenerThrows
+    ) implements ExperimentEvent {}
+
+    record AfterCommitAsyncNewTx(
+            String originTag,
+            String listenerTag,
+            boolean listenerThrows
+    ) implements ExperimentEvent {}
+
+    record AfterCommitSyncRequired(
+            String originTag,
+            String listenerTag,
+            boolean listenerThrows
+    ) implements ExperimentEvent {}
+
+    record BeforeCommitAsyncNewTx(
+            String originTag,
+            String listenerTag,
+            boolean listenerThrows
+    ) implements ExperimentEvent {}
+}

--- a/src/test/java/gravit/code/experiment/txevent/fixture/ExperimentGate.java
+++ b/src/test/java/gravit/code/experiment/txevent/fixture/ExperimentGate.java
@@ -1,0 +1,32 @@
+package gravit.code.experiment.txevent.fixture;
+
+import java.util.concurrent.CountDownLatch;
+import java.util.concurrent.TimeUnit;
+
+/**
+ * 안티패턴 ⑤ 전용. 원본 트랜잭션을 미커밋 상태로 붙잡아 둔다.
+ * <p>
+ * {@code @Async} 리스너는 위임 후 즉시 반환하므로 원본은 곧장 커밋해버린다. 그러면 "커밋 전"이라는
+ * 관찰 창 자체가 닫힌다. 뒤 순번의 동기 리스너가 이 래치를 기다려 창을 열어둔다.
+ */
+public class ExperimentGate {
+
+    private volatile CountDownLatch listenerRead = new CountDownLatch(1);
+
+    public void signalListenerRead() {
+        listenerRead.countDown();
+    }
+
+    public boolean awaitListenerRead(long timeout, TimeUnit unit) {
+        try {
+            return listenerRead.await(timeout, unit);
+        } catch (InterruptedException e) {
+            Thread.currentThread().interrupt();
+            return false;
+        }
+    }
+
+    public void reset() {
+        listenerRead = new CountDownLatch(1);
+    }
+}

--- a/src/test/java/gravit/code/experiment/txevent/fixture/ExperimentPublisher.java
+++ b/src/test/java/gravit/code/experiment/txevent/fixture/ExperimentPublisher.java
@@ -1,0 +1,28 @@
+package gravit.code.experiment.txevent.fixture;
+
+import lombok.RequiredArgsConstructor;
+import org.springframework.context.ApplicationEventPublisher;
+import org.springframework.transaction.annotation.Transactional;
+
+import static gravit.code.experiment.txevent.fixture.TraceRecorder.ORIGIN;
+
+/**
+ * 원본 트랜잭션 보유자. 프로덕션의 Service 경계에 대응한다.
+ */
+@RequiredArgsConstructor
+public class ExperimentPublisher {
+
+    private final ExperimentRecordRepository experimentRecordRepository;
+    private final ApplicationEventPublisher eventPublisher;
+    private final TraceRecorder traceRecorder;
+
+    @Transactional
+    public void publish(ExperimentEvent event) {
+        traceRecorder.capture(ORIGIN);
+
+        // 원본 행을 먼저 저장해야, BEFORE_COMMIT 비동기 리스너가 미커밋 상태를 조회하는 순간을 관찰할 수 있다.
+        experimentRecordRepository.save(ExperimentRecord.create(event.originTag()));
+
+        eventPublisher.publishEvent(event);
+    }
+}

--- a/src/test/java/gravit/code/experiment/txevent/fixture/ExperimentRecord.java
+++ b/src/test/java/gravit/code/experiment/txevent/fixture/ExperimentRecord.java
@@ -1,0 +1,37 @@
+package gravit.code.experiment.txevent.fixture;
+
+import jakarta.persistence.Column;
+import jakarta.persistence.Entity;
+import jakarta.persistence.GeneratedValue;
+import jakarta.persistence.GenerationType;
+import jakarta.persistence.Id;
+import jakarta.persistence.Table;
+import lombok.AccessLevel;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+/**
+ * 조합별 쓰기가 실제로 커밋됐는지 판별하는 유일한 관찰 대상.
+ * IDENTITY는 persist() 시점에 INSERT를 즉시 발행하므로, 커밋되지 않은 쓰기가 유실되는 경로가 그대로 드러난다.
+ */
+@Entity
+@Table(name = "experiment_record")
+@Getter
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+public class ExperimentRecord {
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Long id;
+
+    @Column(nullable = false)
+    private String tag;
+
+    private ExperimentRecord(String tag) {
+        this.tag = tag;
+    }
+
+    public static ExperimentRecord create(String tag) {
+        return new ExperimentRecord(tag);
+    }
+}

--- a/src/test/java/gravit/code/experiment/txevent/fixture/ExperimentRecordRepository.java
+++ b/src/test/java/gravit/code/experiment/txevent/fixture/ExperimentRecordRepository.java
@@ -1,0 +1,8 @@
+package gravit.code.experiment.txevent.fixture;
+
+import org.springframework.data.jpa.repository.JpaRepository;
+
+public interface ExperimentRecordRepository extends JpaRepository<ExperimentRecord, Long> {
+
+    boolean existsByTag(String tag);
+}

--- a/src/test/java/gravit/code/experiment/txevent/fixture/ExperimentRecordWriter.java
+++ b/src/test/java/gravit/code/experiment/txevent/fixture/ExperimentRecordWriter.java
@@ -1,0 +1,35 @@
+package gravit.code.experiment.txevent.fixture;
+
+import lombok.RequiredArgsConstructor;
+import org.springframework.transaction.annotation.Propagation;
+import org.springframework.transaction.annotation.Transactional;
+
+import static gravit.code.experiment.txevent.fixture.TraceRecorder.LISTENER_WRITE_VISIBLE_IN_SAME_TX;
+
+/**
+ * {@code @Transactional(REQUIRED)}를 리스너 <b>바깥</b>이 아니라 <b>안쪽</b>(호출되는 서비스)에 두기 위한 fixture.
+ * <p>
+ * Spring 6.1의 {@code RestrictedTransactionalEventListenerFactory}는 BEFORE_COMMIT이 아닌 리스너 메서드에
+ * REQUIRES_NEW/NOT_SUPPORTED가 아닌 {@code @Transactional}이 붙으면 컨텍스트 기동을 거부한다.
+ * 그러나 그 가드는 <b>리스너의 어노테이션만</b> 검사할 뿐, 리스너가 무엇을 호출하는지는 보지 못한다.
+ * <p>
+ * 프로덕션 리스너들이 실제로 이 모양이다 (예: {@code LearningEventListener} → {@code LearningCommandService}).
+ * 따라서 안티패턴 ④는 가드를 통과한 채로 그대로 재현된다.
+ */
+@RequiredArgsConstructor
+public class ExperimentRecordWriter {
+
+    private final ExperimentRecordRepository experimentRecordRepository;
+    private final TraceRecorder traceRecorder;
+
+    @Transactional(propagation = Propagation.REQUIRED)
+    public void write(String label, String tag) {
+        traceRecorder.capture(label);
+
+        experimentRecordRepository.save(ExperimentRecord.create(tag));
+
+        // 자기 트랜잭션(=자기 커넥션) 안에서 방금 쓴 행을 조회한다.
+        // true면 INSERT가 DB에 실제로 도달했다는 뜻이다. 나중에 밖에서 안 보이면 "쓰였다가 사라진" 것이다.
+        traceRecorder.putFlag(LISTENER_WRITE_VISIBLE_IN_SAME_TX, experimentRecordRepository.existsByTag(tag));
+    }
+}

--- a/src/test/java/gravit/code/experiment/txevent/fixture/ExperimentRecordWriter.java
+++ b/src/test/java/gravit/code/experiment/txevent/fixture/ExperimentRecordWriter.java
@@ -11,10 +11,10 @@ import static gravit.code.experiment.txevent.fixture.TraceRecorder.LISTENER_WRIT
  * <p>
  * Spring 6.1의 {@code RestrictedTransactionalEventListenerFactory}는 BEFORE_COMMIT이 아닌 리스너 메서드에
  * REQUIRES_NEW/NOT_SUPPORTED가 아닌 {@code @Transactional}이 붙으면 컨텍스트 기동을 거부한다.
- * 그러나 그 가드는 <b>리스너의 어노테이션만</b> 검사할 뿐, 리스너가 무엇을 호출하는지는 보지 못한다.
+ * 그러나 이 검증은 <b>리스너에 붙은 어노테이션만</b> 볼 뿐, 리스너가 무엇을 호출하는지는 보지 않는다.
  * <p>
  * 프로덕션 리스너들이 실제로 이 모양이다 (예: {@code LearningEventListener} → {@code LearningCommandService}).
- * 따라서 안티패턴 ④는 가드를 통과한 채로 그대로 재현된다.
+ * 따라서 안티패턴 ④는 이 검증을 통과한 채로 그대로 재현된다.
  */
 @RequiredArgsConstructor
 public class ExperimentRecordWriter {

--- a/src/test/java/gravit/code/experiment/txevent/fixture/TraceRecorder.java
+++ b/src/test/java/gravit/code/experiment/txevent/fixture/TraceRecorder.java
@@ -1,0 +1,88 @@
+package gravit.code.experiment.txevent.fixture;
+
+import jakarta.persistence.EntityManagerFactory;
+import lombok.RequiredArgsConstructor;
+
+import java.util.Map;
+import java.util.Optional;
+import java.util.concurrent.ConcurrentHashMap;
+
+/**
+ * 비동기 리스너가 다른 스레드에서 기록하므로 전부 동시성 컬렉션으로 둔다.
+ */
+@RequiredArgsConstructor
+public class TraceRecorder {
+
+    public static final String ORIGIN = "origin";
+    public static final String LISTENER = "listener";
+
+    /** 리스너 메서드 진입 직후, 아직 어떤 {@code @Transactional}도 거치지 않은 시점의 스레드 상태. */
+    public static final String LISTENER_ENTRY = "listener-entry";
+
+    /** 리스너가 자기 트랜잭션에서 원본 행을 조회할 수 있는지. AFTER_COMMIT이면 true, BEFORE_COMMIT + 별도 트랜잭션이면 false. */
+    public static final String ORIGIN_VISIBLE_TO_LISTENER = "originVisibleToListener";
+
+    /**
+     * 리스너가 방금 쓴 행이 <b>자기 트랜잭션(=자기 커넥션) 안에서</b> 보이는지.
+     * <p>
+     * true면 INSERT가 DB에 도달한 뒤 커밋되지 않아 사라진 것이고,
+     * false면 INSERT가 <b>발행조차 되지 않은</b> 것이다. 후자가 안티패턴 ④의 실제 거동이다.
+     */
+    public static final String LISTENER_WRITE_VISIBLE_IN_SAME_TX = "listenerWriteVisibleInSameTx";
+
+    /**
+     * 게이트가 타임아웃이 아니라 <b>비동기 리스너의 신호</b>로 풀렸는지 (안티패턴 ⑤).
+     * <p>
+     * 이 값이 true여야 "리스너가 조회한 시점에 원본은 아직 커밋 전이었다"가 보장된다.
+     * false면 게이트가 먼저 만료되어 원본이 커밋됐을 수 있으므로, 그 실행의 관찰은 무의미하다.
+     */
+    public static final String GATE_HELD_UNTIL_LISTENER_READ = "gateHeldUntilListenerRead";
+
+    private final EntityManagerFactory entityManagerFactory;
+
+    private final Map<String, ExecutionTrace> traces = new ConcurrentHashMap<>();
+    private final Map<String, Throwable> errors = new ConcurrentHashMap<>();
+    private final Map<String, Boolean> flags = new ConcurrentHashMap<>();
+
+    public void capture(String label) {
+        traces.put(label, ExecutionTrace.here(label, entityManagerFactory));
+    }
+
+    public void captureError(String label, Throwable error) {
+        errors.put(label, error);
+    }
+
+    public void putFlag(String key, boolean value) {
+        flags.put(key, value);
+    }
+
+    public ExecutionTrace trace(String label) {
+        return traces.get(label);
+    }
+
+    public Optional<Throwable> error(String label) {
+        return Optional.ofNullable(errors.get(label));
+    }
+
+    public boolean flag(String key) {
+        return Boolean.TRUE.equals(flags.get(key));
+    }
+
+    public Map<String, ExecutionTrace> traces() {
+        return Map.copyOf(traces);
+    }
+
+    public Map<String, Boolean> flags() {
+        return Map.copyOf(flags);
+    }
+
+    public Map<String, Throwable> errors() {
+        return Map.copyOf(errors);
+    }
+
+    public void reset() {
+        traces.clear();
+        errors.clear();
+        flags.clear();
+    }
+}

--- a/src/test/java/gravit/code/experiment/txevent/listener/AfterCommitAsyncNewTxListener.java
+++ b/src/test/java/gravit/code/experiment/txevent/listener/AfterCommitAsyncNewTxListener.java
@@ -1,0 +1,56 @@
+package gravit.code.experiment.txevent.listener;
+
+import gravit.code.experiment.txevent.fixture.ExperimentEvent;
+import gravit.code.experiment.txevent.fixture.ExperimentRecord;
+import gravit.code.experiment.txevent.fixture.ExperimentRecordRepository;
+import gravit.code.experiment.txevent.fixture.TraceRecorder;
+import lombok.RequiredArgsConstructor;
+import org.springframework.scheduling.annotation.Async;
+import org.springframework.transaction.annotation.Propagation;
+import org.springframework.transaction.annotation.Transactional;
+import org.springframework.transaction.event.TransactionPhase;
+import org.springframework.transaction.event.TransactionalEventListener;
+
+import static gravit.code.experiment.txevent.fixture.ExperimentEvent.LISTENER_FAILURE_MESSAGE;
+import static gravit.code.experiment.txevent.fixture.TraceRecorder.LISTENER;
+import static gravit.code.experiment.txevent.fixture.TraceRecorder.ORIGIN_VISIBLE_TO_LISTENER;
+
+/**
+ * 권장 조합 ③ — AFTER_COMMIT + 비동기 + REQUIRES_NEW.
+ * <p>
+ * {@code AsyncAnnotationBeanPostProcessor}가 {@code setBeforeExistingAdvisors(true)}로 등록되므로
+ * {@code @Async} 어드바이저가 {@code @Transactional}보다 <b>바깥</b>에 걸린다.
+ * 따라서 트랜잭션은 요청 스레드가 아니라 비동기 풀 스레드에서 열린다.
+ * <p>
+ * 예외는 ②와 마찬가지로 요청 스레드에 닿지 않는다. 다만 이유가 다르다.
+ * ②는 {@code invokeAfterCompletion}이 삼키고, ③은 그 이전에 이미 스레드가 갈라져
+ * {@code AsyncUncaughtExceptionHandler}가 처리한다.
+ */
+@RequiredArgsConstructor
+public class AfterCommitAsyncNewTxListener {
+
+    private final ExperimentRecordRepository experimentRecordRepository;
+    private final TraceRecorder traceRecorder;
+
+    @Async("experimentAsync")
+    @TransactionalEventListener(phase = TransactionPhase.AFTER_COMMIT)
+    @Transactional(propagation = Propagation.REQUIRES_NEW)
+    public void handle(ExperimentEvent.AfterCommitAsyncNewTx event) {
+        try {
+            traceRecorder.capture(LISTENER);
+
+            // 원본은 이미 커밋됐으므로, 다른 스레드의 다른 커넥션에서도 보인다.
+            traceRecorder.putFlag(ORIGIN_VISIBLE_TO_LISTENER, experimentRecordRepository.existsByTag(event.originTag()));
+
+            experimentRecordRepository.save(ExperimentRecord.create(event.listenerTag()));
+
+            if (event.listenerThrows()) {
+                throw new IllegalStateException(LISTENER_FAILURE_MESSAGE);
+            }
+        } catch (Exception e) {
+            // 기록 후 재던져, 예외가 삼켜지는 경로 자체를 보존한다.
+            traceRecorder.captureError(LISTENER, e);
+            throw e;
+        }
+    }
+}

--- a/src/test/java/gravit/code/experiment/txevent/listener/AfterCommitSyncNewTxListener.java
+++ b/src/test/java/gravit/code/experiment/txevent/listener/AfterCommitSyncNewTxListener.java
@@ -1,0 +1,52 @@
+package gravit.code.experiment.txevent.listener;
+
+import gravit.code.experiment.txevent.fixture.ExperimentEvent;
+import gravit.code.experiment.txevent.fixture.ExperimentRecord;
+import gravit.code.experiment.txevent.fixture.ExperimentRecordRepository;
+import gravit.code.experiment.txevent.fixture.TraceRecorder;
+import lombok.RequiredArgsConstructor;
+import org.springframework.transaction.annotation.Propagation;
+import org.springframework.transaction.annotation.Transactional;
+import org.springframework.transaction.event.TransactionPhase;
+import org.springframework.transaction.event.TransactionalEventListener;
+
+import static gravit.code.experiment.txevent.fixture.ExperimentEvent.LISTENER_FAILURE_MESSAGE;
+import static gravit.code.experiment.txevent.fixture.TraceRecorder.LISTENER;
+import static gravit.code.experiment.txevent.fixture.TraceRecorder.ORIGIN_VISIBLE_TO_LISTENER;
+
+/**
+ * 권장 조합 ② — AFTER_COMMIT + 동기 + REQUIRES_NEW.
+ * 독립된 새 트랜잭션에서 실행되어 원본에 영향을 주지 않는다.
+ * <p>
+ * 예외는 요청 스레드로 전파되지 <b>않는다</b>. {@code TransactionalApplicationListenerSynchronization}은
+ * {@code afterCommit()}이 아니라 {@code afterCompletion(int)}에 AFTER_COMMIT 처리를 구현하는데,
+ * {@code TransactionSynchronizationUtils.invokeAfterCompletion}이 Throwable을 잡아 ERROR 로그만 남기고 삼킨다.
+ * (반면 {@code invokeAfterCommit}에는 catch 블록이 없다.)
+ */
+@RequiredArgsConstructor
+public class AfterCommitSyncNewTxListener {
+
+    private final ExperimentRecordRepository experimentRecordRepository;
+    private final TraceRecorder traceRecorder;
+
+    @TransactionalEventListener(phase = TransactionPhase.AFTER_COMMIT)
+    @Transactional(propagation = Propagation.REQUIRES_NEW)
+    public void handle(ExperimentEvent.AfterCommitSyncNewTx event) {
+        try {
+            traceRecorder.capture(LISTENER);
+
+            // 원본은 이미 커밋됐으므로, 별도 트랜잭션에서도 보인다.
+            traceRecorder.putFlag(ORIGIN_VISIBLE_TO_LISTENER, experimentRecordRepository.existsByTag(event.originTag()));
+
+            experimentRecordRepository.save(ExperimentRecord.create(event.listenerTag()));
+
+            if (event.listenerThrows()) {
+                throw new IllegalStateException(LISTENER_FAILURE_MESSAGE);
+            }
+        } catch (Exception e) {
+            // 기록 후 재던져, 예외가 삼켜지는 경로 자체를 보존한다.
+            traceRecorder.captureError(LISTENER, e);
+            throw e;
+        }
+    }
+}

--- a/src/test/java/gravit/code/experiment/txevent/listener/AfterCommitSyncRequiredListener.java
+++ b/src/test/java/gravit/code/experiment/txevent/listener/AfterCommitSyncRequiredListener.java
@@ -1,0 +1,51 @@
+package gravit.code.experiment.txevent.listener;
+
+import gravit.code.experiment.txevent.fixture.ExperimentEvent;
+import gravit.code.experiment.txevent.fixture.ExperimentRecordWriter;
+import gravit.code.experiment.txevent.fixture.TraceRecorder;
+import lombok.RequiredArgsConstructor;
+import org.springframework.transaction.event.TransactionPhase;
+import org.springframework.transaction.event.TransactionalEventListener;
+
+import static gravit.code.experiment.txevent.fixture.ExperimentEvent.LISTENER_FAILURE_MESSAGE;
+import static gravit.code.experiment.txevent.fixture.TraceRecorder.LISTENER;
+import static gravit.code.experiment.txevent.fixture.TraceRecorder.LISTENER_ENTRY;
+
+/**
+ * 안티패턴 ④ — AFTER_COMMIT + 동기 + REQUIRED.
+ * <p>
+ * 이 메서드에 {@code @Transactional(propagation = REQUIRED)}를 직접 붙이면
+ * {@code RestrictedTransactionalEventListenerFactory}가 컨텍스트 기동을 거부한다(Spring 6.1+).
+ * 그래서 REQUIRED는 리스너가 호출하는 {@link ExperimentRecordWriter} 쪽에 둔다.
+ * 가드는 리스너의 어노테이션만 보므로 이 형태는 통과하고, 안티패턴은 그대로 성립한다.
+ * <p>
+ * AFTER_COMMIT 시점엔 {@code EntityManagerHolder}가 아직 언바인드되지 않아
+ * ({@code doCleanupAfterCompletion}은 콜백 이후 실행) {@code isExistingTransaction()}이 참이다.
+ * REQUIRED는 새 트랜잭션을 열지 않고 <b>이미 커밋이 끝난 원본 트랜잭션에 그대로 참여</b>한다.
+ * 두 번째 커밋은 일어나지 않으므로 여기서의 쓰기는 커넥션 반납과 함께 사라진다.
+ */
+@RequiredArgsConstructor
+public class AfterCommitSyncRequiredListener {
+
+    private final ExperimentRecordWriter experimentRecordWriter;
+    private final TraceRecorder traceRecorder;
+
+    @TransactionalEventListener(phase = TransactionPhase.AFTER_COMMIT)
+    public void handle(ExperimentEvent.AfterCommitSyncRequired event) {
+        try {
+            // @Transactional을 거치기 전, 죽은 트랜잭션이 남긴 스레드 상태를 그대로 찍는다.
+            traceRecorder.capture(LISTENER_ENTRY);
+
+            experimentRecordWriter.write(LISTENER, event.listenerTag());
+
+            if (event.listenerThrows()) {
+                throw new IllegalStateException(LISTENER_FAILURE_MESSAGE);
+            }
+        } catch (Exception e) {
+            // write() 자체가 죽은 트랜잭션에서 예외를 던질 가능성도 있어, 무엇이 터지든 기록만 하고 재던진다.
+            // 어차피 invokeAfterCompletion이 삼키므로 호출자는 아무것도 알 수 없다.
+            traceRecorder.captureError(LISTENER, e);
+            throw e;
+        }
+    }
+}

--- a/src/test/java/gravit/code/experiment/txevent/listener/AfterCommitSyncRequiredListener.java
+++ b/src/test/java/gravit/code/experiment/txevent/listener/AfterCommitSyncRequiredListener.java
@@ -17,7 +17,7 @@ import static gravit.code.experiment.txevent.fixture.TraceRecorder.LISTENER_ENTR
  * 이 메서드에 {@code @Transactional(propagation = REQUIRED)}를 직접 붙이면
  * {@code RestrictedTransactionalEventListenerFactory}가 컨텍스트 기동을 거부한다(Spring 6.1+).
  * 그래서 REQUIRED는 리스너가 호출하는 {@link ExperimentRecordWriter} 쪽에 둔다.
- * 가드는 리스너의 어노테이션만 보므로 이 형태는 통과하고, 안티패턴은 그대로 성립한다.
+ * 이 검증은 리스너에 붙은 어노테이션만 보므로 이 형태는 통과하고, 안티패턴은 그대로 성립한다.
  * <p>
  * AFTER_COMMIT 시점엔 {@code EntityManagerHolder}가 아직 언바인드되지 않아
  * ({@code doCleanupAfterCompletion}은 콜백 이후 실행) {@code isExistingTransaction()}이 참이다.
@@ -33,7 +33,7 @@ public class AfterCommitSyncRequiredListener {
     @TransactionalEventListener(phase = TransactionPhase.AFTER_COMMIT)
     public void handle(ExperimentEvent.AfterCommitSyncRequired event) {
         try {
-            // @Transactional을 거치기 전, 죽은 트랜잭션이 남긴 스레드 상태를 그대로 찍는다.
+            // @Transactional을 거치기 전, 커밋이 끝났는데도 스레드에 남아 있는 원본 트랜잭션 상태를 그대로 찍는다.
             traceRecorder.capture(LISTENER_ENTRY);
 
             experimentRecordWriter.write(LISTENER, event.listenerTag());
@@ -42,7 +42,7 @@ public class AfterCommitSyncRequiredListener {
                 throw new IllegalStateException(LISTENER_FAILURE_MESSAGE);
             }
         } catch (Exception e) {
-            // write() 자체가 죽은 트랜잭션에서 예외를 던질 가능성도 있어, 무엇이 터지든 기록만 하고 재던진다.
+            // write()가 이미 종료된 트랜잭션 위에서 예외를 던질 가능성도 있어, 무엇이 터지든 기록만 하고 재던진다.
             // 어차피 invokeAfterCompletion이 삼키므로 호출자는 아무것도 알 수 없다.
             traceRecorder.captureError(LISTENER, e);
             throw e;

--- a/src/test/java/gravit/code/experiment/txevent/listener/BeforeCommitAsyncNewTxListener.java
+++ b/src/test/java/gravit/code/experiment/txevent/listener/BeforeCommitAsyncNewTxListener.java
@@ -1,0 +1,80 @@
+package gravit.code.experiment.txevent.listener;
+
+import gravit.code.experiment.txevent.fixture.ExperimentEvent;
+import gravit.code.experiment.txevent.fixture.ExperimentGate;
+import gravit.code.experiment.txevent.fixture.ExperimentRecord;
+import gravit.code.experiment.txevent.fixture.ExperimentRecordRepository;
+import gravit.code.experiment.txevent.fixture.TraceRecorder;
+import lombok.RequiredArgsConstructor;
+import org.springframework.core.annotation.Order;
+import org.springframework.scheduling.annotation.Async;
+import org.springframework.transaction.annotation.Propagation;
+import org.springframework.transaction.annotation.Transactional;
+import org.springframework.transaction.event.TransactionPhase;
+import org.springframework.transaction.event.TransactionalEventListener;
+
+import java.util.concurrent.TimeUnit;
+
+import static gravit.code.experiment.txevent.fixture.ExperimentEvent.LISTENER_FAILURE_MESSAGE;
+import static gravit.code.experiment.txevent.fixture.TraceRecorder.GATE_HELD_UNTIL_LISTENER_READ;
+import static gravit.code.experiment.txevent.fixture.TraceRecorder.LISTENER;
+import static gravit.code.experiment.txevent.fixture.TraceRecorder.ORIGIN_VISIBLE_TO_LISTENER;
+
+/**
+ * 안티패턴 ⑤ — BEFORE_COMMIT + 비동기 + REQUIRES_NEW.
+ * <p>
+ * 다른 스레드로 위임되는 순간 BEFORE_COMMIT이 약속하는 두 가지가 모두 사라진다.
+ * <ul>
+ *     <li>"커밋 전 실행" — 실행은 커밋 전이 맞지만, 별도 트랜잭션이라 원본의 미커밋 데이터를 볼 수 없다.</li>
+ *     <li>"원본 개입" — 예외를 던져도 원본 스레드에 닿지 못해 롤백을 유발하지 못한다.</li>
+ * </ul>
+ */
+@RequiredArgsConstructor
+public class BeforeCommitAsyncNewTxListener {
+
+    private static final long GATE_TIMEOUT_SECONDS = 5L;
+
+    private final ExperimentRecordRepository experimentRecordRepository;
+    private final TraceRecorder traceRecorder;
+    private final ExperimentGate experimentGate;
+
+    @Order(1)
+    @Async("experimentAsync")
+    @TransactionalEventListener(phase = TransactionPhase.BEFORE_COMMIT)
+    @Transactional(propagation = Propagation.REQUIRES_NEW)
+    public void handle(ExperimentEvent.BeforeCommitAsyncNewTx event) {
+        try {
+            traceRecorder.capture(LISTENER);
+
+            // 원본은 아직 커밋 전이다. 그러나 별도 스레드의 별도 트랜잭션이라 READ_COMMITTED에서 보이지 않는다.
+            traceRecorder.putFlag(ORIGIN_VISIBLE_TO_LISTENER, experimentRecordRepository.existsByTag(event.originTag()));
+
+            experimentRecordRepository.save(ExperimentRecord.create(event.listenerTag()));
+
+            if (event.listenerThrows()) {
+                throw new IllegalStateException(LISTENER_FAILURE_MESSAGE);
+            }
+        } catch (Exception e) {
+            traceRecorder.captureError(LISTENER, e);
+            throw e;
+        } finally {
+            experimentGate.signalListenerRead();
+        }
+    }
+
+    /**
+     * {@code @Order(1)}이 비동기 위임 후 즉시 반환하므로, 원본 스레드를 여기서 붙잡아
+     * 비동기 리스너가 "원본 미커밋" 상태를 관찰할 창을 연다. {@code @Async}가 없으니 원본 스레드에서 동기 실행된다.
+     * <p>
+     * 이 메서드는 {@code triggerBeforeCommit} 안에서 실행되므로 {@code doCommit}보다 앞선다.
+     * 즉 여기서 대기하는 동안 원본은 확실히 미커밋 상태다.
+     */
+    @Order(2)
+    @TransactionalEventListener(phase = TransactionPhase.BEFORE_COMMIT)
+    public void holdOriginUncommitted(ExperimentEvent.BeforeCommitAsyncNewTx event) {
+        boolean signaledByListener = experimentGate.awaitListenerRead(GATE_TIMEOUT_SECONDS, TimeUnit.SECONDS);
+
+        // 타임아웃으로 풀렸다면 원본이 먼저 커밋됐을 수 있어 관찰이 무의미하다. 테스트가 이 값을 단언한다.
+        traceRecorder.putFlag(GATE_HELD_UNTIL_LISTENER_READ, signaledByListener);
+    }
+}

--- a/src/test/java/gravit/code/experiment/txevent/listener/BeforeCommitSyncRequiredListener.java
+++ b/src/test/java/gravit/code/experiment/txevent/listener/BeforeCommitSyncRequiredListener.java
@@ -1,0 +1,37 @@
+package gravit.code.experiment.txevent.listener;
+
+import gravit.code.experiment.txevent.fixture.ExperimentEvent;
+import gravit.code.experiment.txevent.fixture.ExperimentRecord;
+import gravit.code.experiment.txevent.fixture.ExperimentRecordRepository;
+import gravit.code.experiment.txevent.fixture.TraceRecorder;
+import lombok.RequiredArgsConstructor;
+import org.springframework.transaction.annotation.Propagation;
+import org.springframework.transaction.annotation.Transactional;
+import org.springframework.transaction.event.TransactionPhase;
+import org.springframework.transaction.event.TransactionalEventListener;
+
+import static gravit.code.experiment.txevent.fixture.ExperimentEvent.LISTENER_FAILURE_MESSAGE;
+import static gravit.code.experiment.txevent.fixture.TraceRecorder.LISTENER;
+
+/**
+ * 권장 조합 ① — BEFORE_COMMIT + 동기 + REQUIRED.
+ * 원본 트랜잭션에 참여해 하나로 커밋/롤백된다.
+ */
+@RequiredArgsConstructor
+public class BeforeCommitSyncRequiredListener {
+
+    private final ExperimentRecordRepository experimentRecordRepository;
+    private final TraceRecorder traceRecorder;
+
+    @TransactionalEventListener(phase = TransactionPhase.BEFORE_COMMIT)
+    @Transactional(propagation = Propagation.REQUIRED)
+    public void handle(ExperimentEvent.BeforeCommitSyncRequired event) {
+        traceRecorder.capture(LISTENER);
+
+        experimentRecordRepository.save(ExperimentRecord.create(event.listenerTag()));
+
+        if (event.listenerThrows()) {
+            throw new IllegalStateException(LISTENER_FAILURE_MESSAGE);
+        }
+    }
+}


### PR DESCRIPTION
### 1. 연관 이슈

---
 - close #432

<br>

### 2. 구현 사항

---
**구현 사항 1 — 조합별 실험 코드 추가 (프로덕션 코드 무변경)**

- 추가: `src/test/java/gravit/code/experiment/txevent/` — 이벤트·발행자·리스너 5종·관찰용 fixture와 통합 테스트 2개(`RecommendedCombinationIntegrationTest`, `AntiPatternCombinationIntegrationTest`, 10개 시나리오)
- 수정: `build.gradle` — `test`에서 `experiment` 태그 제외, 전용 `experimentTest` 태스크 추가. 실험은 Testcontainers 컨텍스트를 따로 띄우므로 CI 기본 실행에서 빼고 `./gradlew experimentTest`로만 돌린다
- 조합마다 **어노테이션만 다른 동일한 구조**의 리스너를 두어 조합 외의 변수를 통제했다

<br>

**구현 사항 2 — 조합별 관측 결과**

원본 트랜잭션이 행을 하나 저장하고 이벤트를 발행하면, 리스너가 또 다른 행을 저장한다. 이 두 행이 살아남는지를 **데이터 잔존 / 트랜잭션 경계 / 스레드 경계 / 예외 전파 방향** 네 가지로 관찰했다.

| # | phase | 스레드 | propagation | 트랜잭션·스레드 경계 | 리스너 정상 | 리스너 예외 |
|---|---|---|---|---|---|---|
| ① | BEFORE_COMMIT | 동기 | REQUIRED | 원본 트랜잭션에 참여 (같은 EntityManager·같은 스레드) | 둘 다 커밋 | **원본까지 롤백**, 예외가 요청 스레드로 전파 |
| ② | AFTER_COMMIT | 동기 | REQUIRES_NEW | 새 트랜잭션, 같은 스레드 | 둘 다 커밋 | 원본 유지 / 리스너만 롤백 / **예외 삼켜짐** |
| ③ | AFTER_COMMIT | 비동기 | REQUIRES_NEW | 새 트랜잭션, 비동기 풀 스레드 | 둘 다 커밋 | 원본 유지 / 리스너만 롤백 / 예외 삼켜짐 |
| ④ | AFTER_COMMIT | 동기 | REQUIRED | **이미 커밋이 끝난 원본 트랜잭션에 참여** (같은 EntityManager) | ⚠️ **예외 없이 리스너 쓰기 유실** | (구분 불가) |
| ⑤ | BEFORE_COMMIT | 비동기 | REQUIRES_NEW | 새 트랜잭션, 비동기 풀 스레드 | 원본과 리스너가 각자 커밋 | 원본 롤백 **못 시킴** |

**리스너가 원본이 저장한 행을 조회할 수 있는가** (`existsByTag(원본태그)`)

- ② `true` / ③ `true` — 원본이 이미 커밋된 뒤에 실행되므로 보인다
- ⑤ `false` — 커밋 전이지만 별도 스레드의 별도 커넥션이라 READ_COMMITTED에서 보이지 않는다

②③이 모두 `true`라는 점이 중요하다. 스레드가 갈라져서 못 보는 게 아니라 **phase 때문에** 못 보는 것임을 ③이 분리해 준다. 같은 `REQUIRES_NEW`인데 phase가 가시성을 가른다.

**판단 기준으로 `transactionName`을 쓰면 안 된다.** ④에서도 트랜잭션 이름은 새 트랜잭션인 것처럼 갱신되어 속는다. 같은 트랜잭션에 참여했는지는 **`EntityManager` 인스턴스가 동일한지**로 봐야 한다.

<br>

**구현 사항 3 — AFTER_COMMIT 리스너의 `@Transactional` 제약과 우회 경로** ⚠️ 가장 중요

Spring 6.1부터 `RestrictedTransactionalEventListenerFactory`가 **AFTER_COMMIT(및 AFTER_ROLLBACK / AFTER_COMPLETION) 리스너 메서드에는 `REQUIRES_NEW`와 `NOT_SUPPORTED` 외의 `@Transactional`을 허용하지 않는다.** `REQUIRED`를 붙이면 애플리케이션이 아예 기동하지 않는다.

```
IllegalStateException: @TransactionalEventListener method must not be annotated with
@Transactional unless when declared as REQUIRES_NEW or NOT_SUPPORTED
  at RestrictedTransactionalEventListenerFactory.createApplicationListener
```

- **BEFORE_COMMIT은 이 검증 대상에서 제외된다.** 그래서 조합 ①이 정상 기동한다 — Spring이 ①을 정당한 조합으로 인정한다는 뜻이다.
- 뒤집어 말하면 **AFTER_COMMIT에서 권장 조합 ②③은 Spring이 강제하는 유일한 선택지**다.

<br>

**그런데 이 검증은 리스너 메서드·클래스에 붙은 어노테이션만 본다. 리스너가 무엇을 호출하는지는 보지 않는다.**

```java
@TransactionalEventListener(phase = AFTER_COMMIT)   // @Transactional 없음 → 검증 통과
public void handle(SomeEvent event) {
    someCommandService.doSomething();               // 이 안에 @Transactional(REQUIRED) → 조합 ④가 그대로 성립
}
```

이 경우 `REQUIRED`는 새 트랜잭션을 열지 않고 **이미 커밋이 끝난 원본 트랜잭션에 참여한다.** 그 트랜잭션은 다시 커밋되지 않으므로 **리스너의 쓰기는 예외 하나 없이 사라진다.** `SimpleJpaRepository`의 메서드에도 `@Transactional`이 붙어 있어서, **리스너에서 리포지토리를 직접 호출하기만 해도 똑같은 일이 벌어진다.**

**우리 프로덕션 리스너들이 정확히 이 형태다** (`LearningEventListener` → `LearningCommandService`). 지금은 전부 BEFORE_COMMIT이라 안전하지만, **phase만 AFTER_COMMIT으로 바꾸면 컴파일도 기동도 정상인 채로 쓰기가 유실된다.** 그래서 실험에서도 ④는 리스너가 호출하는 `ExperimentRecordWriter`에 `REQUIRED`를 두는 방식으로 재현했다.

<br>

**구현 사항 4 — 그 외 새로 알아낸 것** (상세는 위키로 분리 예정)

**1) AFTER_COMMIT 리스너의 예외는 요청 스레드로 전파되지 않는다 (이슈 본문 표 정정)**

동기 AFTER_COMMIT이면 예외가 응답에 반영될 것 같지만, 실제로는 삼켜지고 ERROR 로그만 남는다.
`TransactionalApplicationListenerSynchronization`은 `afterCommit()`을 구현하지 않아 **`afterCompletion(STATUS_COMMITTED)` 경로로 실행**되는데, `TransactionSynchronizationUtils.invokeAfterCompletion`은 `catch (Throwable)`로 예외를 삼킨다 (`invokeAfterCommit`에는 catch가 없다).

→ **후속 작업의 성패를 사용자 응답에 반영하는 것은 AFTER_COMMIT으로는 불가능하다.**
→ ②와 ③의 실질적 차이는 "예외가 응답에 반영되는가"가 아니라 **요청 스레드 점유(응답 지연)와 리스너 간 실행 순서 보장**이다.
→ 실전 영향: `NotificationEventListener`(②형)의 실패는 요청에 드러나지 않고 로그로만 남는다. **알림 유실을 인지하려면 로그 알람이나 재처리 경로가 필요하다.**

<br>

**2) ④의 쓰기 유실은 롤백이 아니라 INSERT가 발행조차 되지 않아서 생긴다**

처음엔 "INSERT는 DB에 도달했다가 커넥션 반납 시 롤백된다"고 예상했으나, 리스너가 자기 트랜잭션 안에서 방금 저장한 행을 다시 조회하게 해보니 **`false`** 였다. 자기 커넥션에서조차 보이지 않는다.

AFTER_COMMIT 콜백 구간에서는 **Spring과 Hibernate가 트랜잭션 상태를 다르게 판단한다.**

| | 판단 |
|---|---|
| Spring `isActualTransactionActive()` | **true** ← 그래서 REQUIRED가 참여한다 |
| Hibernate `isTransactionInProgress()` | **false** ← 원본 `EntityTransaction`은 이미 커밋됐다 |

Hibernate가 트랜잭션이 없다고 보면 identity insert가 지연되고(`DelayedPostInsertIdentifier`), `autoFlushIfRequired`도 첫 줄에서 곧바로 반환해 flush가 일어나지 않는다. 결국 INSERT가 `ActionQueue`에 담긴 채 `EntityManager`가 닫히면서 **커밋되지 못하고 사라진다. 롤백 로그조차 남지 않는다.**

<br>

**3) ⑤는 BEFORE_COMMIT을 쓰는 이유를 둘 다 잃는다**

BEFORE_COMMIT을 고르는 이유는 "원본의 미커밋 데이터를 볼 수 있다"와 "실패 시 원본을 롤백시킬 수 있다" 둘인데, `@Async`를 붙이는 순간 별도 스레드·별도 커넥션이 되어 **둘 다 사라진다.** 그럴 바엔 ③을 쓰는 편이 원본 가시성까지 얻으므로, **⑤를 선택할 이유가 없다.**

<br>

**결론**

- 리스너 실패 시 **원본까지 되돌려야 한다면 ①이 유일한 선택지**다
- 원본을 지키고 리스너를 부가 작업으로 처리하려면 ②, 응답 지연까지 피하려면 ③
- **④는 예외 없이 데이터를 잃고, ⑤는 BEFORE_COMMIT을 쓴 의미가 없다**

<br>

**검증**

`./gradlew experimentTest` — 10개 시나리오 전부 통과(Docker 필요). CI에서는 `experiment` 태그로 제외된다.
