### PR TITLE
fix: controller 와 docs 의 중복 파라미터 정의 수정

### DIFF
--- a/src/main/java/gravit/code/fcm/controller/FcmTokenController.java
+++ b/src/main/java/gravit/code/fcm/controller/FcmTokenController.java
@@ -7,7 +7,6 @@ import gravit.code.fcm.dto.response.FcmTokenExistsResponse;
 import gravit.code.fcm.service.FcmTokenCommandService;
 import gravit.code.fcm.service.FcmTokenQueryService;
 import jakarta.validation.Valid;
-import jakarta.validation.constraints.NotBlank;
 import lombok.RequiredArgsConstructor;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
@@ -41,7 +40,6 @@ public class FcmTokenController implements FcmTokenControllerDocs {
     @GetMapping("/exists")
     public ResponseEntity<FcmTokenExistsResponse> checkFcmTokenExist(
             @AuthenticationPrincipal LoginUser loginUser,
-            @NotBlank(message = "디바이스 아이디가 비어있습니다.")
             @RequestParam("deviceId") String deviceId
     ){
         return ResponseEntity.status(HttpStatus.OK).body(fcmTokenQueryService.checkFcmTokenExist(loginUser.getId(), deviceId));

--- a/src/main/java/gravit/code/fcm/controller/docs/FcmTokenControllerDocs.java
+++ b/src/main/java/gravit/code/fcm/controller/docs/FcmTokenControllerDocs.java
@@ -13,6 +13,7 @@ import io.swagger.v3.oas.annotations.responses.ApiResponse;
 import io.swagger.v3.oas.annotations.responses.ApiResponses;
 import io.swagger.v3.oas.annotations.tags.Tag;
 import jakarta.validation.Valid;
+import jakarta.validation.constraints.NotBlank;
 import org.springframework.http.MediaType;
 import org.springframework.http.ResponseEntity;
 import org.springframework.security.core.annotation.AuthenticationPrincipal;
@@ -91,6 +92,7 @@ public interface FcmTokenControllerDocs {
     ResponseEntity<FcmTokenExistsResponse> checkFcmTokenExist(
             @AuthenticationPrincipal LoginUser loginUser,
             @Parameter(description = "클라이언트 디바이스 식별자", example = "a1b2c3d4-e5f6-7890-abcd-ef1234567890", required = true)
+            @NotBlank(message = "디바이스 아이디가 비어있습니다.")
             @RequestParam("deviceId") String deviceId
     );
 }

--- a/src/main/java/gravit/code/user/controller/MyPageController.java
+++ b/src/main/java/gravit/code/user/controller/MyPageController.java
@@ -8,8 +8,6 @@ import gravit.code.learning.facade.LearningFacade;
 import gravit.code.user.controller.docs.MyPageControllerDocs;
 import gravit.code.user.dto.response.MyPageBannerResponse;
 import gravit.code.user.facade.UserFacade;
-import jakarta.validation.constraints.Max;
-import jakarta.validation.constraints.Min;
 import lombok.RequiredArgsConstructor;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
@@ -47,7 +45,7 @@ public class MyPageController implements MyPageControllerDocs {
     @GetMapping("/learning/history")
     public ResponseEntity<LearningHistoryResponse> getMyPageLearningHistory(
             @AuthenticationPrincipal LoginUser loginUser,
-            @RequestParam("year") @Min(2025) @Max(2099)int year
+            @RequestParam("year") int year
     ){
         return ResponseEntity.status(HttpStatus.OK).body(learningFacade.getMyPageLearningHistory(loginUser.getId(), year));
     }


### PR DESCRIPTION
### 1. 연관 이슈

---
 - close #이슈 번호

<br>

### 2. 구현 사항

---
**구현 사항 1**

❗️구현 사항에 대한 설명을 최대한 자세하게 적어주세요 ❗


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **변경 사항**
  - FCM 토큰 존재 여부 조회 시 빈 디바이스 ID에 대한 입력 검증이 API 문서 및 계약에 반영되었습니다.
  - 학습 기록 조회의 연도 입력 범위 제한이 제거되어 기존 범위를 벗어난 연도도 요청할 수 있습니다.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->