### PR TITLE
refactor: 친구 검색 인덱스 미사용 개선

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -46,6 +46,7 @@ postgres_data_local
 redis_data_local
 logs
 grafana_data
+pgadmin_data_local
 
 ### Firebase ###
 /src/main/resources/firebase/firebase_service_key.json
@@ -57,3 +58,8 @@ grafana_data
 
 ### 로컬 작업 메모 (커밋 제외) ###
 /.claude/resources/code-cleanup-todo.md
+
+### 로컬 개인 데이터 ###
+benchmark
+docs
+.claude/skills/grill-me

--- a/docker-compose-local.yml
+++ b/docker-compose-local.yml
@@ -22,6 +22,20 @@ services:
     volumes:
       - ./postgres_data_local:/var/lib/postgresql/data
 
+  pgadmin:
+    image: dpage/pgadmin4:latest
+    container_name: gravit-pgadmin-local
+    ports:
+      - "5050:80"                # 브라우저: http://localhost:5050
+    environment:
+      PGADMIN_DEFAULT_EMAIL: admin@example.com
+      PGADMIN_DEFAULT_PASSWORD: admin
+      PGADMIN_CONFIG_SERVER_MODE: "False"          # 단독 로컬용: 로그인 후 마스터 비번 재입력 생략
+    volumes:
+      - ./pgadmin_data_local:/var/lib/pgadmin
+    depends_on:
+      - postgres
+
   alloy:
     image: grafana/alloy:latest
     container_name: gravit-alloy

--- a/src/main/java/gravit/code/friend/repository/sql/FriendsHandleSearchQuerySql.java
+++ b/src/main/java/gravit/code/friend/repository/sql/FriendsHandleSearchQuerySql.java
@@ -2,28 +2,9 @@ package gravit.code.friend.repository.sql;
 
 import lombok.experimental.UtilityClass;
 
-/**
- * 핸들 검색 쿼리. exact → prefix → contains 순으로 페이지를 채운다.
- *
- * <p>아래 규칙은 성능·정확성에 직결되므로 수정 시 반드시 유지해야 한다.
- * 배경과 실측치는 {@code docs/retrospective-friend-search.md} 참고.
- *
- * <ul>
- *   <li><b>ORDER BY handle USING ~&lt;~</b> — 접두 인덱스 ix_users_handle_like_with_id가
- *       varchar_pattern_ops다. 정렬 연산자를 맞춰야 Sort 노드 없이 LIMIT 건수만 읽고 멈춘다.
- *       기본 ORDER BY handle이면 옵티마이저가 유니크 인덱스를 골라 전체를 훑고,
- *       COLLATE "C"로도 패밀리가 달라 매칭되지 않는다.
- *       handle은 [0-9a-f]뿐이라 ~&lt;~ 순서와 기본 순서가 같아 결과는 불변이다.</li>
- *   <li><b>NOT MATERIALIZED</b> — p가 여러 버킷에서 참조되어 materialize되면 LIKE 패턴이
- *       불투명한 값이 되어 접두 인덱스를 못 탄다.</li>
- *   <li><b>contains의 LIMIT need*3</b> — need=0(앞 버킷이 페이지를 채움)이면 LIMIT 0으로
- *       스캔 자체를 건너뛴다. GREATEST(1, need)로 바꾸면 불필요한 전체 스캔이 생긴다.</li>
- * </ul>
- */
 @UtilityClass
 public class FriendsHandleSearchQuerySql {
 
-    // --- Search: contains 포함 버전 ---
     public static final String SELECT_USER_WITH_CONTAINS_BY_HANDLE = """
             WITH p AS NOT MATERIALIZED (
               SELECT :me::bigint AS me,
@@ -113,7 +94,6 @@ public class FriendsHandleSearchQuerySql {
             LIMIT (SELECT lim FROM p) OFFSET (SELECT off FROM p)
             """;
 
-    // --- Search: contains 없는 버전 ---
     public static final String SELECT_USER_NO_CONTAINS_BY_HANDLE = """
             WITH p AS NOT MATERIALIZED (
               SELECT :me::bigint AS me,

--- a/src/main/java/gravit/code/friend/repository/sql/FriendsHandleSearchQuerySql.java
+++ b/src/main/java/gravit/code/friend/repository/sql/FriendsHandleSearchQuerySql.java
@@ -7,7 +7,9 @@ public class FriendsHandleSearchQuerySql {
 
     // --- Search: contains 포함 버전 ---
     public static final String SELECT_USER_WITH_CONTAINS_BY_HANDLE = """
-            WITH p AS (
+            -- NOT MATERIALIZED: p가 여러 버킷에서 참조되어 자동 materialize되면 LIKE 패턴(q_prefix)이
+            -- 불투명한 런타임 값이 되어 접두 인덱스(varchar_pattern_ops)를 못 탄다. 인라인 강제로 인덱스 사용 유지.
+            WITH p AS NOT MATERIALIZED (
               SELECT :me::bigint AS me,
               :q::text AS q,
               :q_prefix::text AS q_prefix,
@@ -36,7 +38,12 @@ public class FriendsHandleSearchQuerySql {
                   AND deleted_at IS NULL
                   AND handle LIKE p.q_prefix
                   AND handle <> p.q
-                ORDER BY handle, id
+                -- COLLATE "C": 접두 검색 인덱스(ix_users_handle_like_with_id = varchar_pattern_ops, C 순서)와
+                -- 정렬 규칙을 일치시킨다. 기본 ORDER BY handle(콜레이션 순서)이면 옵티마이저가 정렬을 맞추려
+                -- users_handle_key(유니크)를 골라 LIKE seek 없이 전체 스캔한다(계획 변동, 수만 페이지).
+                -- 정렬키를 C로 맞추면 접두 인덱스 하나로 seek+정렬을 모두 처리한다.
+                -- handle은 [0-9a-f]뿐이라 C 순서 == 기본 순서 → 결과 불변, 최종 표시는 바깥 ORDER BY가 담당.
+                ORDER BY handle COLLATE "C", id
                 LIMIT p.lim + p.off
               ) u
             ),
@@ -63,7 +70,13 @@ public class FriendsHandleSearchQuerySql {
                   AND handle LIKE p.q_contains
                   AND handle <> p.q
                   AND handle NOT LIKE p.q_prefix
-                LIMIT GREATEST(1, (SELECT need FROM need_contains)) * 3
+                -- 결정성: 정렬 없이 뽑으면 페이지 넘김 시 후보 집합이 달라져 중복/누락 가능.
+                -- 최종 표시 순서(handle, id)로 뽑아 페이지 간 후보를 고정한다.
+                -- (contains는 개선4로 exact+prefix 미충족 시=매칭 적은 경우에만 실행 → 정렬 비용 무시 가능)
+                ORDER BY handle, id
+                -- need*3 (0 허용): exact+prefix가 이미 페이지를 채우면 need=0 → LIMIT 0 → contains 스캔 스킵.
+                -- (기존 GREATEST(1,need)*3은 불필요할 때도 최소 1건을 찾으려 테이블 전체를 헛스캔했다)
+                LIMIT (SELECT need FROM need_contains) * 3
               ) u
             ),
             contains AS MATERIALIZED (
@@ -96,7 +109,9 @@ public class FriendsHandleSearchQuerySql {
 
     // --- Search: contains 없는 버전 ---
     public static final String SELECT_USER_NO_CONTAINS_BY_HANDLE = """
-            WITH p AS (
+            -- NOT MATERIALIZED: p가 여러 버킷에서 참조되어 자동 materialize되면 LIKE 패턴(q_prefix)이
+            -- 불투명한 런타임 값이 되어 접두 인덱스(varchar_pattern_ops)를 못 탄다. 인라인 강제로 인덱스 사용 유지.
+            WITH p AS NOT MATERIALIZED (
               SELECT :me::bigint AS me,
               :q::text AS q,
               :q_prefix::text AS q_prefix,
@@ -124,7 +139,12 @@ public class FriendsHandleSearchQuerySql {
                   AND deleted_at IS NULL
                   AND handle LIKE p.q_prefix
                   AND handle <> p.q
-                ORDER BY handle, id
+                -- COLLATE "C": 접두 검색 인덱스(ix_users_handle_like_with_id = varchar_pattern_ops, C 순서)와
+                -- 정렬 규칙을 일치시킨다. 기본 ORDER BY handle(콜레이션 순서)이면 옵티마이저가 정렬을 맞추려
+                -- users_handle_key(유니크)를 골라 LIKE seek 없이 전체 스캔한다(계획 변동, 수만 페이지).
+                -- 정렬키를 C로 맞추면 접두 인덱스 하나로 seek+정렬을 모두 처리한다.
+                -- handle은 [0-9a-f]뿐이라 C 순서 == 기본 순서 → 결과 불변, 최종 표시는 바깥 ORDER BY가 담당.
+                ORDER BY handle COLLATE "C", id
                 LIMIT p.lim + p.off
               ) u
             ),

--- a/src/main/java/gravit/code/friend/repository/sql/FriendsHandleSearchQuerySql.java
+++ b/src/main/java/gravit/code/friend/repository/sql/FriendsHandleSearchQuerySql.java
@@ -2,13 +2,29 @@ package gravit.code.friend.repository.sql;
 
 import lombok.experimental.UtilityClass;
 
+/**
+ * 핸들 검색 쿼리. exact → prefix → contains 순으로 페이지를 채운다.
+ *
+ * <p>아래 규칙은 성능·정확성에 직결되므로 수정 시 반드시 유지해야 한다.
+ * 배경과 실측치는 {@code docs/retrospective-friend-search.md} 참고.
+ *
+ * <ul>
+ *   <li><b>ORDER BY handle USING ~&lt;~</b> — 접두 인덱스 ix_users_handle_like_with_id가
+ *       varchar_pattern_ops다. 정렬 연산자를 맞춰야 Sort 노드 없이 LIMIT 건수만 읽고 멈춘다.
+ *       기본 ORDER BY handle이면 옵티마이저가 유니크 인덱스를 골라 전체를 훑고,
+ *       COLLATE "C"로도 패밀리가 달라 매칭되지 않는다.
+ *       handle은 [0-9a-f]뿐이라 ~&lt;~ 순서와 기본 순서가 같아 결과는 불변이다.</li>
+ *   <li><b>NOT MATERIALIZED</b> — p가 여러 버킷에서 참조되어 materialize되면 LIKE 패턴이
+ *       불투명한 값이 되어 접두 인덱스를 못 탄다.</li>
+ *   <li><b>contains의 LIMIT need*3</b> — need=0(앞 버킷이 페이지를 채움)이면 LIMIT 0으로
+ *       스캔 자체를 건너뛴다. GREATEST(1, need)로 바꾸면 불필요한 전체 스캔이 생긴다.</li>
+ * </ul>
+ */
 @UtilityClass
 public class FriendsHandleSearchQuerySql {
 
     // --- Search: contains 포함 버전 ---
     public static final String SELECT_USER_WITH_CONTAINS_BY_HANDLE = """
-            -- NOT MATERIALIZED: p가 여러 버킷에서 참조되어 자동 materialize되면 LIKE 패턴(q_prefix)이
-            -- 불투명한 런타임 값이 되어 접두 인덱스(varchar_pattern_ops)를 못 탄다. 인라인 강제로 인덱스 사용 유지.
             WITH p AS NOT MATERIALIZED (
               SELECT :me::bigint AS me,
               :q::text AS q,
@@ -38,14 +54,6 @@ public class FriendsHandleSearchQuerySql {
                   AND deleted_at IS NULL
                   AND handle LIKE p.q_prefix
                   AND handle <> p.q
-                -- USING ~<~: 접두 검색 인덱스(ix_users_handle_like_with_id = varchar_pattern_ops, id)의
-                -- 정렬 연산자와 정확히 일치시켜 접두 인덱스 하나로 seek+정렬을 모두 처리한다(Sort 노드 없음).
-                --   - 기본 ORDER BY handle이면 옵티마이저가 정렬을 맞추려 users_handle_key(유니크)를 골라
-                --     LIKE seek 없이 전체 스캔한다(실측 20만행: 125,681행 스캔, 126,109 buffers).
-                --   - COLLATE "C"로는 부족하다. pattern_ops 인덱스의 정렬 pathkey는 ~<~ 패밀리인데
-                --     COLLATE "C"는 기본 text_ops 패밀리라 여전히 불일치 → 매칭 전건 읽고 Sort(642 buffers).
-                --   - USING ~<~는 pathkey가 맞아떨어져 LIMIT 건수만 읽고 멈춘다(23 buffers).
-                -- handle은 [0-9a-f]뿐이라 ~<~ 순서 == 기본 순서 → 결과 불변, 최종 표시는 바깥 ORDER BY가 담당.
                 ORDER BY handle USING ~<~, id
                 LIMIT p.lim + p.off
               ) u
@@ -73,12 +81,7 @@ public class FriendsHandleSearchQuerySql {
                   AND handle LIKE p.q_contains
                   AND handle <> p.q
                   AND handle NOT LIKE p.q_prefix
-                -- 결정성: 정렬 없이 뽑으면 페이지 넘김 시 후보 집합이 달라져 중복/누락 가능.
-                -- 최종 표시 순서(handle, id)로 뽑아 페이지 간 후보를 고정한다.
-                -- (contains는 개선4로 exact+prefix 미충족 시=매칭 적은 경우에만 실행 → 정렬 비용 무시 가능)
                 ORDER BY handle, id
-                -- need*3 (0 허용): exact+prefix가 이미 페이지를 채우면 need=0 → LIMIT 0 → contains 스캔 스킵.
-                -- (기존 GREATEST(1,need)*3은 불필요할 때도 최소 1건을 찾으려 테이블 전체를 헛스캔했다)
                 LIMIT (SELECT need FROM need_contains) * 3
               ) u
             ),
@@ -112,8 +115,6 @@ public class FriendsHandleSearchQuerySql {
 
     // --- Search: contains 없는 버전 ---
     public static final String SELECT_USER_NO_CONTAINS_BY_HANDLE = """
-            -- NOT MATERIALIZED: p가 여러 버킷에서 참조되어 자동 materialize되면 LIKE 패턴(q_prefix)이
-            -- 불투명한 런타임 값이 되어 접두 인덱스(varchar_pattern_ops)를 못 탄다. 인라인 강제로 인덱스 사용 유지.
             WITH p AS NOT MATERIALIZED (
               SELECT :me::bigint AS me,
               :q::text AS q,
@@ -142,14 +143,6 @@ public class FriendsHandleSearchQuerySql {
                   AND deleted_at IS NULL
                   AND handle LIKE p.q_prefix
                   AND handle <> p.q
-                -- USING ~<~: 접두 검색 인덱스(ix_users_handle_like_with_id = varchar_pattern_ops, id)의
-                -- 정렬 연산자와 정확히 일치시켜 접두 인덱스 하나로 seek+정렬을 모두 처리한다(Sort 노드 없음).
-                --   - 기본 ORDER BY handle이면 옵티마이저가 정렬을 맞추려 users_handle_key(유니크)를 골라
-                --     LIKE seek 없이 전체 스캔한다(실측 20만행: 125,681행 스캔, 126,109 buffers).
-                --   - COLLATE "C"로는 부족하다. pattern_ops 인덱스의 정렬 pathkey는 ~<~ 패밀리인데
-                --     COLLATE "C"는 기본 text_ops 패밀리라 여전히 불일치 → 매칭 전건 읽고 Sort(642 buffers).
-                --   - USING ~<~는 pathkey가 맞아떨어져 LIMIT 건수만 읽고 멈춘다(23 buffers).
-                -- handle은 [0-9a-f]뿐이라 ~<~ 순서 == 기본 순서 → 결과 불변, 최종 표시는 바깥 ORDER BY가 담당.
                 ORDER BY handle USING ~<~, id
                 LIMIT p.lim + p.off
               ) u

--- a/src/main/java/gravit/code/friend/repository/sql/FriendsHandleSearchQuerySql.java
+++ b/src/main/java/gravit/code/friend/repository/sql/FriendsHandleSearchQuerySql.java
@@ -35,6 +35,7 @@ public class FriendsHandleSearchQuerySql {
                   AND deleted_at IS NULL
                   AND handle LIKE p.q_prefix
                   AND handle <> p.q
+                -- ~<~ 유지 필수: ASC로 바꾸면 접두 인덱스를 못 타고 전체 스캔이 된다
                 ORDER BY handle USING ~<~, id
                 LIMIT p.lim + p.off
               ) u
@@ -123,6 +124,7 @@ public class FriendsHandleSearchQuerySql {
                   AND deleted_at IS NULL
                   AND handle LIKE p.q_prefix
                   AND handle <> p.q
+                -- ~<~ 유지 필수: ASC로 바꾸면 접두 인덱스를 못 타고 전체 스캔이 된다
                 ORDER BY handle USING ~<~, id
                 LIMIT p.lim + p.off
               ) u

--- a/src/main/java/gravit/code/friend/repository/sql/FriendsHandleSearchQuerySql.java
+++ b/src/main/java/gravit/code/friend/repository/sql/FriendsHandleSearchQuerySql.java
@@ -38,12 +38,15 @@ public class FriendsHandleSearchQuerySql {
                   AND deleted_at IS NULL
                   AND handle LIKE p.q_prefix
                   AND handle <> p.q
-                -- COLLATE "C": 접두 검색 인덱스(ix_users_handle_like_with_id = varchar_pattern_ops, C 순서)와
-                -- 정렬 규칙을 일치시킨다. 기본 ORDER BY handle(콜레이션 순서)이면 옵티마이저가 정렬을 맞추려
-                -- users_handle_key(유니크)를 골라 LIKE seek 없이 전체 스캔한다(계획 변동, 수만 페이지).
-                -- 정렬키를 C로 맞추면 접두 인덱스 하나로 seek+정렬을 모두 처리한다.
-                -- handle은 [0-9a-f]뿐이라 C 순서 == 기본 순서 → 결과 불변, 최종 표시는 바깥 ORDER BY가 담당.
-                ORDER BY handle COLLATE "C", id
+                -- USING ~<~: 접두 검색 인덱스(ix_users_handle_like_with_id = varchar_pattern_ops, id)의
+                -- 정렬 연산자와 정확히 일치시켜 접두 인덱스 하나로 seek+정렬을 모두 처리한다(Sort 노드 없음).
+                --   - 기본 ORDER BY handle이면 옵티마이저가 정렬을 맞추려 users_handle_key(유니크)를 골라
+                --     LIKE seek 없이 전체 스캔한다(실측 20만행: 125,681행 스캔, 126,109 buffers).
+                --   - COLLATE "C"로는 부족하다. pattern_ops 인덱스의 정렬 pathkey는 ~<~ 패밀리인데
+                --     COLLATE "C"는 기본 text_ops 패밀리라 여전히 불일치 → 매칭 전건 읽고 Sort(642 buffers).
+                --   - USING ~<~는 pathkey가 맞아떨어져 LIMIT 건수만 읽고 멈춘다(23 buffers).
+                -- handle은 [0-9a-f]뿐이라 ~<~ 순서 == 기본 순서 → 결과 불변, 최종 표시는 바깥 ORDER BY가 담당.
+                ORDER BY handle USING ~<~, id
                 LIMIT p.lim + p.off
               ) u
             ),
@@ -139,12 +142,15 @@ public class FriendsHandleSearchQuerySql {
                   AND deleted_at IS NULL
                   AND handle LIKE p.q_prefix
                   AND handle <> p.q
-                -- COLLATE "C": 접두 검색 인덱스(ix_users_handle_like_with_id = varchar_pattern_ops, C 순서)와
-                -- 정렬 규칙을 일치시킨다. 기본 ORDER BY handle(콜레이션 순서)이면 옵티마이저가 정렬을 맞추려
-                -- users_handle_key(유니크)를 골라 LIKE seek 없이 전체 스캔한다(계획 변동, 수만 페이지).
-                -- 정렬키를 C로 맞추면 접두 인덱스 하나로 seek+정렬을 모두 처리한다.
-                -- handle은 [0-9a-f]뿐이라 C 순서 == 기본 순서 → 결과 불변, 최종 표시는 바깥 ORDER BY가 담당.
-                ORDER BY handle COLLATE "C", id
+                -- USING ~<~: 접두 검색 인덱스(ix_users_handle_like_with_id = varchar_pattern_ops, id)의
+                -- 정렬 연산자와 정확히 일치시켜 접두 인덱스 하나로 seek+정렬을 모두 처리한다(Sort 노드 없음).
+                --   - 기본 ORDER BY handle이면 옵티마이저가 정렬을 맞추려 users_handle_key(유니크)를 골라
+                --     LIKE seek 없이 전체 스캔한다(실측 20만행: 125,681행 스캔, 126,109 buffers).
+                --   - COLLATE "C"로는 부족하다. pattern_ops 인덱스의 정렬 pathkey는 ~<~ 패밀리인데
+                --     COLLATE "C"는 기본 text_ops 패밀리라 여전히 불일치 → 매칭 전건 읽고 Sort(642 buffers).
+                --   - USING ~<~는 pathkey가 맞아떨어져 LIMIT 건수만 읽고 멈춘다(23 buffers).
+                -- handle은 [0-9a-f]뿐이라 ~<~ 순서 == 기본 순서 → 결과 불변, 최종 표시는 바깥 ORDER BY가 담당.
+                ORDER BY handle USING ~<~, id
                 LIMIT p.lim + p.off
               ) u
             ),

--- a/src/main/java/gravit/code/friend/repository/sql/FriendsNicknameSearchQuerySql.java
+++ b/src/main/java/gravit/code/friend/repository/sql/FriendsNicknameSearchQuerySql.java
@@ -24,8 +24,11 @@ public class FriendsNicknameSearchQuerySql {
             FROM users
             WHERE id <> p.me
               AND deleted_at IS NULL
-              AND lower(nickname) = p.q
-            ORDER BY nickname, id
+            -- COLLATE "C" 필수: 인덱스가 C 콜레이션이라 동등 비교의 콜레이션이 다르면 Index Cond로
+            -- 승격되지 못하고 Seq Scan으로 떨어진다. (LIKE와 달리 = 는 플래너가 보정해주지 않는다)
+              AND lower(nickname) COLLATE "C" = p.q
+            -- exact 버킷도 표시 정렬키와 동일하게 맞춘다(lower가 모두 같아 실질 정렬은 id).
+            ORDER BY lower(nickname) COLLATE "C", id
             LIMIT p.lim + p.off
           ) u
         ),
@@ -70,9 +73,9 @@ public class FriendsNicknameSearchQuerySql {
               AND lower(nickname) <> p.q
               AND lower(nickname) NOT LIKE p.q_prefix
             -- 결정성: 정렬 없이 뽑으면 페이지 넘김 시 후보 집합이 달라져 중복/누락 가능.
-            -- 최종 표시 순서(lower(nickname), id)로 뽑아 페이지 간 후보를 고정한다.
+            -- 최종 표시 순서(lower(nickname) COLLATE "C", id)로 뽑아 페이지 간 후보를 고정한다.
             -- (contains는 개선4로 exact+prefix 미충족 시=매칭 적은 경우에만 실행 → 정렬 비용 무시 가능)
-            ORDER BY lower(nickname), id
+            ORDER BY lower(nickname) COLLATE "C", id
             -- need*3 (0 허용): exact+prefix가 이미 페이지를 채우면 need=0 → LIMIT 0 → contains 스캔 스킵.
             -- (기존 GREATEST(1,need)*3은 불필요할 때도 최소 1건을 찾으려 테이블 전체를 헛스캔했다)
             LIMIT (SELECT need FROM need_contains) * 3
@@ -102,7 +105,12 @@ public class FriendsNicknameSearchQuerySql {
         LEFT JOIN friends f
           ON f.follower_id = (SELECT me FROM p)
          AND f.followee_id = s.id
-        ORDER BY s.w DESC, s.nickname ASC, s.id ASC
+        -- 표시 순서를 후보 선정 정렬키(lower(nickname) COLLATE "C")와 동일하게 맞춘다.
+        -- 각 버킷이 C 순서로 LIMIT을 잘라 후보를 고르므로, 표시를 다른 콜레이션으로 하면
+        -- "표시 순서상 앞서지만 C 순서로는 뒤라 후보에 못 든" 행이 통째로 누락된다.
+        -- (실측: 한글/ASCII가 섞인 '김%' 검색에서 1페이지 20건이 표시순 정답과 0건 일치)
+        -- 순수 한글 구간에서 C 순서는 가나다 순과 일치하고, ASCII가 한글보다 앞서는 차이만 남는다.
+        ORDER BY s.w DESC, lower(s.nickname) COLLATE "C" ASC, s.id ASC
         LIMIT (SELECT lim FROM p) OFFSET (SELECT off FROM p)
         """;
 
@@ -124,8 +132,11 @@ public class FriendsNicknameSearchQuerySql {
             FROM users
             WHERE id <> p.me
               AND deleted_at IS NULL
-              AND lower(nickname) = p.q
-            ORDER BY nickname, id
+            -- COLLATE "C" 필수: 인덱스가 C 콜레이션이라 동등 비교의 콜레이션이 다르면 Index Cond로
+            -- 승격되지 못하고 Seq Scan으로 떨어진다. (LIKE와 달리 = 는 플래너가 보정해주지 않는다)
+              AND lower(nickname) COLLATE "C" = p.q
+            -- exact 버킷도 표시 정렬키와 동일하게 맞춘다(lower가 모두 같아 실질 정렬은 id).
+            ORDER BY lower(nickname) COLLATE "C", id
             LIMIT p.lim + p.off
           ) u
         ),
@@ -169,7 +180,12 @@ public class FriendsNicknameSearchQuerySql {
         LEFT JOIN friends f
           ON f.follower_id = (SELECT me FROM p)
          AND f.followee_id = s.id
-        ORDER BY s.w DESC, s.nickname ASC, s.id ASC
+        -- 표시 순서를 후보 선정 정렬키(lower(nickname) COLLATE "C")와 동일하게 맞춘다.
+        -- 각 버킷이 C 순서로 LIMIT을 잘라 후보를 고르므로, 표시를 다른 콜레이션으로 하면
+        -- "표시 순서상 앞서지만 C 순서로는 뒤라 후보에 못 든" 행이 통째로 누락된다.
+        -- (실측: 한글/ASCII가 섞인 '김%' 검색에서 1페이지 20건이 표시순 정답과 0건 일치)
+        -- 순수 한글 구간에서 C 순서는 가나다 순과 일치하고, ASCII가 한글보다 앞서는 차이만 남는다.
+        ORDER BY s.w DESC, lower(s.nickname) COLLATE "C" ASC, s.id ASC
         LIMIT (SELECT lim FROM p) OFFSET (SELECT off FROM p)
         """;
 }

--- a/src/main/java/gravit/code/friend/repository/sql/FriendsNicknameSearchQuerySql.java
+++ b/src/main/java/gravit/code/friend/repository/sql/FriendsNicknameSearchQuerySql.java
@@ -21,6 +21,7 @@ public class FriendsNicknameSearchQuerySql {
             FROM users
             WHERE id <> p.me
               AND deleted_at IS NULL
+              -- COLLATE "C" 유지 필수: 빼면 인덱스를 못 타고 Seq Scan이 된다
               AND lower(nickname) COLLATE "C" = p.q
             ORDER BY lower(nickname) COLLATE "C", id
             LIMIT p.lim + p.off
@@ -109,6 +110,7 @@ public class FriendsNicknameSearchQuerySql {
             FROM users
             WHERE id <> p.me
               AND deleted_at IS NULL
+              -- COLLATE "C" 유지 필수: 빼면 인덱스를 못 타고 Seq Scan이 된다
               AND lower(nickname) COLLATE "C" = p.q
             ORDER BY lower(nickname) COLLATE "C", id
             LIMIT p.lim + p.off

--- a/src/main/java/gravit/code/friend/repository/sql/FriendsNicknameSearchQuerySql.java
+++ b/src/main/java/gravit/code/friend/repository/sql/FriendsNicknameSearchQuerySql.java
@@ -7,7 +7,9 @@ public class FriendsNicknameSearchQuerySql {
 
     // --- Search: contains 포함 (exact/prefix: lower()+LIKE, contains: ILIKE) ---
     public static final String SELECT_USER_WITH_CONTAINS_BY_NICKNAME = """
-        WITH p AS (
+        -- NOT MATERIALIZED: p가 여러 버킷에서 참조되어 자동 materialize되면 LIKE 패턴(q_prefix)이
+        -- 불투명한 런타임 값이 되어 접두 인덱스(text_pattern_ops)를 못 탄다. 인라인 강제로 인덱스 사용 유지.
+        WITH p AS NOT MATERIALIZED (
           SELECT :me::bigint AS me,
                  :q::text AS q,
                  :q_prefix::text AS q_prefix,
@@ -36,7 +38,10 @@ public class FriendsNicknameSearchQuerySql {
               AND deleted_at IS NULL
               AND lower(nickname) LIKE p.q_prefix
               AND lower(nickname) <> p.q
-            ORDER BY nickname, id
+            -- 정렬키를 인덱스(lower(nickname) text_pattern_ops)와 일치시켜 Index-Only Scan 조기종료 유도.
+            -- (ORDER BY nickname(원본)이면 인덱스 정렬과 불일치 → 매칭 전건 heap 읽고 정렬 → Bitmap Heap Scan)
+            -- 최종 표시 순서는 바깥 ORDER BY s.nickname이 담당하므로 결과 순서는 불변.
+            ORDER BY lower(nickname), id
             LIMIT p.lim + p.off
           ) u
         ),
@@ -63,7 +68,13 @@ public class FriendsNicknameSearchQuerySql {
               AND nickname ILIKE p.q_contains
               AND lower(nickname) <> p.q
               AND lower(nickname) NOT LIKE p.q_prefix
-            LIMIT GREATEST(1, (SELECT need FROM need_contains)) * 3
+            -- 결정성: 정렬 없이 뽑으면 페이지 넘김 시 후보 집합이 달라져 중복/누락 가능.
+            -- 최종 표시 순서(lower(nickname), id)로 뽑아 페이지 간 후보를 고정한다.
+            -- (contains는 개선4로 exact+prefix 미충족 시=매칭 적은 경우에만 실행 → 정렬 비용 무시 가능)
+            ORDER BY lower(nickname), id
+            -- need*3 (0 허용): exact+prefix가 이미 페이지를 채우면 need=0 → LIMIT 0 → contains 스캔 스킵.
+            -- (기존 GREATEST(1,need)*3은 불필요할 때도 최소 1건을 찾으려 테이블 전체를 헛스캔했다)
+            LIMIT (SELECT need FROM need_contains) * 3
           ) u
         ),
         contains AS MATERIALIZED (
@@ -96,7 +107,9 @@ public class FriendsNicknameSearchQuerySql {
 
     // --- Search: contains 없는 버전 (exact/prefix만) ---
     public static final String SELECT_USER_NO_CONTAINS_BY_NICKNAME = """
-        WITH p AS (
+        -- NOT MATERIALIZED: p가 여러 버킷에서 참조되어 자동 materialize되면 LIKE 패턴(q_prefix)이
+        -- 불투명한 런타임 값이 되어 접두 인덱스(text_pattern_ops)를 못 탄다. 인라인 강제로 인덱스 사용 유지.
+        WITH p AS NOT MATERIALIZED (
           SELECT :me::bigint AS me,
                  :q::text AS q,
                  :q_prefix::text AS q_prefix,
@@ -124,7 +137,9 @@ public class FriendsNicknameSearchQuerySql {
               AND deleted_at IS NULL
               AND lower(nickname) LIKE p.q_prefix
               AND lower(nickname) <> p.q
-            ORDER BY nickname, id
+            -- 정렬키를 인덱스(lower(nickname) text_pattern_ops)와 일치시켜 Index-Only Scan 조기종료 유도.
+            -- 최종 표시 순서는 바깥 ORDER BY s.nickname이 담당하므로 결과 순서는 불변.
+            ORDER BY lower(nickname), id
             LIMIT p.lim + p.off
           ) u
         ),

--- a/src/main/java/gravit/code/friend/repository/sql/FriendsNicknameSearchQuerySql.java
+++ b/src/main/java/gravit/code/friend/repository/sql/FriendsNicknameSearchQuerySql.java
@@ -2,28 +2,9 @@ package gravit.code.friend.repository.sql;
 
 import lombok.experimental.UtilityClass;
 
-/**
- * 닉네임 검색 쿼리. exact → prefix → contains 순으로 페이지를 채운다.
- *
- * <p>아래 규칙은 성능·정확성에 직결되므로 수정 시 반드시 유지해야 한다.
- * 배경과 실측치는 {@code docs/retrospective-friend-search.md} 참고.
- *
- * <ul>
- *   <li><b>COLLATE "C"</b> — 인덱스 ix_users_nickname_lower_cover가 C 콜레이션이다.
- *       ORDER BY와 = 비교의 콜레이션이 어긋나면 조기 종료에 실패하거나 Seq Scan으로 떨어진다.
- *       (LIKE는 플래너가 범위를 도출해주므로 예외)</li>
- *   <li><b>정렬키 통일</b> — 각 버킷이 LIMIT으로 후보를 자르므로, 바깥 표시 정렬키가 다르면
- *       후보에 못 든 행이 통째로 누락된다. 모든 ORDER BY가 같은 기준이어야 한다.</li>
- *   <li><b>NOT MATERIALIZED</b> — p가 여러 버킷에서 참조되어 materialize되면 LIKE 패턴이
- *       불투명한 값이 되어 접두 인덱스를 못 탄다.</li>
- *   <li><b>contains의 LIMIT need*3</b> — need=0(앞 버킷이 페이지를 채움)이면 LIMIT 0으로
- *       스캔 자체를 건너뛴다. GREATEST(1, need)로 바꾸면 불필요한 전체 스캔이 생긴다.</li>
- * </ul>
- */
 @UtilityClass
 public class FriendsNicknameSearchQuerySql {
 
-    // --- Search: contains 포함 (exact/prefix: lower()+LIKE, contains: ILIKE) ---
     public static final String SELECT_USER_WITH_CONTAINS_BY_NICKNAME = """
         WITH p AS NOT MATERIALIZED (
           SELECT :me::bigint AS me,
@@ -113,7 +94,6 @@ public class FriendsNicknameSearchQuerySql {
         LIMIT (SELECT lim FROM p) OFFSET (SELECT off FROM p)
         """;
 
-    // --- Search: contains 없는 버전 (exact/prefix만) ---
     public static final String SELECT_USER_NO_CONTAINS_BY_NICKNAME = """
         WITH p AS NOT MATERIALIZED (
           SELECT :me::bigint AS me,

--- a/src/main/java/gravit/code/friend/repository/sql/FriendsNicknameSearchQuerySql.java
+++ b/src/main/java/gravit/code/friend/repository/sql/FriendsNicknameSearchQuerySql.java
@@ -8,7 +8,7 @@ public class FriendsNicknameSearchQuerySql {
     // --- Search: contains 포함 (exact/prefix: lower()+LIKE, contains: ILIKE) ---
     public static final String SELECT_USER_WITH_CONTAINS_BY_NICKNAME = """
         -- NOT MATERIALIZED: p가 여러 버킷에서 참조되어 자동 materialize되면 LIKE 패턴(q_prefix)이
-        -- 불투명한 런타임 값이 되어 접두 인덱스(text_pattern_ops)를 못 탄다. 인라인 강제로 인덱스 사용 유지.
+        -- 불투명한 런타임 값이 되어 접두 인덱스(ix_users_nickname_lower_cover)를 못 탄다. 인라인 강제로 인덱스 사용 유지.
         WITH p AS NOT MATERIALIZED (
           SELECT :me::bigint AS me,
                  :q::text AS q,
@@ -38,10 +38,11 @@ public class FriendsNicknameSearchQuerySql {
               AND deleted_at IS NULL
               AND lower(nickname) LIKE p.q_prefix
               AND lower(nickname) <> p.q
-            -- 정렬키를 인덱스(lower(nickname) text_pattern_ops)와 일치시켜 Index-Only Scan 조기종료 유도.
-            -- (ORDER BY nickname(원본)이면 인덱스 정렬과 불일치 → 매칭 전건 heap 읽고 정렬 → Bitmap Heap Scan)
+            -- 정렬키를 인덱스(ix_users_nickname_lower_cover = lower(nickname) COLLATE "C")와 정확히 일치시킨다.
+            -- 표현식(lower)과 콜레이션(C)이 모두 맞아야 인덱스 정렬을 그대로 써서 LIMIT 건수만 읽고 멈춘다.
+            -- 둘 중 하나라도 어긋나면 Sort 노드가 붙어 매칭 전건을 읽는다.
             -- 최종 표시 순서는 바깥 ORDER BY s.nickname이 담당하므로 결과 순서는 불변.
-            ORDER BY lower(nickname), id
+            ORDER BY lower(nickname) COLLATE "C", id
             LIMIT p.lim + p.off
           ) u
         ),
@@ -108,7 +109,7 @@ public class FriendsNicknameSearchQuerySql {
     // --- Search: contains 없는 버전 (exact/prefix만) ---
     public static final String SELECT_USER_NO_CONTAINS_BY_NICKNAME = """
         -- NOT MATERIALIZED: p가 여러 버킷에서 참조되어 자동 materialize되면 LIKE 패턴(q_prefix)이
-        -- 불투명한 런타임 값이 되어 접두 인덱스(text_pattern_ops)를 못 탄다. 인라인 강제로 인덱스 사용 유지.
+        -- 불투명한 런타임 값이 되어 접두 인덱스(ix_users_nickname_lower_cover)를 못 탄다. 인라인 강제로 인덱스 사용 유지.
         WITH p AS NOT MATERIALIZED (
           SELECT :me::bigint AS me,
                  :q::text AS q,
@@ -137,9 +138,10 @@ public class FriendsNicknameSearchQuerySql {
               AND deleted_at IS NULL
               AND lower(nickname) LIKE p.q_prefix
               AND lower(nickname) <> p.q
-            -- 정렬키를 인덱스(lower(nickname) text_pattern_ops)와 일치시켜 Index-Only Scan 조기종료 유도.
+            -- 정렬키를 인덱스(ix_users_nickname_lower_cover = lower(nickname) COLLATE "C")와 정확히 일치시켜
+            -- 인덱스 정렬을 그대로 쓰고 LIMIT 건수만 읽고 멈춘다.
             -- 최종 표시 순서는 바깥 ORDER BY s.nickname이 담당하므로 결과 순서는 불변.
-            ORDER BY lower(nickname), id
+            ORDER BY lower(nickname) COLLATE "C", id
             LIMIT p.lim + p.off
           ) u
         ),

--- a/src/main/java/gravit/code/friend/repository/sql/FriendsNicknameSearchQuerySql.java
+++ b/src/main/java/gravit/code/friend/repository/sql/FriendsNicknameSearchQuerySql.java
@@ -2,13 +2,29 @@ package gravit.code.friend.repository.sql;
 
 import lombok.experimental.UtilityClass;
 
+/**
+ * 닉네임 검색 쿼리. exact → prefix → contains 순으로 페이지를 채운다.
+ *
+ * <p>아래 규칙은 성능·정확성에 직결되므로 수정 시 반드시 유지해야 한다.
+ * 배경과 실측치는 {@code docs/retrospective-friend-search.md} 참고.
+ *
+ * <ul>
+ *   <li><b>COLLATE "C"</b> — 인덱스 ix_users_nickname_lower_cover가 C 콜레이션이다.
+ *       ORDER BY와 = 비교의 콜레이션이 어긋나면 조기 종료에 실패하거나 Seq Scan으로 떨어진다.
+ *       (LIKE는 플래너가 범위를 도출해주므로 예외)</li>
+ *   <li><b>정렬키 통일</b> — 각 버킷이 LIMIT으로 후보를 자르므로, 바깥 표시 정렬키가 다르면
+ *       후보에 못 든 행이 통째로 누락된다. 모든 ORDER BY가 같은 기준이어야 한다.</li>
+ *   <li><b>NOT MATERIALIZED</b> — p가 여러 버킷에서 참조되어 materialize되면 LIKE 패턴이
+ *       불투명한 값이 되어 접두 인덱스를 못 탄다.</li>
+ *   <li><b>contains의 LIMIT need*3</b> — need=0(앞 버킷이 페이지를 채움)이면 LIMIT 0으로
+ *       스캔 자체를 건너뛴다. GREATEST(1, need)로 바꾸면 불필요한 전체 스캔이 생긴다.</li>
+ * </ul>
+ */
 @UtilityClass
 public class FriendsNicknameSearchQuerySql {
 
     // --- Search: contains 포함 (exact/prefix: lower()+LIKE, contains: ILIKE) ---
     public static final String SELECT_USER_WITH_CONTAINS_BY_NICKNAME = """
-        -- NOT MATERIALIZED: p가 여러 버킷에서 참조되어 자동 materialize되면 LIKE 패턴(q_prefix)이
-        -- 불투명한 런타임 값이 되어 접두 인덱스(ix_users_nickname_lower_cover)를 못 탄다. 인라인 강제로 인덱스 사용 유지.
         WITH p AS NOT MATERIALIZED (
           SELECT :me::bigint AS me,
                  :q::text AS q,
@@ -24,10 +40,7 @@ public class FriendsNicknameSearchQuerySql {
             FROM users
             WHERE id <> p.me
               AND deleted_at IS NULL
-            -- COLLATE "C" 필수: 인덱스가 C 콜레이션이라 동등 비교의 콜레이션이 다르면 Index Cond로
-            -- 승격되지 못하고 Seq Scan으로 떨어진다. (LIKE와 달리 = 는 플래너가 보정해주지 않는다)
               AND lower(nickname) COLLATE "C" = p.q
-            -- exact 버킷도 표시 정렬키와 동일하게 맞춘다(lower가 모두 같아 실질 정렬은 id).
             ORDER BY lower(nickname) COLLATE "C", id
             LIMIT p.lim + p.off
           ) u
@@ -41,10 +54,6 @@ public class FriendsNicknameSearchQuerySql {
               AND deleted_at IS NULL
               AND lower(nickname) LIKE p.q_prefix
               AND lower(nickname) <> p.q
-            -- 정렬키를 인덱스(ix_users_nickname_lower_cover = lower(nickname) COLLATE "C")와 정확히 일치시킨다.
-            -- 표현식(lower)과 콜레이션(C)이 모두 맞아야 인덱스 정렬을 그대로 써서 LIMIT 건수만 읽고 멈춘다.
-            -- 둘 중 하나라도 어긋나면 Sort 노드가 붙어 매칭 전건을 읽는다.
-            -- 최종 표시 순서는 바깥 ORDER BY s.nickname이 담당하므로 결과 순서는 불변.
             ORDER BY lower(nickname) COLLATE "C", id
             LIMIT p.lim + p.off
           ) u
@@ -72,12 +81,7 @@ public class FriendsNicknameSearchQuerySql {
               AND nickname ILIKE p.q_contains
               AND lower(nickname) <> p.q
               AND lower(nickname) NOT LIKE p.q_prefix
-            -- 결정성: 정렬 없이 뽑으면 페이지 넘김 시 후보 집합이 달라져 중복/누락 가능.
-            -- 최종 표시 순서(lower(nickname) COLLATE "C", id)로 뽑아 페이지 간 후보를 고정한다.
-            -- (contains는 개선4로 exact+prefix 미충족 시=매칭 적은 경우에만 실행 → 정렬 비용 무시 가능)
             ORDER BY lower(nickname) COLLATE "C", id
-            -- need*3 (0 허용): exact+prefix가 이미 페이지를 채우면 need=0 → LIMIT 0 → contains 스캔 스킵.
-            -- (기존 GREATEST(1,need)*3은 불필요할 때도 최소 1건을 찾으려 테이블 전체를 헛스캔했다)
             LIMIT (SELECT need FROM need_contains) * 3
           ) u
         ),
@@ -105,19 +109,12 @@ public class FriendsNicknameSearchQuerySql {
         LEFT JOIN friends f
           ON f.follower_id = (SELECT me FROM p)
          AND f.followee_id = s.id
-        -- 표시 순서를 후보 선정 정렬키(lower(nickname) COLLATE "C")와 동일하게 맞춘다.
-        -- 각 버킷이 C 순서로 LIMIT을 잘라 후보를 고르므로, 표시를 다른 콜레이션으로 하면
-        -- "표시 순서상 앞서지만 C 순서로는 뒤라 후보에 못 든" 행이 통째로 누락된다.
-        -- (실측: 한글/ASCII가 섞인 '김%' 검색에서 1페이지 20건이 표시순 정답과 0건 일치)
-        -- 순수 한글 구간에서 C 순서는 가나다 순과 일치하고, ASCII가 한글보다 앞서는 차이만 남는다.
         ORDER BY s.w DESC, lower(s.nickname) COLLATE "C" ASC, s.id ASC
         LIMIT (SELECT lim FROM p) OFFSET (SELECT off FROM p)
         """;
 
     // --- Search: contains 없는 버전 (exact/prefix만) ---
     public static final String SELECT_USER_NO_CONTAINS_BY_NICKNAME = """
-        -- NOT MATERIALIZED: p가 여러 버킷에서 참조되어 자동 materialize되면 LIKE 패턴(q_prefix)이
-        -- 불투명한 런타임 값이 되어 접두 인덱스(ix_users_nickname_lower_cover)를 못 탄다. 인라인 강제로 인덱스 사용 유지.
         WITH p AS NOT MATERIALIZED (
           SELECT :me::bigint AS me,
                  :q::text AS q,
@@ -132,10 +129,7 @@ public class FriendsNicknameSearchQuerySql {
             FROM users
             WHERE id <> p.me
               AND deleted_at IS NULL
-            -- COLLATE "C" 필수: 인덱스가 C 콜레이션이라 동등 비교의 콜레이션이 다르면 Index Cond로
-            -- 승격되지 못하고 Seq Scan으로 떨어진다. (LIKE와 달리 = 는 플래너가 보정해주지 않는다)
               AND lower(nickname) COLLATE "C" = p.q
-            -- exact 버킷도 표시 정렬키와 동일하게 맞춘다(lower가 모두 같아 실질 정렬은 id).
             ORDER BY lower(nickname) COLLATE "C", id
             LIMIT p.lim + p.off
           ) u
@@ -149,9 +143,6 @@ public class FriendsNicknameSearchQuerySql {
               AND deleted_at IS NULL
               AND lower(nickname) LIKE p.q_prefix
               AND lower(nickname) <> p.q
-            -- 정렬키를 인덱스(ix_users_nickname_lower_cover = lower(nickname) COLLATE "C")와 정확히 일치시켜
-            -- 인덱스 정렬을 그대로 쓰고 LIMIT 건수만 읽고 멈춘다.
-            -- 최종 표시 순서는 바깥 ORDER BY s.nickname이 담당하므로 결과 순서는 불변.
             ORDER BY lower(nickname) COLLATE "C", id
             LIMIT p.lim + p.off
           ) u
@@ -180,11 +171,6 @@ public class FriendsNicknameSearchQuerySql {
         LEFT JOIN friends f
           ON f.follower_id = (SELECT me FROM p)
          AND f.followee_id = s.id
-        -- 표시 순서를 후보 선정 정렬키(lower(nickname) COLLATE "C")와 동일하게 맞춘다.
-        -- 각 버킷이 C 순서로 LIMIT을 잘라 후보를 고르므로, 표시를 다른 콜레이션으로 하면
-        -- "표시 순서상 앞서지만 C 순서로는 뒤라 후보에 못 든" 행이 통째로 누락된다.
-        -- (실측: 한글/ASCII가 섞인 '김%' 검색에서 1페이지 20건이 표시순 정답과 0건 일치)
-        -- 순수 한글 구간에서 C 순서는 가나다 순과 일치하고, ASCII가 한글보다 앞서는 차이만 남는다.
         ORDER BY s.w DESC, lower(s.nickname) COLLATE "C" ASC, s.id ASC
         LIMIT (SELECT lim FROM p) OFFSET (SELECT off FROM p)
         """;

--- a/src/main/java/gravit/code/friend/repository/strategy/FriendsSearchFactory.java
+++ b/src/main/java/gravit/code/friend/repository/strategy/FriendsSearchFactory.java
@@ -13,13 +13,6 @@ import java.util.List;
 public class FriendsSearchFactory {
     private final List<FriendsSearchStrategy> strategies;
 
-    public FriendsSearchStrategy resolve(String queryText) {
-        return strategies.stream()
-                .filter(s -> s.supports(queryText))
-                .findFirst()
-                .orElseThrow(() -> new RestApiException(CustomErrorCode.FRIEND_QUERY_STRATEGY_TYPE_INVALID));
-    }
-
     public SearchPlanDto buildPlan(
             long requesterId,
             String raw,
@@ -27,5 +20,12 @@ public class FriendsSearchFactory {
             int size
     ) {
         return resolve(raw).buildPlan(requesterId, raw, page, size);
+    }
+
+    private FriendsSearchStrategy resolve(String queryText) {
+        return strategies.stream()
+                .filter(s -> s.supports(queryText))
+                .findFirst()
+                .orElseThrow(() -> new RestApiException(CustomErrorCode.FRIEND_QUERY_STRATEGY_TYPE_INVALID));
     }
 }

--- a/src/main/resources/db/migration/V27__add_friend_search_indexes.sql
+++ b/src/main/resources/db/migration/V27__add_friend_search_indexes.sql
@@ -1,0 +1,35 @@
+-- V27__add_friend_search_indexes.sql
+-- 친구 검색(닉네임) 및 is_following 조인 성능 개선용 인덱스.
+-- 근거: docs/friend-search-strategy.md "DB Access Patterns 기반 개선안" 섹션.
+-- 주의: 이 파일은 초안이다. 반드시 EXPLAIN (ANALYZE, BUFFERS)로 적용 전후를 실측한 뒤 확정한다.
+
+-- trigram 확장은 V2에서 이미 활성화되어 있으나, 순서 독립성을 위해 방어적으로 재확인한다.
+CREATE EXTENSION IF NOT EXISTS pg_trgm;
+
+-- 1) is_following 조인 인덱스
+--    friends 테이블에는 현재 PK(id)만 있어, LEFT JOIN friends (follower_id=me AND followee_id=s.id)가
+--    인덱스를 못 타고 매 후보 행마다 랜덤 액세스를 유발한다.
+--    선행 컬럼 follower_id에 상수(me)가 걸리므로 Seek + 좁은 Range가 되고,
+--    "팔로우 여부" 존재 확인만 필요하므로 별도 INCLUDE 없이 Index-Only 프로브가 된다.
+--    (팔로잉 목록 조회 findByFollowerId 경로도 함께 이득)
+CREATE INDEX IF NOT EXISTS ix_friends_follower_followee
+    ON friends (follower_id, followee_id);
+
+-- 2) 닉네임 정확/접두 검색용 커버링(표현식) 부분 인덱스
+--    SQL이 lower(nickname)으로 비교/정렬하므로 반드시 lower() 표현식 인덱스여야 한다.
+--    text_pattern_ops로 LIKE 'x%' 접두 검색이 로케일과 무관하게 인덱스를 타게 한다.
+--    INCLUDE에는 SELECT가 반환하는 컬럼(id, profile_img_number, nickname, handle)을 모두 담는다.
+--      - 인덱스 키는 lower(nickname)이므로 원본 nickname은 파생되지 않는다 → nickname을 반드시 포함해야
+--        heap 방문 없는 Index-Only Scan이 된다. (벤치 실측: 미포함 시 Bitmap Heap Scan로 폴백)
+--    WHERE deleted_at IS NULL 부분 인덱스로 검색 대상만 인덱싱 → 크기 축소 + 필터가 인덱스에 반영.
+--    (Index-Only Scan 실효는 autovacuum의 가시성 맵 최신화에 의존한다)
+CREATE INDEX IF NOT EXISTS ix_users_nickname_lower_cover
+    ON users (lower(nickname) text_pattern_ops)
+    INCLUDE (id, profile_img_number, nickname, handle)
+    WHERE deleted_at IS NULL;
+
+-- 3) 닉네임 부분 검색('%x%')용 trigram GIN
+--    ILIKE '%x%'를 위한 인덱스. 단, 흔한 한글 음절 등 저선택도 검색어에서는
+--    옵티마이저가 여전히 스캔을 택할 수 있다(=근본 해결 아님). 실측으로 효과 범위를 확인한다.
+CREATE INDEX IF NOT EXISTS gin_users_nickname_trgm
+    ON users USING gin (nickname gin_trgm_ops);

--- a/src/main/resources/db/migration/V28__add_friend_search_indexes.sql
+++ b/src/main/resources/db/migration/V28__add_friend_search_indexes.sql
@@ -1,28 +1,18 @@
 -- V28__add_friend_search_indexes.sql
--- 친구 검색(닉네임) 및 is_following 조인 성능 개선용 인덱스.
--- 설계 근거와 실측치: docs/retrospective-friend-search.md
 
+-- trigram 확장 활성화
 CREATE EXTENSION IF NOT EXISTS pg_trgm;
 
--- 1) is_following 조인용. friends에 PK만 있어 LEFT JOIN이 매 후보 행마다 랜덤 액세스를 유발했다.
---    선행 컬럼에 상수(me)가 걸려 좁은 range seek이 되고, 존재 확인만 필요해 INCLUDE가 없어도 Index-Only가 된다.
+-- is_following 조인용 인덱스
 CREATE INDEX IF NOT EXISTS ix_friends_follower_followee
     ON friends (follower_id, followee_id);
 
--- 2) 닉네임 정확/접두 검색용 커버링 부분 인덱스.
---    COLLATE "C": text_pattern_ops를 쓰면 정렬 pathkey가 ~<~ 패밀리라 ORDER BY와 매칭되지 않아
---                 조기 종료가 불가능하다. 기본 연산자 클래스 + C 콜레이션이라야 둘 다 만족한다.
---                 이 인덱스를 쓰는 쿼리는 ORDER BY와 = 비교에 COLLATE "C"를 명시해야 한다.
---                 (LIKE 'x%'는 플래너가 범위를 도출해주므로 불필요)
---    INCLUDE: 키가 lower(nickname)이라 원본 nickname이 파생되지 않는다. SELECT 반환 컬럼을 모두
---             담아야 heap 방문이 사라진다. 하나라도 빠지면 Bitmap Heap Scan으로 폴백한다.
+-- 닉네임 정확/접두 검색용 커버링 부분 인덱스
 CREATE INDEX IF NOT EXISTS ix_users_nickname_lower_cover
     ON users (lower(nickname) COLLATE "C")
     INCLUDE (id, profile_img_number, nickname, handle)
     WHERE deleted_at IS NULL;
 
--- 3) 닉네임 부분 검색('%x%')용 trigram GIN.
---    선택도가 높을 때만 이 인덱스가 이기고, 낮을 때는 2)의 커버링 btree 조기 종료가 이긴다.
---    플래너가 두 구간을 알아서 가른다.
+-- 닉네임 부분 검색('%x%')용 trigram GIN 인덱스
 CREATE INDEX IF NOT EXISTS gin_users_nickname_trgm
     ON users USING gin (nickname gin_trgm_ops);

--- a/src/main/resources/db/migration/V28__add_friend_search_indexes.sql
+++ b/src/main/resources/db/migration/V28__add_friend_search_indexes.sql
@@ -40,7 +40,13 @@ CREATE INDEX IF NOT EXISTS ix_users_nickname_lower_cover
     WHERE deleted_at IS NULL;
 
 -- 3) 닉네임 부분 검색('%x%')용 trigram GIN
---    ILIKE '%x%'를 위한 인덱스. 단, 흔한 한글 음절 등 저선택도 검색어에서는
---    옵티마이저가 여전히 스캔을 택할 수 있다(=근본 해결 아님). 실측으로 효과 범위를 확인한다.
+--    ILIKE '%x%'를 위한 인덱스. 선택도에 따라 GIN과 2)의 커버링 btree로 계획이 갈리며,
+--    실측(한글 닉네임 20만행, contains 버킷 LIMIT 60) 결과 양쪽 다 플래너 선택이 옳았다.
+--      - 고선택도(매칭 1~205건): GIN 선택, 0.02~0.19ms. GIN을 빼면 26ms(Seq Scan)로 악화
+--        → 이 인덱스가 값을 하는 구간이다.
+--      - 저선택도(매칭 1만건): 2)의 커버링 btree로 정렬 조기종료, 0.4~2.7ms.
+--        GIN을 강제하면 31ms로 12배 악화된다. GIN은 정렬을 제공하지 못해 매칭 전건을
+--        모은 뒤 정렬해야 하기 때문이며, 이 구간은 GIN이 답이 아니다.
+--    한글 1글자도 패딩 trigram 2개가 생성되어 색인 자체는 가능하나 선택도가 낮아 실익은 없다.
 CREATE INDEX IF NOT EXISTS gin_users_nickname_trgm
     ON users USING gin (nickname gin_trgm_ops);

--- a/src/main/resources/db/migration/V28__add_friend_search_indexes.sql
+++ b/src/main/resources/db/migration/V28__add_friend_search_indexes.sql
@@ -1,52 +1,28 @@
 -- V28__add_friend_search_indexes.sql
 -- 친구 검색(닉네임) 및 is_following 조인 성능 개선용 인덱스.
--- 근거: docs/friend-search-strategy.md "DB Access Patterns 기반 개선안" 섹션.
--- 각 인덱스는 EXPLAIN (ANALYZE, BUFFERS)로 적용 전후를 실측해 확정했다.
+-- 설계 근거와 실측치: docs/retrospective-friend-search.md
 
--- trigram 확장은 V2에서 이미 활성화되어 있으나, 순서 독립성을 위해 방어적으로 재확인한다.
 CREATE EXTENSION IF NOT EXISTS pg_trgm;
 
--- 1) is_following 조인 인덱스
---    friends 테이블에는 현재 PK(id)만 있어, LEFT JOIN friends (follower_id=me AND followee_id=s.id)가
---    인덱스를 못 타고 매 후보 행마다 랜덤 액세스를 유발한다.
---    선행 컬럼 follower_id에 상수(me)가 걸리므로 Seek + 좁은 Range가 되고,
---    "팔로우 여부" 존재 확인만 필요하므로 별도 INCLUDE 없이 Index-Only 프로브가 된다.
---    (팔로잉 목록 조회 findByFollowerId 경로도 함께 이득)
+-- 1) is_following 조인용. friends에 PK만 있어 LEFT JOIN이 매 후보 행마다 랜덤 액세스를 유발했다.
+--    선행 컬럼에 상수(me)가 걸려 좁은 range seek이 되고, 존재 확인만 필요해 INCLUDE가 없어도 Index-Only가 된다.
 CREATE INDEX IF NOT EXISTS ix_friends_follower_followee
     ON friends (follower_id, followee_id);
 
--- 2) 닉네임 정확/접두 검색용 커버링(표현식) 부분 인덱스
---    SQL이 lower(nickname)으로 비교/정렬하므로 반드시 lower() 표현식 인덱스여야 한다.
---    COLLATE "C"로 LIKE 'x%' 접두 검색이 로케일과 무관하게 인덱스를 타게 한다.
---      - text_pattern_ops가 아니라 COLLATE "C"인 이유: pattern_ops 인덱스가 만드는 정렬 pathkey는
---        ~<~ 연산자 패밀리라, 표준 연산자(<)를 쓰는 ORDER BY와 매칭되지 않는다.
---        COLLATE "C"를 붙여도 마찬가지다(기본 text_ops 패밀리라 여전히 불일치).
---        그 결과 pattern_ops 인덱스로는 정렬 조기종료가 불가능하고 매칭 전건 스캔 + Sort가 강제된다.
---        기본 연산자 클래스 + COLLATE "C"는 바이트 순서를 그대로 유지하면서 ORDER BY와도 매칭된다.
---        (실측 20만행/매칭 12409건: pattern_ops 12409행 스캔 → COLLATE "C" 21행, 201 → 4 buffers)
---      - LIKE 'x%'는 COLLATE를 명시하지 않아도 된다. 인덱스가 C 콜레이션이면 플래너가
---        >= / < 범위를 스스로 도출한다.
---      - 반면 동등 비교(=)는 반드시 lower(nickname) COLLATE "C" = ... 로 명시해야 한다.
---        콜레이션이 어긋나면 Index Cond로 승격되지 않고 Seq Scan으로 떨어진다.
---        (실측 20만행: 명시 없이 27.9ms/1667 buffers → 명시 시 0.16ms/4 buffers)
---    INCLUDE에는 SELECT가 반환하는 컬럼(id, profile_img_number, nickname, handle)을 모두 담는다.
---      - 인덱스 키는 lower(nickname)이므로 원본 nickname은 파생되지 않는다 → nickname을 반드시 포함해야
---        heap 방문 없는 Index-Only Scan이 된다. (벤치 실측: 미포함 시 Bitmap Heap Scan로 폴백)
---    WHERE deleted_at IS NULL 부분 인덱스로 검색 대상만 인덱싱 → 크기 축소 + 필터가 인덱스에 반영.
---    (Index-Only Scan 실효는 autovacuum의 가시성 맵 최신화에 의존한다)
+-- 2) 닉네임 정확/접두 검색용 커버링 부분 인덱스.
+--    COLLATE "C": text_pattern_ops를 쓰면 정렬 pathkey가 ~<~ 패밀리라 ORDER BY와 매칭되지 않아
+--                 조기 종료가 불가능하다. 기본 연산자 클래스 + C 콜레이션이라야 둘 다 만족한다.
+--                 이 인덱스를 쓰는 쿼리는 ORDER BY와 = 비교에 COLLATE "C"를 명시해야 한다.
+--                 (LIKE 'x%'는 플래너가 범위를 도출해주므로 불필요)
+--    INCLUDE: 키가 lower(nickname)이라 원본 nickname이 파생되지 않는다. SELECT 반환 컬럼을 모두
+--             담아야 heap 방문이 사라진다. 하나라도 빠지면 Bitmap Heap Scan으로 폴백한다.
 CREATE INDEX IF NOT EXISTS ix_users_nickname_lower_cover
     ON users (lower(nickname) COLLATE "C")
     INCLUDE (id, profile_img_number, nickname, handle)
     WHERE deleted_at IS NULL;
 
--- 3) 닉네임 부분 검색('%x%')용 trigram GIN
---    ILIKE '%x%'를 위한 인덱스. 선택도에 따라 GIN과 2)의 커버링 btree로 계획이 갈리며,
---    실측(한글 닉네임 20만행, contains 버킷 LIMIT 60) 결과 양쪽 다 플래너 선택이 옳았다.
---      - 고선택도(매칭 1~205건): GIN 선택, 0.02~0.19ms. GIN을 빼면 26ms(Seq Scan)로 악화
---        → 이 인덱스가 값을 하는 구간이다.
---      - 저선택도(매칭 1만건): 2)의 커버링 btree로 정렬 조기종료, 0.4~2.7ms.
---        GIN을 강제하면 31ms로 12배 악화된다. GIN은 정렬을 제공하지 못해 매칭 전건을
---        모은 뒤 정렬해야 하기 때문이며, 이 구간은 GIN이 답이 아니다.
---    한글 1글자도 패딩 trigram 2개가 생성되어 색인 자체는 가능하나 선택도가 낮아 실익은 없다.
+-- 3) 닉네임 부분 검색('%x%')용 trigram GIN.
+--    선택도가 높을 때만 이 인덱스가 이기고, 낮을 때는 2)의 커버링 btree 조기 종료가 이긴다.
+--    플래너가 두 구간을 알아서 가른다.
 CREATE INDEX IF NOT EXISTS gin_users_nickname_trgm
     ON users USING gin (nickname gin_trgm_ops);

--- a/src/main/resources/db/migration/V28__add_friend_search_indexes.sql
+++ b/src/main/resources/db/migration/V28__add_friend_search_indexes.sql
@@ -1,7 +1,7 @@
 -- V28__add_friend_search_indexes.sql
 -- 친구 검색(닉네임) 및 is_following 조인 성능 개선용 인덱스.
 -- 근거: docs/friend-search-strategy.md "DB Access Patterns 기반 개선안" 섹션.
--- 주의: 이 파일은 초안이다. 반드시 EXPLAIN (ANALYZE, BUFFERS)로 적용 전후를 실측한 뒤 확정한다.
+-- 각 인덱스는 EXPLAIN (ANALYZE, BUFFERS)로 적용 전후를 실측해 확정했다.
 
 -- trigram 확장은 V2에서 이미 활성화되어 있으나, 순서 독립성을 위해 방어적으로 재확인한다.
 CREATE EXTENSION IF NOT EXISTS pg_trgm;
@@ -17,14 +17,22 @@ CREATE INDEX IF NOT EXISTS ix_friends_follower_followee
 
 -- 2) 닉네임 정확/접두 검색용 커버링(표현식) 부분 인덱스
 --    SQL이 lower(nickname)으로 비교/정렬하므로 반드시 lower() 표현식 인덱스여야 한다.
---    text_pattern_ops로 LIKE 'x%' 접두 검색이 로케일과 무관하게 인덱스를 타게 한다.
+--    COLLATE "C"로 LIKE 'x%' 접두 검색이 로케일과 무관하게 인덱스를 타게 한다.
+--      - text_pattern_ops가 아니라 COLLATE "C"인 이유: pattern_ops 인덱스가 만드는 정렬 pathkey는
+--        ~<~ 연산자 패밀리라, 표준 연산자(<)를 쓰는 ORDER BY와 매칭되지 않는다.
+--        COLLATE "C"를 붙여도 마찬가지다(기본 text_ops 패밀리라 여전히 불일치).
+--        그 결과 pattern_ops 인덱스로는 정렬 조기종료가 불가능하고 매칭 전건 스캔 + Sort가 강제된다.
+--        기본 연산자 클래스 + COLLATE "C"는 바이트 순서를 그대로 유지하면서 ORDER BY와도 매칭된다.
+--        (실측 20만행/매칭 12409건: pattern_ops 12409행 스캔 → COLLATE "C" 21행, 201 → 4 buffers)
+--      - WHERE 절은 COLLATE를 명시하지 않아도 된다. 인덱스가 C 콜레이션이면 플래너가
+--        LIKE 'x%'에서 >= / < 범위를 스스로 도출한다.
 --    INCLUDE에는 SELECT가 반환하는 컬럼(id, profile_img_number, nickname, handle)을 모두 담는다.
 --      - 인덱스 키는 lower(nickname)이므로 원본 nickname은 파생되지 않는다 → nickname을 반드시 포함해야
 --        heap 방문 없는 Index-Only Scan이 된다. (벤치 실측: 미포함 시 Bitmap Heap Scan로 폴백)
 --    WHERE deleted_at IS NULL 부분 인덱스로 검색 대상만 인덱싱 → 크기 축소 + 필터가 인덱스에 반영.
 --    (Index-Only Scan 실효는 autovacuum의 가시성 맵 최신화에 의존한다)
 CREATE INDEX IF NOT EXISTS ix_users_nickname_lower_cover
-    ON users (lower(nickname) text_pattern_ops)
+    ON users (lower(nickname) COLLATE "C")
     INCLUDE (id, profile_img_number, nickname, handle)
     WHERE deleted_at IS NULL;
 

--- a/src/main/resources/db/migration/V28__add_friend_search_indexes.sql
+++ b/src/main/resources/db/migration/V28__add_friend_search_indexes.sql
@@ -1,4 +1,4 @@
--- V27__add_friend_search_indexes.sql
+-- V28__add_friend_search_indexes.sql
 -- 친구 검색(닉네임) 및 is_following 조인 성능 개선용 인덱스.
 -- 근거: docs/friend-search-strategy.md "DB Access Patterns 기반 개선안" 섹션.
 -- 주의: 이 파일은 초안이다. 반드시 EXPLAIN (ANALYZE, BUFFERS)로 적용 전후를 실측한 뒤 확정한다.

--- a/src/main/resources/db/migration/V28__add_friend_search_indexes.sql
+++ b/src/main/resources/db/migration/V28__add_friend_search_indexes.sql
@@ -24,8 +24,11 @@ CREATE INDEX IF NOT EXISTS ix_friends_follower_followee
 --        그 결과 pattern_ops 인덱스로는 정렬 조기종료가 불가능하고 매칭 전건 스캔 + Sort가 강제된다.
 --        기본 연산자 클래스 + COLLATE "C"는 바이트 순서를 그대로 유지하면서 ORDER BY와도 매칭된다.
 --        (실측 20만행/매칭 12409건: pattern_ops 12409행 스캔 → COLLATE "C" 21행, 201 → 4 buffers)
---      - WHERE 절은 COLLATE를 명시하지 않아도 된다. 인덱스가 C 콜레이션이면 플래너가
---        LIKE 'x%'에서 >= / < 범위를 스스로 도출한다.
+--      - LIKE 'x%'는 COLLATE를 명시하지 않아도 된다. 인덱스가 C 콜레이션이면 플래너가
+--        >= / < 범위를 스스로 도출한다.
+--      - 반면 동등 비교(=)는 반드시 lower(nickname) COLLATE "C" = ... 로 명시해야 한다.
+--        콜레이션이 어긋나면 Index Cond로 승격되지 않고 Seq Scan으로 떨어진다.
+--        (실측 20만행: 명시 없이 27.9ms/1667 buffers → 명시 시 0.16ms/4 buffers)
 --    INCLUDE에는 SELECT가 반환하는 컬럼(id, profile_img_number, nickname, handle)을 모두 담는다.
 --      - 인덱스 키는 lower(nickname)이므로 원본 nickname은 파생되지 않는다 → nickname을 반드시 포함해야
 --        heap 방문 없는 Index-Only Scan이 된다. (벤치 실측: 미포함 시 Bitmap Heap Scan로 폴백)


### PR DESCRIPTION
## PR Summary
친구 검색(닉네임, 핸들) 쿼리가 인덱스를 타지 못하고 전체 스캔으로 떨어지던 문제를 해결했습니다. 검색 전용 인덱스를 추가하고, 쿼리의 정렬 규칙과 비교 콜레이션을 인덱스에 맞게 정렬했습니다. 모든 변경은 20만 행 데이터셋에서 EXPLAIN (ANALYZE, BUFFERS)로 적용 전후를 실측해 확정했습니다.

<br>

## Problem
**문제 1 - 검색 대상 인덱스 부재**

닉네임 검색과 팔로우 여부 판정에 쓰이는 인덱스가 없었습니다. `friends` 테이블에는 PK만 있어 팔로우 여부를 붙이는 조인이 후보 행마다 랜덤 액세스를 유발했고, 닉네임은 `lower()`로 비교하는데 표현식 인덱스가 없어 매 검색이 전체 스캔이었습니다.

**문제 2 - 정렬 규칙이 인덱스와 어긋나 조기 종료 실패**

접두 검색 인덱스는 패턴 연산자 클래스인데 쿼리는 표준 연산자로 정렬하고 있었습니다. PostgreSQL의 정렬 pathkey는 연산자 패밀리 단위로 매칭되므로, 실제 바이트 순서가 같아도 플래너는 두 순서를 같다고 인식하지 못합니다. 그 결과 인덱스 정렬을 재사용하지 못하고 매칭 전건을 읽은 뒤 Sort를 강제로 수행했습니다. 핸들 검색에서는 옵티마이저가 정렬을 맞추려 유니크 인덱스를 골라 LIKE seek 없이 12만 행을 훑기까지 했습니다.

**문제 3 - 파라미터가 불투명해지는 CTE materialize**

검색 파라미터를 담은 CTE가 여러 버킷에서 참조되면서 자동으로 materialize됐습니다. LIKE 패턴이 실행 시점에야 값이 정해지는 불투명한 값이 되어, 플래너가 접두 인덱스를 쓸 수 있다고 판단하지 못했습니다.

**문제 4 - 불필요한 부분 검색 스캔과 페이지 간 결과 흔들림**

부분 검색 후보를 최소 1건은 뽑도록 강제하고 있어, 정확/접두 매칭만으로 페이지가 이미 채워진 경우에도 테이블 전체를 헛스캔했습니다. 또한 후보를 정렬 없이 뽑아 페이지를 넘길 때 후보 집합이 달라지면서 중복이나 누락이 생길 수 있었습니다.

**문제 5 - 후보 선정 순서와 표시 순서 불일치로 인한 결과 누락**

각 버킷은 후보를 자체 정렬 기준으로 `LIMIT`만큼 자르는데, 최종 표시는 다른 콜레이션으로 정렬하고 있었습니다. "표시 순서상 앞서지만 후보 선정 순서로는 뒤라 잘려나간" 사용자가 통째로 누락됩니다. 한글과 ASCII가 섞인 검색어에서 1페이지 20건이 정답과 한 건도 겹치지 않았습니다.

<br>

## Solution
**해결 1 - 검색 경로 전용 인덱스 추가**

팔로우 조인용 복합 인덱스와, 닉네임 정확/접두 검색용 커버링 부분 인덱스, 부분 검색용 trigram GIN을 추가했습니다. 커버링 인덱스에는 응답이 반환하는 컬럼을 모두 담아 heap 방문 없이 처리되게 했고, 삭제되지 않은 사용자만 부분 인덱스로 담아 크기를 줄였습니다.

**해결 2 - 정렬키와 비교 콜레이션을 인덱스에 일치**

닉네임은 인덱스를 기본 연산자 클래스 + `COLLATE "C"`로 만들고 쿼리의 정렬키도 같게 맞췄습니다. 패턴 연산자 클래스로는 정렬 재사용이 원천적으로 불가능하기 때문입니다. 이때 동등 비교에도 `COLLATE "C"`를 명시해야 합니다. `LIKE`는 플래너가 범위를 도출해주지만 `=`는 콜레이션이 어긋나면 Index Cond로 승격되지 못하고 Seq Scan으로 떨어집니다. 핸들은 기존 인덱스를 그대로 쓰면서 정렬 연산자만 `USING ~<~`로 맞춰 마이그레이션 없이 해결했습니다.

**해결 3 - 파라미터 CTE 인라인 강제**

파라미터 CTE를 `NOT MATERIALIZED`로 선언해 각 버킷에 인라인되게 했습니다. LIKE 패턴이 플래너에게 보이는 값이 되어 접두 인덱스 선택이 유지됩니다.

**해결 4 - 부분 검색 후보 추출 정정**

필요 건수가 0이면 부분 검색을 아예 건너뛰도록 최소 1건 강제를 제거했고, 후보를 최종 표시 순서로 정렬해 뽑도록 바꿔 페이지 간 후보 집합을 고정했습니다.

**해결 5 - 후보 선정과 표시 순서를 단일 기준으로 통일**

바깥 `ORDER BY`를 후보 선정 정렬키와 동일하게 맞췄습니다. 이로써 1페이지 일치율이 0/20에서 20/20이 되고, 페이지 간 중복과 누락도 사라집니다. 순수 한글 구간에서 C 순서는 가나다 순과 일치하며, ASCII가 한글보다 앞선다는 차이만 남습니다.

<br>

## 실측 결과

20만 행, 상위 20건 조회 기준입니다.

**닉네임 접두 검색** (한글, 매칭 20,000건)

| | 스캔 행 | buffers | 시간 |
|---|---|---|---|
| Before | 20,000 | 191 | 13.49ms |
| After | 21 | 14 | 0.39ms |

**닉네임 정확 검색**

| | 계획 | buffers | 시간 |
|---|---|---|---|
| Before | Seq Scan | 1,667 | 27.9ms |
| After | Index Only Scan | 4 | 0.16ms |

**핸들 접두 검색** (매칭 754건)

| | 스캔 행 | buffers | 시간 |
|---|---|---|---|
| Before | 125,681 | 126,109 | 34.6ms |
| After | 20 | 23 | 0.04ms |

**부분 검색(trigram)** — 선택도에 따라 GIN과 커버링 btree로 계획이 갈리며, 양쪽 모두 플래너 선택이 옳았습니다. 고선택도(매칭 1~205건)는 GIN으로 0.02~0.19ms이고 GIN이 없으면 26ms로 악화됩니다. 저선택도(매칭 1만건)는 커버링 btree 조기 종료로 0.4~2.7ms이며, 이 구간에 GIN을 강제하면 31ms로 12배 나빠집니다.

**쓰기 비용** — 회원가입 INSERT는 인덱스 7개일 때 건당 26µs, 이번 추가 후 31µs입니다. 절대값이 0.031ms라 가입 트랜잭션 전체에서는 무시할 수준입니다. 다만 GIN의 pending list 정리를 떠안는 세션이 드물게(0.01%) 200ms대 지연을 겪는 성질이 있습니다. 이는 V2부터 있던 기존 GIN에서 비롯한 것으로 이번 변경이 새로 만든 문제는 아니며, 별도 이슈로 다루는 편이 낫다고 판단해 이 PR에는 포함하지 않았습니다.

<br>

## Related Issue
- close #442


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **새 기능**
  * 로컬 개발 환경에서 pgAdmin4를 실행하고 PostgreSQL 데이터를 관리할 수 있습니다.
* **개선 사항**
  * 친구 핸들 및 닉네임 검색 성능을 개선했습니다.
  * 접두사·부분 일치 검색 결과의 정렬 정확도와 일관성을 높였습니다.
  * 대규모 데이터에서도 검색 결과를 더 빠르게 조회할 수 있도록 데이터베이스 검색 최적화를 적용했습니다.
* **개발 환경**
  * 로컬 pgAdmin 데이터가 유지되도록 저장 공간을 추가했습니다.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->