### PR TITLE
hotfix: 연속 학습일 응답을 weekly-record로 이동(#438)

### DIFF
--- a/.claude/resources/plans/PLAN-438.md
+++ b/.claude/resources/plans/PLAN-438.md
@@ -1,0 +1,119 @@
+# [PLAN-438] main-pages 연속 학습일(consecutiveSolvedDays) 응답 위치 이동(learning→weekly-record)
+
+> 이슈: #438
+> 브랜치: hotfix/438-move-consecutive-solved-days
+
+## 목표
+연속 학습일(`consecutiveSolvedDays`)을 `GET /api/v1/main-pages/learning` 응답(`LearningDetailResponse`)에서 제거하고 `GET /api/v1/main-pages/weekly-record` 응답(`WeeklyLearningRecordResponse`)으로 옮긴다. 값 자체는 `learning` 도메인(`Learning.consecutiveSolvedDays`)에서 오고, 주간 요일 기록은 `dailyLearningRecord` 도메인에서 오므로 두 도메인 Service를 결합하는 신규 `DailyLearningRecordFacade`를 도입한다. DB 컬럼(`learning.consecutive_solved_days`)은 변경 없음 → Flyway 마이그레이션 없음.
+
+## 영향 범위
+### 신규 파일
+- `src/main/java/gravit/code/dailyLearningRecord/facade/DailyLearningRecordFacade.java` — 연속 학습일(learning) + 주간 요일 기록(dailyLearningRecord) 결합해 `WeeklyLearningRecordResponse` 조립
+- `src/test/java/gravit/code/dailyLearningRecord/facade/DailyLearningRecordFacadeIntegrationTest.java` — 신규 Facade 검증(연속일 결합 + 요일 기록 + Learning 미존재 404)
+
+### 수정 파일
+- `src/main/java/gravit/code/dailyLearningRecord/dto/response/WeeklyLearningRecordResponse.java` — `consecutiveSolvedDays` 필드 추가 + 정적 팩토리 `of(int, Set<DayOfWeek>)` 추가
+- `src/main/java/gravit/code/dailyLearningRecord/service/DailyLearningRecordService.java` — `getWeeklyLearningRecord(long): WeeklyLearningRecordResponse` → `getWeeklySolvedDays(long): Set<DayOfWeek>`로 변경(DTO 조립 책임 제거, 조회한 요일 Set만 반환)
+- `src/main/java/gravit/code/user/controller/MainPageController.java` — `/weekly-record`를 `DailyLearningRecordFacade`에 위임, `DailyLearningRecordService` 주입 제거
+- `src/main/java/gravit/code/user/controller/docs/MainPageControllerDocs.java` — `getWeeklyRecord`에 404(`LEARNING_4041`) 응답·설명 보강, `getLearning` 변경 없음
+- `src/main/java/gravit/code/learning/dto/response/LearningDetailResponse.java` — `consecutiveSolvedDays` record 컴포넌트 + `of()` 파라미터 제거
+- `src/main/java/gravit/code/learning/facade/LearningFacade.java` — `getLearningDetail`의 `LearningDetailResponse.of(...)` 호출에서 `consecutiveSolvedDays` 인자 제거(`Learning`은 `recentSolvedChapterId` 때문에 계속 조회)
+- `src/main/java/gravit/code/user/facade/UserFacade.java` — (1) private `getLearningDetail`의 `of()` 인자 제거, (2) deprecated `getMainPage`에서 없어진 서비스 메서드 대체 조립
+- `src/test/java/gravit/code/dailyLearningRecord/service/DailyLearningRecordServiceIntegrationTest.java` — `GetWeeklyLearningRecordResponse` 5개 테스트를 `getWeeklySolvedDays` + `Set<DayOfWeek>` 단언으로 변경
+- `src/test/java/gravit/code/learning/facade/LearningFacadeIntegrationTest.java` — `GetLearningDetail`의 `consecutiveSolvedDays()` 단언 제거
+- `src/test/java/gravit/code/user/facade/UserFacadeIntegrationTest.java` — `getMainPage`의 `learningDetailResponse().consecutiveSolvedDays()` 단언을 `weeklyLearningRecordResponse().consecutiveSolvedDays()`로 이동
+
+## 구현 계획
+> 레이어 순. `Learning` 엔티티/`learning.consecutive_solved_days` 컬럼은 그대로이며, `getConsecutiveSolvedDays()` getter도 그대로 사용한다.
+
+1. **Entity / Flyway**: 변경 없음 (컬럼 이동 아님, API 응답 위치만 이동).
+
+2. **Repository**: 변경 없음.
+
+3. **DTO — `WeeklyLearningRecordResponse`** (`dailyLearningRecord/dto/response/`)
+   - record 컴포넌트 맨 앞에 추가: `@Schema(requiredMode = Schema.RequiredMode.REQUIRED) int consecutiveSolvedDays` (기존 7개 요일 boolean은 순서·이름 유지)
+   - 정적 팩토리 추가(생성자 직접 호출 대신 컨벤션 준수):
+     ```java
+     public static WeeklyLearningRecordResponse of(
+             int consecutiveSolvedDays,
+             Set<DayOfWeek> solvedDays
+     ) {
+         return new WeeklyLearningRecordResponse(
+                 consecutiveSolvedDays,
+                 solvedDays.contains(DayOfWeek.MONDAY),
+                 solvedDays.contains(DayOfWeek.TUESDAY),
+                 solvedDays.contains(DayOfWeek.WEDNESDAY),
+                 solvedDays.contains(DayOfWeek.THURSDAY),
+                 solvedDays.contains(DayOfWeek.FRIDAY),
+                 solvedDays.contains(DayOfWeek.SATURDAY),
+                 solvedDays.contains(DayOfWeek.SUNDAY)
+         );
+     }
+     ```
+   - import 추가: `java.time.DayOfWeek`, `java.util.Set`
+
+4. **Service — `DailyLearningRecordService`** (`dailyLearningRecord/service/`)
+   - `getWeeklyLearningRecord(long userId)` → `getWeeklySolvedDays(long userId)`로 개명, 반환 타입 `WeeklyLearningRecordResponse` → `Set<DayOfWeek>`
+   - 본문: 기존 `monday`/`sunday` 계산 + `findSolvedDatesByUserIdAndDateRange(...).stream().map(LocalDate::getDayOfWeek).collect(toUnmodifiableSet())` 까지 유지하고 그 `Set<DayOfWeek>`를 그대로 반환 (DTO 생성 부분 삭제)
+   - `@Transactional(readOnly = true)` 유지, `WeeklyLearningRecordResponse` import 제거
+
+5. **Facade — `DailyLearningRecordFacade` (신규)** (`dailyLearningRecord/facade/`)
+   - `@Facade` + `@RequiredArgsConstructor`
+   - 필드: `DailyLearningRecordService dailyLearningRecordService`, `LearningQueryService learningQueryService`
+   - 메서드:
+     ```java
+     @Transactional(readOnly = true)
+     public WeeklyLearningRecordResponse getWeeklyLearningRecord(long userId) {
+         int consecutiveSolvedDays = learningQueryService.getLearning(userId).getConsecutiveSolvedDays();
+
+         Set<DayOfWeek> solvedDays = dailyLearningRecordService.getWeeklySolvedDays(userId);
+
+         return WeeklyLearningRecordResponse.of(consecutiveSolvedDays, solvedDays);
+     }
+     ```
+   - 근거: Service는 단일 도메인만 담당(타 도메인 Service 직접 호출 금지)하므로, `learning`+`dailyLearningRecord` 결합은 Facade 책임.
+
+6. **Facade — `LearningFacade.getLearningDetail`** (`learning/facade/`)
+   - `LearningDetailResponse.of(...)` 호출에서 첫 인자 `learning.getConsecutiveSolvedDays()` 제거
+   - `Learning learning = learningQueryService.getLearning(userId);`와 `learning.getRecentSolvedChapterId()`는 그대로 유지
+
+7. **DTO — `LearningDetailResponse`** (`learning/dto/response/`)
+   - record 컴포넌트 `int consecutiveSolvedDays`(+ 위의 `@Schema`) 제거
+   - `of(...)`에서 `consecutiveSolvedDays` 파라미터·`.consecutiveSolvedDays(...)` 빌더 호출 제거
+   - 남는 컴포넌트: `recentSolvedChapterId`, `recentSolvedChapterTitle`, `recentSolvedChapterProgressRate`, `units`
+
+8. **Facade — `UserFacade`** (`user/facade/`) — deprecated 경로 유지 목적
+   - private `getLearningDetail(long, Learning)`: `LearningDetailResponse.of(...)`에서 `learning.getConsecutiveSolvedDays()` 인자 제거
+   - `getMainPage(long)`: 72번 라인 `dailyLearningRecordService.getWeeklyLearningRecord(userId)`가 사라지므로 아래로 교체(이미 지역변수 `learning` 보유):
+     ```java
+     Set<DayOfWeek> solvedDays = dailyLearningRecordService.getWeeklySolvedDays(userId);
+     WeeklyLearningRecordResponse weeklyLearningRecordResponse =
+             WeeklyLearningRecordResponse.of(learning.getConsecutiveSolvedDays(), solvedDays);
+     ```
+   - import 추가: `java.time.DayOfWeek`, `java.util.Set` (기존 `WeeklyLearningRecordResponse` import 유지)
+
+9. **Controller — `MainPageController`** (`user/controller/`)
+   - 필드 `DailyLearningRecordService dailyLearningRecordService` → `DailyLearningRecordFacade dailyLearningRecordFacade`로 교체(해당 서비스는 `/weekly-record`에서만 사용)
+   - `getWeeklyRecord`: `dailyLearningRecordFacade.getWeeklyLearningRecord(loginUser.getId())` 위임
+   - import 교체: `DailyLearningRecordService` → `DailyLearningRecordFacade`
+
+10. **Docs — `MainPageControllerDocs.getWeeklyRecord`** (`user/controller/docs/`)
+    - `@Operation` 설명에 연속 학습일 포함되도록 보강("주간 학습 기록(연속 학습일, 요일별 학습 여부)")
+    - 404 `@ApiResponse` 추가: `LEARNING_4041`("학습 정보 조회에 실패하였습니다.") — weekly-record가 이제 `getLearning`에 의존하므로. `getLearning` docs는 변경 없음(설명에 연속 학습일 언급 없음)
+
+## 결정 필요 (Decisions needed)
+- [x] 연속 학습일 조립 위치 — 신규 `DailyLearningRecordFacade`로 결정. (Service의 타 도메인 호출 금지 컨벤션상 Facade가 유일한 정석. 대안인 "Controller에서 두 서비스 조합"은 Controller 비즈니스 로직 금지 위반)
+- [x] weekly-record의 Learning 의존으로 인한 404 발생 — 허용으로 결정. 모든 유저는 가입 시 `LearningCommandService`가 `Learning.create`로 생성하므로 실질 발생 없음. 기존 `/learning`도 동일하게 `getLearning` 404를 가지므로 일관됨. Swagger에 404 명시.
+
+## 검증
+- 대상 테스트:
+  - `DailyLearningRecordFacadeIntegrationTest`(신규) — ① 연속 학습일(예: 7)이 응답에 실린다 ② 요일별 학습 여부가 정확히 매핑된다 ③ `Learning` 미존재 시 `RestApiException(LEARNING_NOT_FOUND)`
+  - `DailyLearningRecordServiceIntegrationTest`(수정) — `GetWeeklyLearningRecordResponse` 5개 시나리오를 `getWeeklySolvedDays` 호출 + `assertThat(result).contains(DayOfWeek.MONDAY)` / `doesNotContain(...)` 형태로 변경
+  - `LearningFacadeIntegrationTest`(수정) — `GetLearningDetail`에서 `consecutiveSolvedDays()` 단언 2건 제거(나머지 recentSolvedChapter/units/404 단언 유지)
+  - `UserFacadeIntegrationTest`(수정) — `getMainPage` 테스트의 `learningDetailResponse().consecutiveSolvedDays()` → `weeklyLearningRecordResponse().consecutiveSolvedDays()`로 이동(getMyPageBanner의 `consecutiveSolvedDays` 단언은 `MyPageBannerResponse` 소속이라 변경 없음)
+  - `./gradlew compileJava compileTestJava` — 미사용 import/시그니처 오류 확인
+  - `./gradlew test` — 전체 통과 확인
+
+## Deviation Log
+- `LearningFacadeIntegrationTest.java`: 계획은 `consecutiveSolvedDays()` 단언만 제거였으나, 첫 테스트의 `ReflectionTestUtils.setField(learning, "consecutiveSolvedDays", 5)`도 함께 제거 — 이유: 단언이 사라져 해당 setField가 죽은 준비 코드가 됨.
+- 검증(`./gradlew test`)은 미완료 — 이유: 대상 테스트가 전부 `@TCSpringBootTest`(Testcontainers)인데 현재 환경에 Docker 데몬이 없어 실행 불가(`DockerClientProviderStrategy` NoClassDefFoundError). `./gradlew compileJava compileTestJava`는 성공. Docker 기동 후 재실행 필요.

--- a/src/main/java/gravit/code/dailyLearningRecord/dto/response/WeeklyLearningRecordResponse.java
+++ b/src/main/java/gravit/code/dailyLearningRecord/dto/response/WeeklyLearningRecordResponse.java
@@ -2,7 +2,13 @@ package gravit.code.dailyLearningRecord.dto.response;
 
 import io.swagger.v3.oas.annotations.media.Schema;
 
+import java.time.DayOfWeek;
+import java.util.Set;
+
 public record WeeklyLearningRecordResponse(
+        @Schema(requiredMode = Schema.RequiredMode.REQUIRED)
+        int consecutiveSolvedDays,
+
         @Schema(requiredMode = Schema.RequiredMode.REQUIRED)
         boolean MONDAY,
 
@@ -24,4 +30,19 @@ public record WeeklyLearningRecordResponse(
         @Schema(requiredMode = Schema.RequiredMode.REQUIRED)
         boolean SUNDAY
 ) {
+    public static WeeklyLearningRecordResponse of(
+            int consecutiveSolvedDays,
+            Set<DayOfWeek> solvedDays
+    ) {
+        return new WeeklyLearningRecordResponse(
+                consecutiveSolvedDays,
+                solvedDays.contains(DayOfWeek.MONDAY),
+                solvedDays.contains(DayOfWeek.TUESDAY),
+                solvedDays.contains(DayOfWeek.WEDNESDAY),
+                solvedDays.contains(DayOfWeek.THURSDAY),
+                solvedDays.contains(DayOfWeek.FRIDAY),
+                solvedDays.contains(DayOfWeek.SATURDAY),
+                solvedDays.contains(DayOfWeek.SUNDAY)
+        );
+    }
 }

--- a/src/main/java/gravit/code/dailyLearningRecord/facade/DailyLearningRecordFacade.java
+++ b/src/main/java/gravit/code/dailyLearningRecord/facade/DailyLearningRecordFacade.java
@@ -1,0 +1,28 @@
+package gravit.code.dailyLearningRecord.facade;
+
+import gravit.code.dailyLearningRecord.dto.response.WeeklyLearningRecordResponse;
+import gravit.code.dailyLearningRecord.service.DailyLearningRecordService;
+import gravit.code.global.annotation.Facade;
+import gravit.code.learning.service.LearningQueryService;
+import lombok.RequiredArgsConstructor;
+import org.springframework.transaction.annotation.Transactional;
+
+import java.time.DayOfWeek;
+import java.util.Set;
+
+@Facade
+@RequiredArgsConstructor
+public class DailyLearningRecordFacade {
+
+    private final DailyLearningRecordService dailyLearningRecordService;
+    private final LearningQueryService learningQueryService;
+
+    @Transactional(readOnly = true)
+    public WeeklyLearningRecordResponse getWeeklyLearningRecord(long userId) {
+        int consecutiveSolvedDays = learningQueryService.getLearning(userId).getConsecutiveSolvedDays();
+
+        Set<DayOfWeek> solvedDays = dailyLearningRecordService.getWeeklySolvedDays(userId);
+
+        return WeeklyLearningRecordResponse.of(consecutiveSolvedDays, solvedDays);
+    }
+}

--- a/src/main/java/gravit/code/dailyLearningRecord/service/DailyLearningRecordService.java
+++ b/src/main/java/gravit/code/dailyLearningRecord/service/DailyLearningRecordService.java
@@ -2,7 +2,6 @@ package gravit.code.dailyLearningRecord.service;
 
 import gravit.code.dailyLearningRecord.domain.DailyLearningRecord;
 import gravit.code.dailyLearningRecord.dto.response.DailySolvedCountResponse;
-import gravit.code.dailyLearningRecord.dto.response.WeeklyLearningRecordResponse;
 import gravit.code.dailyLearningRecord.dto.response.WeeklyLearningReportResponse;
 import gravit.code.dailyLearningRecord.repository.DailyLearningRecordRepository;
 import gravit.code.global.consts.TimeZoneConst;
@@ -25,24 +24,14 @@ public class DailyLearningRecordService {
     private final DailyLearningRecordRepository dailyLearningRecordRepository;
 
     @Transactional(readOnly = true)
-    public WeeklyLearningRecordResponse getWeeklyLearningRecord(long userId) {
+    public Set<DayOfWeek> getWeeklySolvedDays(long userId) {
         LocalDate today = LocalDate.now(TimeZoneConst.KST);
         LocalDate monday = today.with(DayOfWeek.MONDAY);
         LocalDate sunday = today.with(DayOfWeek.SUNDAY);
 
-        Set<DayOfWeek> solvedDays = dailyLearningRecordRepository.findSolvedDatesByUserIdAndDateRange(userId, monday, sunday).stream()
+        return dailyLearningRecordRepository.findSolvedDatesByUserIdAndDateRange(userId, monday, sunday).stream()
                 .map(LocalDate::getDayOfWeek)
                 .collect(Collectors.toUnmodifiableSet());
-
-        return new WeeklyLearningRecordResponse(
-                solvedDays.contains(DayOfWeek.MONDAY),
-                solvedDays.contains(DayOfWeek.TUESDAY),
-                solvedDays.contains(DayOfWeek.WEDNESDAY),
-                solvedDays.contains(DayOfWeek.THURSDAY),
-                solvedDays.contains(DayOfWeek.FRIDAY),
-                solvedDays.contains(DayOfWeek.SATURDAY),
-                solvedDays.contains(DayOfWeek.SUNDAY)
-        );
     }
 
     @Transactional(readOnly = true)

--- a/src/main/java/gravit/code/learning/dto/response/LearningDetailResponse.java
+++ b/src/main/java/gravit/code/learning/dto/response/LearningDetailResponse.java
@@ -10,9 +10,6 @@ import java.util.List;
 @Builder(access = AccessLevel.PRIVATE)
 public record LearningDetailResponse(
         @Schema(requiredMode = Schema.RequiredMode.REQUIRED)
-        int consecutiveSolvedDays,
-
-        @Schema(requiredMode = Schema.RequiredMode.REQUIRED)
         long recentSolvedChapterId,
 
         @Schema(requiredMode = Schema.RequiredMode.REQUIRED)
@@ -25,14 +22,12 @@ public record LearningDetailResponse(
         List<UnitProgressSummaryResponse> units
 ) {
     public static LearningDetailResponse of(
-            int consecutiveSolvedDays,
             long recentSolvedChapterId,
             String recentSolvedChapterTitle,
             double recentSolvedChapterProgressRate,
             List<UnitProgressSummaryResponse> units
     ){
         return LearningDetailResponse.builder()
-                .consecutiveSolvedDays(consecutiveSolvedDays)
                 .recentSolvedChapterId(recentSolvedChapterId)
                 .recentSolvedChapterTitle(recentSolvedChapterTitle)
                 .recentSolvedChapterProgressRate(recentSolvedChapterProgressRate)

--- a/src/main/java/gravit/code/learning/facade/LearningFacade.java
+++ b/src/main/java/gravit/code/learning/facade/LearningFacade.java
@@ -53,7 +53,6 @@ public class LearningFacade {
         double chapterProgressRate = learningProgressRateService.getChapterProgress(chapterId, userId);
 
         return LearningDetailResponse.of(
-                learning.getConsecutiveSolvedDays(),
                 recentSolvedChapter.getId(),
                 recentSolvedChapter.getTitle(),
                 chapterProgressRate,

--- a/src/main/java/gravit/code/user/controller/MainPageController.java
+++ b/src/main/java/gravit/code/user/controller/MainPageController.java
@@ -2,7 +2,7 @@ package gravit.code.user.controller;
 
 import gravit.code.auth.domain.LoginUser;
 import gravit.code.dailyLearningRecord.dto.response.WeeklyLearningRecordResponse;
-import gravit.code.dailyLearningRecord.service.DailyLearningRecordService;
+import gravit.code.dailyLearningRecord.facade.DailyLearningRecordFacade;
 import gravit.code.league.dto.response.LeagueDetailResponse;
 import gravit.code.learning.dto.response.LearningDetailResponse;
 import gravit.code.learning.facade.LearningFacade;
@@ -33,7 +33,7 @@ public class MainPageController implements MainPageControllerDocs {
     private final LearningFacade learningFacade;
     private final UserLeagueService userLeagueService;
     private final UnitQueryService unitQueryService;
-    private final DailyLearningRecordService dailyLearningRecordService;
+    private final DailyLearningRecordFacade dailyLearningRecordFacade;
     private final MissionService missionService;
 
     @GetMapping("/profile")
@@ -58,7 +58,7 @@ public class MainPageController implements MainPageControllerDocs {
 
     @GetMapping("/weekly-record")
     public ResponseEntity<WeeklyLearningRecordResponse> getWeeklyRecord(@AuthenticationPrincipal LoginUser loginUser) {
-        return ResponseEntity.status(HttpStatus.OK).body(dailyLearningRecordService.getWeeklyLearningRecord(loginUser.getId()));
+        return ResponseEntity.status(HttpStatus.OK).body(dailyLearningRecordFacade.getWeeklyLearningRecord(loginUser.getId()));
     }
 
     @GetMapping("/mission")

--- a/src/main/java/gravit/code/user/controller/docs/MainPageControllerDocs.java
+++ b/src/main/java/gravit/code/user/controller/docs/MainPageControllerDocs.java
@@ -122,10 +122,20 @@ public interface MainPageControllerDocs {
     })
     ResponseEntity<List<RecommendedUnitResponse>> getUnits(@AuthenticationPrincipal LoginUser loginUser);
 
-    @Operation(summary = "메인페이지 주간 학습 기록 조회", description = "메인페이지 주간 학습 기록을 조회합니다<br>" +
+    @Operation(summary = "메인페이지 주간 학습 기록 조회", description = "메인페이지 주간 학습 기록(연속 학습일, 요일별 학습 여부)을 조회합니다<br>" +
             "🔐 <strong>Jwt 필요</strong><br>")
     @ApiResponses({
             @ApiResponse(responseCode = "200", description = "✅ 메인페이지 주간 학습 기록 조회 성공"),
+            @ApiResponse(responseCode = "404", description = "🚨 학습 정보 조회 실패",
+                    content = @Content(mediaType = MediaType.APPLICATION_JSON_VALUE,
+                            examples = {
+                                    @ExampleObject(
+                                            name = "학습 정보 조회 실패",
+                                            value = "{\"error\" : \"LEARNING_4041\", \"message\" : \"학습 정보 조회에 실패하였습니다.\"}"
+                                    )
+                            },
+                            schema = @Schema(implementation = ErrorResponse.class))
+            ),
             @ApiResponse(responseCode = "500", description = "🚨 예기치 못한 예외 발생",
                     content = @Content(mediaType = MediaType.APPLICATION_JSON_VALUE,
                             examples = {

--- a/src/main/java/gravit/code/user/facade/UserFacade.java
+++ b/src/main/java/gravit/code/user/facade/UserFacade.java
@@ -25,7 +25,9 @@ import gravit.code.userLeague.service.UserLeagueService;
 import lombok.RequiredArgsConstructor;
 import org.springframework.transaction.annotation.Transactional;
 
+import java.time.DayOfWeek;
 import java.util.List;
+import java.util.Set;
 
 @Facade
 @RequiredArgsConstructor
@@ -69,7 +71,9 @@ public class UserFacade {
 
         List<RecommendedUnitResponse> recommendedUnitResponses = unitQueryService.getRecommendedUnits(userId);
 
-        WeeklyLearningRecordResponse weeklyLearningRecordResponse = dailyLearningRecordService.getWeeklyLearningRecord(userId);
+        Set<DayOfWeek> solvedDays = dailyLearningRecordService.getWeeklySolvedDays(userId);
+        WeeklyLearningRecordResponse weeklyLearningRecordResponse =
+                WeeklyLearningRecordResponse.of(learning.getConsecutiveSolvedDays(), solvedDays);
 
         MissionDetailResponse missionDetailResponse = missionService.getMissionDetail(userId);
 
@@ -114,7 +118,6 @@ public class UserFacade {
         double chapterProgressRate = learningProgressRateService.getChapterProgress(chapterId, userId);
 
         return LearningDetailResponse.of(
-                learning.getConsecutiveSolvedDays(),
                 recentSolvedChapter.getId(),
                 recentSolvedChapter.getTitle(),
                 chapterProgressRate,

--- a/src/test/java/gravit/code/dailyLearningRecord/facade/DailyLearningRecordFacadeIntegrationTest.java
+++ b/src/test/java/gravit/code/dailyLearningRecord/facade/DailyLearningRecordFacadeIntegrationTest.java
@@ -1,0 +1,108 @@
+package gravit.code.dailyLearningRecord.facade;
+
+import gravit.code.dailyLearningRecord.domain.DailyLearningRecord;
+import gravit.code.dailyLearningRecord.dto.response.WeeklyLearningRecordResponse;
+import gravit.code.dailyLearningRecord.repository.DailyLearningRecordRepository;
+import gravit.code.global.exception.domain.RestApiException;
+import gravit.code.learning.domain.Learning;
+import gravit.code.learning.repository.LearningRepository;
+import gravit.code.support.TCSpringBootTest;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Nested;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.test.util.ReflectionTestUtils;
+
+import java.time.DayOfWeek;
+import java.time.LocalDate;
+import java.time.ZoneId;
+
+import static gravit.code.global.exception.domain.CustomErrorCode.LEARNING_NOT_FOUND;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static org.assertj.core.api.SoftAssertions.assertSoftly;
+
+@TCSpringBootTest
+class DailyLearningRecordFacadeIntegrationTest {
+
+    private static final ZoneId KST = ZoneId.of("Asia/Seoul");
+
+    @Autowired
+    private DailyLearningRecordFacade dailyLearningRecordFacade;
+
+    @Autowired
+    private DailyLearningRecordRepository dailyLearningRecordRepository;
+
+    @Autowired
+    private LearningRepository learningRepository;
+
+    private Learning saveLearningWithConsecutiveDays(long userId, int consecutiveSolvedDays) {
+        Learning learning = Learning.create(userId);
+        ReflectionTestUtils.setField(learning, "consecutiveSolvedDays", consecutiveSolvedDays);
+        return learningRepository.save(learning);
+    }
+
+    @Nested
+    @DisplayName("주간 학습 기록을 조회할 때")
+    class GetWeeklyLearningRecord {
+
+        @Test
+        void 연속_학습일과_학습한_요일을_함께_반환한다() {
+            // given
+            long userId = 1L;
+            saveLearningWithConsecutiveDays(userId, 7);
+
+            LocalDate monday = LocalDate.now(KST).with(DayOfWeek.MONDAY);
+            dailyLearningRecordRepository.save(DailyLearningRecord.create(userId, monday));
+            dailyLearningRecordRepository.save(DailyLearningRecord.create(userId, monday.plusDays(2)));
+
+            // when
+            WeeklyLearningRecordResponse result = dailyLearningRecordFacade.getWeeklyLearningRecord(userId);
+
+            // then
+            assertSoftly(softly -> {
+                softly.assertThat(result.consecutiveSolvedDays()).isEqualTo(7);
+                softly.assertThat(result.MONDAY()).isTrue();
+                softly.assertThat(result.TUESDAY()).isFalse();
+                softly.assertThat(result.WEDNESDAY()).isTrue();
+                softly.assertThat(result.THURSDAY()).isFalse();
+                softly.assertThat(result.FRIDAY()).isFalse();
+                softly.assertThat(result.SATURDAY()).isFalse();
+                softly.assertThat(result.SUNDAY()).isFalse();
+            });
+        }
+
+        @Test
+        void 학습한_요일이_없어도_연속_학습일은_반환한다() {
+            // given
+            long userId = 1L;
+            saveLearningWithConsecutiveDays(userId, 3);
+
+            // when
+            WeeklyLearningRecordResponse result = dailyLearningRecordFacade.getWeeklyLearningRecord(userId);
+
+            // then
+            assertSoftly(softly -> {
+                softly.assertThat(result.consecutiveSolvedDays()).isEqualTo(3);
+                softly.assertThat(result.MONDAY()).isFalse();
+                softly.assertThat(result.TUESDAY()).isFalse();
+                softly.assertThat(result.WEDNESDAY()).isFalse();
+                softly.assertThat(result.THURSDAY()).isFalse();
+                softly.assertThat(result.FRIDAY()).isFalse();
+                softly.assertThat(result.SATURDAY()).isFalse();
+                softly.assertThat(result.SUNDAY()).isFalse();
+            });
+        }
+
+        @Test
+        void 학습_정보가_없으면_예외를_던진다() {
+            // given
+            long nonExistentUserId = 999L;
+
+            // when & then
+            assertThatThrownBy(() -> dailyLearningRecordFacade.getWeeklyLearningRecord(nonExistentUserId))
+                    .isInstanceOf(RestApiException.class)
+                    .extracting(e -> ((RestApiException) e).getErrorCode())
+                    .isEqualTo(LEARNING_NOT_FOUND);
+        }
+    }
+}

--- a/src/test/java/gravit/code/dailyLearningRecord/service/DailyLearningRecordServiceIntegrationTest.java
+++ b/src/test/java/gravit/code/dailyLearningRecord/service/DailyLearningRecordServiceIntegrationTest.java
@@ -2,7 +2,6 @@ package gravit.code.dailyLearningRecord.service;
 
 import gravit.code.dailyLearningRecord.domain.DailyLearningRecord;
 import gravit.code.dailyLearningRecord.dto.response.DailySolvedCountResponse;
-import gravit.code.dailyLearningRecord.dto.response.WeeklyLearningRecordResponse;
 import gravit.code.dailyLearningRecord.dto.response.WeeklyLearningReportResponse;
 import gravit.code.dailyLearningRecord.repository.DailyLearningRecordRepository;
 import gravit.code.support.TCSpringBootTest;
@@ -16,6 +15,7 @@ import java.time.LocalDate;
 import java.time.ZoneId;
 import java.util.List;
 import java.util.Optional;
+import java.util.Set;
 
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatCode;
@@ -39,11 +39,11 @@ class DailyLearningRecordServiceIntegrationTest {
     }
 
     @Nested
-    @DisplayName("주간 학습 기록을 조회할 때")
-    class GetWeeklyLearningRecordResponse {
+    @DisplayName("주간 학습 요일을 조회할 때")
+    class GetWeeklySolvedDays {
 
         @Test
-        void 모든_요일에_학습_기록이_있으면_모두_true를_반환한다() {
+        void 모든_요일에_학습_기록이_있으면_모든_요일을_반환한다() {
             // given
             long userId = 1L;
             LocalDate monday = LocalDate.now(KST).with(DayOfWeek.MONDAY);
@@ -52,22 +52,22 @@ class DailyLearningRecordServiceIntegrationTest {
             }
 
             // when
-            WeeklyLearningRecordResponse result = dailyLearningRecordService.getWeeklyLearningRecord(userId);
+            Set<DayOfWeek> result = dailyLearningRecordService.getWeeklySolvedDays(userId);
 
             // then
-            assertSoftly(softly -> {
-                softly.assertThat(result.MONDAY()).isTrue();
-                softly.assertThat(result.TUESDAY()).isTrue();
-                softly.assertThat(result.WEDNESDAY()).isTrue();
-                softly.assertThat(result.THURSDAY()).isTrue();
-                softly.assertThat(result.FRIDAY()).isTrue();
-                softly.assertThat(result.SATURDAY()).isTrue();
-                softly.assertThat(result.SUNDAY()).isTrue();
-            });
+            assertThat(result).containsExactlyInAnyOrder(
+                    DayOfWeek.MONDAY,
+                    DayOfWeek.TUESDAY,
+                    DayOfWeek.WEDNESDAY,
+                    DayOfWeek.THURSDAY,
+                    DayOfWeek.FRIDAY,
+                    DayOfWeek.SATURDAY,
+                    DayOfWeek.SUNDAY
+            );
         }
 
         @Test
-        void 월요일과_수요일만_학습했다면_해당_요일만_true를_반환한다() {
+        void 월요일과_수요일만_학습했다면_해당_요일만_반환한다() {
             // given
             long userId = 1L;
             LocalDate monday = LocalDate.now(KST).with(DayOfWeek.MONDAY);
@@ -75,38 +75,22 @@ class DailyLearningRecordServiceIntegrationTest {
             dailyLearningRecordRepository.save(DailyLearningRecord.create(userId, monday.plusDays(2)));
 
             // when
-            WeeklyLearningRecordResponse result = dailyLearningRecordService.getWeeklyLearningRecord(userId);
+            Set<DayOfWeek> result = dailyLearningRecordService.getWeeklySolvedDays(userId);
 
             // then
-            assertSoftly(softly -> {
-                softly.assertThat(result.MONDAY()).isTrue();
-                softly.assertThat(result.TUESDAY()).isFalse();
-                softly.assertThat(result.WEDNESDAY()).isTrue();
-                softly.assertThat(result.THURSDAY()).isFalse();
-                softly.assertThat(result.FRIDAY()).isFalse();
-                softly.assertThat(result.SATURDAY()).isFalse();
-                softly.assertThat(result.SUNDAY()).isFalse();
-            });
+            assertThat(result).containsExactlyInAnyOrder(DayOfWeek.MONDAY, DayOfWeek.WEDNESDAY);
         }
 
         @Test
-        void 학습_기록이_없으면_모두_false를_반환한다() {
+        void 학습_기록이_없으면_빈_결과를_반환한다() {
             // given
             long userId = 1L;
 
             // when
-            WeeklyLearningRecordResponse result = dailyLearningRecordService.getWeeklyLearningRecord(userId);
+            Set<DayOfWeek> result = dailyLearningRecordService.getWeeklySolvedDays(userId);
 
             // then
-            assertSoftly(softly -> {
-                softly.assertThat(result.MONDAY()).isFalse();
-                softly.assertThat(result.TUESDAY()).isFalse();
-                softly.assertThat(result.WEDNESDAY()).isFalse();
-                softly.assertThat(result.THURSDAY()).isFalse();
-                softly.assertThat(result.FRIDAY()).isFalse();
-                softly.assertThat(result.SATURDAY()).isFalse();
-                softly.assertThat(result.SUNDAY()).isFalse();
-            });
+            assertThat(result).isEmpty();
         }
 
         @Test
@@ -119,18 +103,10 @@ class DailyLearningRecordServiceIntegrationTest {
             dailyLearningRecordRepository.save(DailyLearningRecord.create(userId, nextMonday));
 
             // when
-            WeeklyLearningRecordResponse result = dailyLearningRecordService.getWeeklyLearningRecord(userId);
+            Set<DayOfWeek> result = dailyLearningRecordService.getWeeklySolvedDays(userId);
 
             // then
-            assertSoftly(softly -> {
-                softly.assertThat(result.MONDAY()).isFalse();
-                softly.assertThat(result.TUESDAY()).isFalse();
-                softly.assertThat(result.WEDNESDAY()).isFalse();
-                softly.assertThat(result.THURSDAY()).isFalse();
-                softly.assertThat(result.FRIDAY()).isFalse();
-                softly.assertThat(result.SATURDAY()).isFalse();
-                softly.assertThat(result.SUNDAY()).isFalse();
-            });
+            assertThat(result).isEmpty();
         }
 
         @Test
@@ -142,18 +118,10 @@ class DailyLearningRecordServiceIntegrationTest {
             dailyLearningRecordRepository.save(DailyLearningRecord.create(otherUserId, monday));
 
             // when
-            WeeklyLearningRecordResponse result = dailyLearningRecordService.getWeeklyLearningRecord(userId);
+            Set<DayOfWeek> result = dailyLearningRecordService.getWeeklySolvedDays(userId);
 
             // then
-            assertSoftly(softly -> {
-                softly.assertThat(result.MONDAY()).isFalse();
-                softly.assertThat(result.TUESDAY()).isFalse();
-                softly.assertThat(result.WEDNESDAY()).isFalse();
-                softly.assertThat(result.THURSDAY()).isFalse();
-                softly.assertThat(result.FRIDAY()).isFalse();
-                softly.assertThat(result.SATURDAY()).isFalse();
-                softly.assertThat(result.SUNDAY()).isFalse();
-            });
+            assertThat(result).isEmpty();
         }
     }
 

--- a/src/test/java/gravit/code/learning/facade/LearningFacadeIntegrationTest.java
+++ b/src/test/java/gravit/code/learning/facade/LearningFacadeIntegrationTest.java
@@ -69,7 +69,6 @@ class LearningFacadeIntegrationTest {
 
             Learning learning = Learning.create(user.getId());
             ReflectionTestUtils.setField(learning, "recentSolvedChapterId", chapter.getId());
-            ReflectionTestUtils.setField(learning, "consecutiveSolvedDays", 5);
             learningRepository.save(learning);
 
             // when
@@ -77,7 +76,6 @@ class LearningFacadeIntegrationTest {
 
             // then
             assertSoftly(softly -> {
-                softly.assertThat(result.consecutiveSolvedDays()).isEqualTo(5);
                 softly.assertThat(result.recentSolvedChapterId()).isEqualTo(chapter.getId());
                 softly.assertThat(result.recentSolvedChapterTitle()).isEqualTo("운영체제");
                 softly.assertThat(result.units()).hasSize(2);
@@ -101,7 +99,6 @@ class LearningFacadeIntegrationTest {
 
             // then
             assertSoftly(softly -> {
-                softly.assertThat(result.consecutiveSolvedDays()).isZero();
                 softly.assertThat(result.recentSolvedChapterProgressRate()).isZero();
                 softly.assertThat(result.recentSolvedChapterId()).isEqualTo(chapter.getId());
                 softly.assertThat(result.units()).hasSize(2);

--- a/src/test/java/gravit/code/user/facade/UserFacadeIntegrationTest.java
+++ b/src/test/java/gravit/code/user/facade/UserFacadeIntegrationTest.java
@@ -158,7 +158,7 @@ class UserFacadeIntegrationTest {
 
             // then
             assertSoftly(softly -> {
-                softly.assertThat(result.learningDetailResponse().consecutiveSolvedDays()).isZero();
+                softly.assertThat(result.weeklyLearningRecordResponse().consecutiveSolvedDays()).isZero();
                 softly.assertThat(result.learningDetailResponse().recentSolvedChapterProgressRate()).isZero();
                 softly.assertThat(result.weeklyLearningRecordResponse().MONDAY()).isFalse();
                 softly.assertThat(result.recommendedUnitResponses()).hasSize(2);


### PR DESCRIPTION
### 1. 연관 이슈

---
- close #438

<br>

### 2. 구현 사항

---
- `consecutiveSolvedDays`를 `/main-pages/learning` 응답에서 제거하고 `/main-pages/weekly-record` 응답으로 이동
- 두 도메인(learning + dailyLearningRecord) 결합용 `DailyLearningRecordFacade` 추가
- Swagger: `weekly-record`에 404(LEARNING_4041) 추가


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **변경 사항**
  * 학습 상세 응답에서 연속 학습 일수 정보가 제거되었습니다.
  * 연속 학습 일수와 주간 요일별 학습 기록이 주간 학습 기록 응답에서 함께 제공됩니다.
  * 주간 학습 기록 조회 시 요일별 학습 여부가 정확히 반영됩니다.

* **테스트**
  * 주간 학습 요일 및 연속 학습 일수 응답 검증을 보강했습니다.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->