### PR TITLE
refactor: 레슨 제출을 이력 누적 구조로 전환(#450)

### DIFF
--- a/.claude/resources/plans/PLAN-450.md
+++ b/.claude/resources/plans/PLAN-450.md
@@ -1,0 +1,200 @@
+# [PLAN-450] 레슨 제출 기록을 이력 누적 구조로 전환
+
+> 이슈: #450
+> 브랜치: refactor/450-lesson-submission-history
+
+## 목표
+
+`LessonSubmission`을 유저와 레슨당 1행 덮어쓰기에서 제출마다 새 행을 쌓는 이력 구조로 바꾼다.
+총 학습 시간, 평균 정확도, 주간 리포트가 실제 시도 이력을 반영하게 하고, 1행 전제를 깔고 있던 조회들을 함께 재설계한다.
+
+## 선행 조건
+
+## 영향 범위
+
+### 신규 파일
+- `src/main/resources/db/migration/V28__convert_lesson_submission_to_history.sql` — try_count 제거, created_at 백필
+
+### 수정 파일
+- `src/main/java/gravit/code/lesson/domain/LessonSubmission.java` — tryCount 필드와 갱신 메서드 3개 제거
+- `src/main/java/gravit/code/lesson/repository/LessonSubmissionRepository.java` — 잠금 조회 제거, DISTINCT 집계 전환, 기준 시각을 createdAt으로 변경
+- `src/main/java/gravit/code/lesson/service/LessonSubmissionCommandService.java` — 덮어쓰기 분기 제거, 항상 INSERT
+- `src/main/java/gravit/code/lesson/service/LessonSubmissionQueryService.java` — 완료 레슨 수 조회를 DISTINCT 메서드로 교체
+- `src/main/java/gravit/code/lesson/facade/LessonFacade.java` — saveLessonSubmission 호출에서 isFirstTry 인자 제거
+- `src/main/java/gravit/code/global/exception/domain/CustomErrorCode.java` — LESSON_SUBMISSION_NOT_FOUND 제거
+- `src/test/java/gravit/code/lesson/service/LessonSubmissionCommandServiceUnitTest.java` — 재풀이 시나리오 재작성
+- `src/test/java/gravit/code/lesson/service/LessonSubmissionCommandServiceIntegrationTest.java` — 재풀이 시나리오 재작성
+- `src/test/java/gravit/code/lesson/service/LessonSubmissionQueryServiceIntegrationTest.java` — 재시도 누적 케이스 추가
+- `src/test/java/gravit/code/lesson/facade/LessonFacadeUnitTest.java` — 변경된 호출 시그니처에 맞춰 verify 수정
+
+## 구현 계획
+
+### 1. Entity / Flyway
+
+`LessonSubmission`
+- `tryCount` 필드 제거, `@Column(name = "try_count")` 제거
+- 생성자의 `this.tryCount = 1;` 제거
+- `updateTryCount()`, `updateLearningTime(int)`, `updateAccuracy(int)` 제거 — 이력 구조에서는 행을 갱신하지 않는다
+- `create(...)`, `validateAccuracy(int)`는 그대로 유지
+
+`V28__convert_lesson_submission_to_history.sql`
+```sql
+-- V28__convert_lesson_submission_to_history.sql
+-- 레슨 제출을 유저+레슨당 1행 덮어쓰기에서 제출마다 새 행을 쌓는 이력 구조로 전환
+
+-- 시도 횟수는 엔티티 필드 대신 행 개수로 센다
+ALTER TABLE lesson_submission
+    DROP COLUMN try_count;
+
+-- 주간 리포트 기준 시각이 created_at으로 바뀌므로, V7 이전 행의 빈 created_at을 채운다
+UPDATE lesson_submission
+SET created_at = COALESCE(updated_at, NOW())
+WHERE created_at IS NULL;
+```
+
+> 배포 순서 주의: `try_count`는 NOT NULL이라 구버전 인스턴스가 남아 있는 상태에서 컬럼을 드롭하면 해당 인스턴스의 INSERT가 실패한다. 마이그레이션과 애플리케이션 배포가 함께 나가는지 확인한다.
+
+### 2. Repository — `LessonSubmissionRepository`
+
+| 메서드 | 변경 |
+|---|---|
+| `findByLessonIdAndUserId` | **삭제**. 갱신 대상 행을 잡던 용도이며 `@Lock(PESSIMISTIC_WRITE)`도 함께 사라진다. `LockModeType`, `Lock` import 제거 |
+| `countByUserId` | **삭제 후 교체** (아래 신규 메서드) |
+| `findLearningRateTopPercent` | 서브쿼리의 `COUNT(ls.id) AS solved_count` → `COUNT(DISTINCT ls.lesson_id) AS solved_count` |
+| `getPeakLearningHour` | `EXTRACT(HOUR FROM updated_at)` → `created_at`, `WHERE ... updated_at IS NOT NULL` → `created_at IS NOT NULL` |
+| `findTopChaptersByUserIdInWeek` | SELECT의 `COUNT(l.id)` → `COUNT(DISTINCT l.id)`, `ls.updatedAt` → `ls.createdAt` |
+| `countSolvedLessonsByUserIdInWeek` | `COUNT(ls.id)` → `COUNT(DISTINCT ls.lessonId)`, `ls.updatedAt` → `ls.createdAt` |
+| `findWeakLessonsByUserId` | 아래 별도 항목 |
+| `countLessonSubmissionByLessonIdAndUserId` | 변경 없음. 이제 실제 시도 횟수를 반환한다 |
+| `existsByLessonIdAndUserId` | 변경 없음 |
+| `countSolvedLessonByChapterIdAndUserId` / `...ByUnitIdAndUserId` | 변경 없음. 이미 `COUNT(DISTINCT l.id)` |
+| `getTotalLearningTime` / `getAverageAccuracy` | 쿼리 변경 없음. 행이 시도 1건이 되면서 값이 저절로 교정된다 |
+
+신규 메서드
+```java
+@Query("""
+    SELECT COUNT(DISTINCT ls.lessonId)
+    FROM LessonSubmission ls
+    WHERE ls.userId = :userId
+""")
+long countDistinctLessonByUserId(@Param("userId") long userId);
+```
+
+`findWeakLessonsByUserId` 재작성
+현재는 `FROM LessonSubmission ls JOIN Lesson l`이라 제출 1건당 1행이 나온다. 이력이 쌓이면 같은 레슨이 시도 횟수만큼 중복 반환된다.
+집계 기준을 제출이 아니라 레슨으로 바꾼다. FROM 절을 `Lesson`으로 두고 제출 이력은 EXISTS 조건으로만 쓴다.
+
+```java
+@Query("""
+    SELECT new gravit.code.learning.dto.internal.WeakLessonStatDto(
+        l.id, u.title, c.title,
+        (SELECT COUNT(DISTINCT ps.problemId)
+         FROM ProblemSubmission ps
+         WHERE ps.userId = :userId
+           AND ps.isCorrect = false
+           AND ps.problemId IN (SELECT p.id FROM Problem p WHERE p.lessonId = l.id)),
+        (SELECT COUNT(p.id) FROM Problem p WHERE p.lessonId = l.id)
+    )
+    FROM Lesson l
+    JOIN Unit u ON u.id = l.unitId
+    JOIN Chapter c ON c.id = u.chapterId
+    WHERE EXISTS (
+        SELECT 1 FROM LessonSubmission ls
+        WHERE ls.lessonId = l.id AND ls.userId = :userId
+    )
+    ORDER BY
+        (1.0 * (SELECT COUNT(DISTINCT ps.problemId)
+                FROM ProblemSubmission ps
+                WHERE ps.userId = :userId
+                  AND ps.isCorrect = false
+                  AND ps.problemId IN (SELECT p.id FROM Problem p WHERE p.lessonId = l.id))
+         / NULLIF((SELECT COUNT(p.id) FROM Problem p WHERE p.lessonId = l.id), 0)) DESC,
+        l.id ASC
+""")
+List<WeakLessonStatDto> findWeakLessonsByUserId(
+        @Param("userId") long userId,
+        Pageable pageable
+);
+```
+> 내부 서브쿼리의 `COUNT(DISTINCT ps.problemId)`는 PR #449가 이미 반영한 내용이다. 리베이스 후 중복 적용하지 않는다.
+
+### 3. Service
+
+`LessonSubmissionCommandService`
+```java
+@Transactional
+public void saveLessonSubmission(
+        long userId,
+        LessonSubmissionSaveRequest request
+)
+```
+- `isFirstTry` 파라미터 제거
+- 분기 전체를 제거하고 항상 `LessonSubmission.create(...)` 후 `save`
+- `findByLessonIdAndUserId` 조회와 `LESSON_SUBMISSION_NOT_FOUND` 예외 제거
+- `lessonRepository.existsById` 검증은 유지
+
+`LessonSubmissionQueryService`
+- `getCompletedLessonCount(long userId)` — `countByUserId` → `countDistinctLessonByUserId` 호출로 교체. 반환 타입과 `Math.toIntExact` 래핑은 유지
+- `getLessonSubmissionTryCount`, `checkFirstLessonSubmission`, `getTotalLearningHours`, `getAverageAccuracy`, `getPeakLearningHour`, `getTopChapters`, `getWeakConcepts` — 시그니처 변경 없음
+
+`LearningProgressRateService`
+- `getPlanetConquestRate`에서 `lessonSubmissionRepository.countByUserId` → `countDistinctLessonByUserId`
+- `getLearningRankPercentile`, `getChapterProgress`, `getUnitProgress` — 변경 없음
+
+`MissionService`
+- 코드 변경 없음. `getLessonSubmissionTryCount`가 이제 실제 시도 횟수를 반환하면서 `tryCount > 1` 가드가 의미를 갖는다
+- 다만 `LessonFacade`가 `isFirstTry`일 때만 `LessonCompletedEvent`를 발행하므로, 현재 흐름에서 이 가드는 여전히 발동하지 않는다. 아래 "결정 필요" 참고
+
+### 4. Facade
+
+`LessonFacade.saveLessonSubmission`
+- `lessonSubmissionCommandService.saveLessonSubmission(userId, request.lessonSubmissionSaveRequest(), isFirstTry)` → 인자에서 `isFirstTry` 제거
+- `isFirstTry` 변수 자체는 유지한다. `userService.updateUserLevelByLessonSubmission`의 경험치 지급 분기와 `LessonCompletedEvent` 발행 조건이 계속 사용한다
+- 그 외 흐름 변경 없음
+
+### 5. DTO
+변경 없음. `LessonSubmissionSaveRequest(lessonId, learningTime, accuracy)`와 `LessonSubmissionSaveResponse`를 그대로 쓴다.
+
+### 6. Controller
+변경 없음. API 경로와 응답 스펙이 그대로다.
+
+### 7. 예외 코드
+`CustomErrorCode.LESSON_SUBMISSION_NOT_FOUND`는 유일한 사용처가 사라지므로 제거한다.
+
+## 결정 필요 (Decisions needed)
+
+- [x] `MissionService`의 `tryCount > 1` 가드를 어떻게 둘지 → **그대로 유지**
+  이슈 본문은 이 가드가 "실제로 동작하게 된다"고 적었으나, 코드를 확인해 보니 사실과 다르다.
+  `LessonFacade`는 `isFirstTry`일 때만 `LessonCompletedEvent`를 발행하고, `MissionEventListener`를 거쳐 `handleLessonMission`이 호출되는 시점에는 이미 첫 행이 INSERT된 뒤라 시도 횟수는 항상 1이다.
+  즉 값은 정확해지지만 가드는 여전히 발동하지 않는다.
+  가드는 코드 변경 없이 그대로 두고, 이벤트 게이트가 바뀌어도 미션이 중복 적립되지 않는 이중 방어로 남긴다.
+  이벤트 발행 조건 자체를 손보는 선택지는 리스너 설계 영역이라 담당 범위 밖이며, 인계 사항으로 분류한다.
+
+## 검증
+
+- `LessonSubmissionCommandServiceUnitTest`
+  - `재풀이면_기존_기록을_업데이트한다` → `재풀이면_새_행을_저장한다`로 교체. `findByLessonIdAndUserId` 호출이 없고 `save`가 호출되는지 검증
+  - `재풀이인데_기존_기록이_없으면_예외를_던진다` 삭제. 해당 예외 경로가 사라진다
+  - `첫_풀이면_새로_생성한다`, `레슨이_존재하지_않으면_예외를_던진다`는 인자 변경만 반영
+- `LessonSubmissionCommandServiceIntegrationTest`
+  - 같은 레슨을 2회 제출하면 행이 2개 쌓이고 각 행의 learningTime, accuracy가 제출값 그대로인지 검증
+- `LessonSubmissionQueryServiceIntegrationTest`
+  - `getCompletedLessonCount` — 같은 레슨 3회 제출 시 1을 반환 (DISTINCT)
+  - `getLessonSubmissionTryCount` — 같은 레슨 3회 제출 시 3을 반환
+  - `getTotalLearningHours` — 재시도분이 합산되는지 (기존 `학습_기록이_여러_개면...` 옆에 재시도 케이스 추가)
+  - `getAverageAccuracy` — 40점, 100점 2회 제출 시 70을 반환
+  - `getTopChapters` — 같은 레슨을 여러 번 제출해도 solvedLessonCount가 부풀지 않는지
+  - `getWeakConcepts` — 같은 레슨 재제출 시 응답에 중복 레슨이 없는지
+- `LessonFacadeUnitTest`
+  - `lessonSubmissionCommandService.saveLessonSubmission(userId, request)` 2인자 verify로 수정
+  - `재풀이면_이벤트를_발행하지_않는다`는 그대로 통과해야 한다
+- `MissionServiceUnitTest`
+  - 시도 횟수 2 스텁은 이제 서비스 계약상 유효한 입력이므로 유지한다
+- `./gradlew build` — flyway validate 포함, V28 체크섬 확인
+
+## Deviation Log
+
+- `LessonSubmissionCommandServiceUnitTest`: `재풀이면_새_행을_저장한다`에서 `findByLessonIdAndUserId` 미호출 검증을 넣지 않았다 — 이유: 해당 메서드를 리포지토리에서 삭제해 `verify(..., never())` 대상 자체가 사라졌다. `save` 호출 검증만 남긴다
+- `LearningProgressRateServiceUnitTest`: 계획서 수정 파일 목록에 없었으나 `countByUserId` 스텁 3건을 `countDistinctLessonByUserId`로 교체했다 — 이유: 메서드 삭제로 컴파일이 깨진다
+- `LessonSubmissionQueryServiceIntegrationTest`: 계획서 "검증" 항목의 신규 케이스를 `write-test`로 넘겼다가 이후 모두 추가 완료 — 이력 누적 6개 케이스(시도 횟수 3, 완료 레슨 DISTINCT 1, 학습 시간 합산, 평균 정확도 70, TOP 챕터 미부풀림, 취약 개념 미중복)
+- `LessonSubmissionQueryService.getTotalLearningHours()`: 계획서에 없던 변경 — 반환값을 소수점 첫째 자리 반올림으로 바꾸고 `SECONDS_PER_HOUR`, `LEARNING_HOURS_ROUNDING_SCALE` 상수를 도입했다. 이유: 사용자 요청(계획서 범위 밖의 별도 지시)

--- a/src/main/java/gravit/code/global/exception/domain/CustomErrorCode.java
+++ b/src/main/java/gravit/code/global/exception/domain/CustomErrorCode.java
@@ -58,7 +58,6 @@ public enum CustomErrorCode implements ErrorCode {
 
     // Lesson
     LESSON_NOT_FOUND(HttpStatus.NOT_FOUND, "LESSON_4041", "레슨 조회에 실패하였습니다."),
-    LESSON_SUBMISSION_NOT_FOUND(HttpStatus.NOT_FOUND, "LESSON_4042", "레슨 풀이 제출 이력 조회에 실패하였습니다."),
     INVALID_ACCURACY(HttpStatus.BAD_REQUEST,"LESSON_4001", "유효하지 않은 정확도입니다."),
 
     // Problem

--- a/src/main/java/gravit/code/learning/service/LearningProgressRateService.java
+++ b/src/main/java/gravit/code/learning/service/LearningProgressRateService.java
@@ -51,7 +51,7 @@ public class LearningProgressRateService {
     public int getPlanetConquestRate(
             long userId
     ) {
-        long solvedLesson = lessonSubmissionRepository.countByUserId(userId);
+        long solvedLesson = lessonSubmissionRepository.countDistinctLessonByUserId(userId);
 
         if(solvedLesson == 0) {
             return 0;

--- a/src/main/java/gravit/code/lesson/domain/LessonSubmission.java
+++ b/src/main/java/gravit/code/lesson/domain/LessonSubmission.java
@@ -28,9 +28,6 @@ public class LessonSubmission extends BaseEntity {
     @Column(name = "learning_time", nullable = false)
     private int learningTime;
 
-    @Column(name = "try_count", nullable = false)
-    private int tryCount;
-
     @Column(name = "accuracy", nullable = false)
     private int accuracy;
 
@@ -49,7 +46,6 @@ public class LessonSubmission extends BaseEntity {
     ) {
         validateAccuracy(accuracy);
         this.learningTime = learningTime;
-        this.tryCount = 1;
         this.accuracy = accuracy;
         this.lessonId = lessonId;
         this.userId = userId;
@@ -67,19 +63,6 @@ public class LessonSubmission extends BaseEntity {
                 .lessonId(lessonId)
                 .userId(userId)
                 .build();
-    }
-
-    public void updateLearningTime(int learningTime){
-        this.learningTime = learningTime;
-    }
-
-    public void updateAccuracy(int accuracy){
-        validateAccuracy(accuracy);
-        this.accuracy = accuracy;
-    }
-
-    public void updateTryCount() {
-        this.tryCount++;
     }
 
     private static void validateAccuracy(int accuracy) {

--- a/src/main/java/gravit/code/lesson/facade/LessonFacade.java
+++ b/src/main/java/gravit/code/lesson/facade/LessonFacade.java
@@ -78,7 +78,7 @@ public class LessonFacade {
         boolean isFirstTry = lessonSubmissionQueryService.checkFirstLessonSubmission(userId, request.lessonSubmissionSaveRequest().lessonId());
 
         // 레슨 풀이 결과, 문제 풀이 결과 저장
-        lessonSubmissionCommandService.saveLessonSubmission(userId, request.lessonSubmissionSaveRequest(), isFirstTry);
+        lessonSubmissionCommandService.saveLessonSubmission(userId, request.lessonSubmissionSaveRequest());
         problemSubmissionCommandService.saveProblemSubmissions(userId, request.problemSubmissionRequests());
 
         // 응답 데이터 조회

--- a/src/main/java/gravit/code/lesson/repository/LessonSubmissionRepository.java
+++ b/src/main/java/gravit/code/lesson/repository/LessonSubmissionRepository.java
@@ -3,10 +3,8 @@ package gravit.code.lesson.repository;
 import gravit.code.chapter.dto.internal.ChapterSolvedStatDto;
 import gravit.code.learning.dto.internal.WeakLessonStatDto;
 import gravit.code.lesson.domain.LessonSubmission;
-import jakarta.persistence.LockModeType;
 import org.springframework.data.domain.Pageable;
 import org.springframework.data.jpa.repository.JpaRepository;
-import org.springframework.data.jpa.repository.Lock;
 import org.springframework.data.jpa.repository.Query;
 import org.springframework.data.repository.query.Param;
 
@@ -16,13 +14,12 @@ import java.util.Optional;
 
 public interface LessonSubmissionRepository extends JpaRepository<LessonSubmission, Long> {
 
-    @Lock(LockModeType.PESSIMISTIC_WRITE)
-    Optional<LessonSubmission> findByLessonIdAndUserId(
-            long lessonId,
-            long userId
-    );
-
-    long countByUserId(long userId);
+    @Query("""
+        SELECT COUNT(DISTINCT ls.lessonId)
+        FROM LessonSubmission ls
+        WHERE ls.userId = :userId
+    """)
+    long countDistinctLessonByUserId(@Param("userId") long userId);
 
     @Query("""
         SELECT COUNT(DISTINCT l.id)
@@ -65,7 +62,7 @@ public interface LessonSubmissionRepository extends JpaRepository<LessonSubmissi
     @Query(value = """
             SELECT CAST(CEIL(CUME_DIST() OVER (ORDER BY solved_count DESC) * 100) AS INTEGER)
             FROM (
-                SELECT u.id AS user_id, COUNT(ls.id) AS solved_count
+                SELECT u.id AS user_id, COUNT(DISTINCT ls.lesson_id) AS solved_count
                 FROM users u
                 LEFT JOIN lesson_submission ls ON ls.user_id = u.id
                 WHERE u.deleted_at IS NULL
@@ -90,9 +87,9 @@ public interface LessonSubmissionRepository extends JpaRepository<LessonSubmissi
     int getAverageAccuracy(@Param("userId") long userId);
 
     @Query(value = """
-        SELECT CAST(EXTRACT(HOUR FROM updated_at) AS INTEGER) AS hour
+        SELECT CAST(EXTRACT(HOUR FROM created_at) AS INTEGER) AS hour
         FROM lesson_submission
-        WHERE user_id = :userId AND updated_at IS NOT NULL
+        WHERE user_id = :userId AND created_at IS NOT NULL
         GROUP BY hour
         ORDER BY COUNT(*) DESC, hour ASC
         LIMIT 1
@@ -101,15 +98,15 @@ public interface LessonSubmissionRepository extends JpaRepository<LessonSubmissi
 
     @Query("""
         SELECT new gravit.code.chapter.dto.internal.ChapterSolvedStatDto(
-            c.id, c.title, COUNT(l.id)
+            c.id, c.title, COUNT(DISTINCT l.id)
         )
         FROM LessonSubmission ls
         JOIN Lesson l ON l.id = ls.lessonId
         JOIN Unit u ON u.id = l.unitId
         JOIN Chapter c ON c.id = u.chapterId
         WHERE ls.userId = :userId
-          AND ls.updatedAt >= :weekStart
-          AND ls.updatedAt < :nextWeekStart
+          AND ls.createdAt >= :weekStart
+          AND ls.createdAt < :nextWeekStart
         GROUP BY c.id, c.title
         ORDER BY COUNT(DISTINCT l.id) DESC, c.id ASC
     """)
@@ -121,11 +118,11 @@ public interface LessonSubmissionRepository extends JpaRepository<LessonSubmissi
     );
 
     @Query("""
-        SELECT COUNT(ls.id)
+        SELECT COUNT(DISTINCT ls.lessonId)
         FROM LessonSubmission ls
         WHERE ls.userId = :userId
-          AND ls.updatedAt >= :weekStart
-          AND ls.updatedAt < :nextWeekStart
+          AND ls.createdAt >= :weekStart
+          AND ls.createdAt < :nextWeekStart
     """)
     long countSolvedLessonsByUserIdInWeek(
             @Param("userId") long userId,
@@ -143,11 +140,13 @@ public interface LessonSubmissionRepository extends JpaRepository<LessonSubmissi
                AND ps.problemId IN (SELECT p.id FROM Problem p WHERE p.lessonId = l.id)),
             (SELECT COUNT(p.id) FROM Problem p WHERE p.lessonId = l.id)
         )
-        FROM LessonSubmission ls
-        JOIN Lesson l ON l.id = ls.lessonId
+        FROM Lesson l
         JOIN Unit u ON u.id = l.unitId
         JOIN Chapter c ON c.id = u.chapterId
-        WHERE ls.userId = :userId
+        WHERE EXISTS (
+            SELECT 1 FROM LessonSubmission ls
+            WHERE ls.lessonId = l.id AND ls.userId = :userId
+        )
         ORDER BY
             (1.0 * (SELECT COUNT(DISTINCT ps.problemId)
                     FROM ProblemSubmission ps

--- a/src/main/java/gravit/code/lesson/service/LessonSubmissionCommandService.java
+++ b/src/main/java/gravit/code/lesson/service/LessonSubmissionCommandService.java
@@ -20,28 +20,17 @@ public class LessonSubmissionCommandService {
     @Transactional
     public void saveLessonSubmission(
         long userId,
-        LessonSubmissionSaveRequest request,
-        boolean isFirstTry
+        LessonSubmissionSaveRequest request
     ) {
         if(!lessonRepository.existsById(request.lessonId()))
             throw new RestApiException(CustomErrorCode.LESSON_NOT_FOUND);
 
-        LessonSubmission lessonSubmission;
-        if(isFirstTry){
-            lessonSubmission = LessonSubmission.create(
-                    request.learningTime(),
-                    request.accuracy(),
-                    request.lessonId(),
-                    userId
-            );
-        }else{
-            lessonSubmission = lessonSubmissionRepository.findByLessonIdAndUserId(request.lessonId(), userId)
-                    .orElseThrow(() -> new RestApiException(CustomErrorCode.LESSON_SUBMISSION_NOT_FOUND));
-
-            lessonSubmission.updateLearningTime(request.learningTime());
-            lessonSubmission.updateAccuracy(request.accuracy());
-            lessonSubmission.updateTryCount();
-        }
+        LessonSubmission lessonSubmission = LessonSubmission.create(
+                request.learningTime(),
+                request.accuracy(),
+                request.lessonId(),
+                userId
+        );
 
         lessonSubmissionRepository.save(lessonSubmission);
     }

--- a/src/main/java/gravit/code/lesson/service/LessonSubmissionQueryService.java
+++ b/src/main/java/gravit/code/lesson/service/LessonSubmissionQueryService.java
@@ -23,6 +23,8 @@ public class LessonSubmissionQueryService {
 
     private static final int TOP_CHAPTERS_LIMIT = 3;
     private static final int WEAK_LESSONS_LIMIT = 7;
+    private static final int SECONDS_PER_HOUR = 60 * 60;
+    private static final double LEARNING_HOURS_ROUNDING_SCALE = 10.0;
 
     private final LessonSubmissionRepository lessonSubmissionRepository;
 
@@ -44,14 +46,16 @@ public class LessonSubmissionQueryService {
 
     @Transactional(readOnly = true)
     public int getCompletedLessonCount(long userId) {
-        return Math.toIntExact(lessonSubmissionRepository.countByUserId(userId));
+        return Math.toIntExact(lessonSubmissionRepository.countDistinctLessonByUserId(userId));
     }
 
     @Transactional(readOnly = true)
     public double getTotalLearningHours(long userId) {
         int learningSeconds = lessonSubmissionRepository.getTotalLearningTime(userId);
 
-        return (double) learningSeconds / (60 * 60);
+        double learningHours = (double) learningSeconds / SECONDS_PER_HOUR;
+
+        return Math.round(learningHours * LEARNING_HOURS_ROUNDING_SCALE) / LEARNING_HOURS_ROUNDING_SCALE;
     }
 
     @Transactional(readOnly = true)

--- a/src/main/resources/db/migration/V28__convert_lesson_submission_to_history.sql
+++ b/src/main/resources/db/migration/V28__convert_lesson_submission_to_history.sql
@@ -1,0 +1,11 @@
+-- V28__convert_lesson_submission_to_history.sql
+-- 레슨 제출을 유저+레슨당 1행 덮어쓰기에서 제출마다 새 행을 쌓는 이력 구조로 전환
+
+-- 시도 횟수는 엔티티 필드 대신 행 개수로 센다
+ALTER TABLE lesson_submission
+    DROP COLUMN try_count;
+
+-- 주간 리포트 기준 시각이 created_at으로 바뀌므로, V7 이전 행의 빈 created_at을 채운다
+UPDATE lesson_submission
+SET created_at = COALESCE(updated_at, NOW())
+WHERE created_at IS NULL;

--- a/src/test/java/gravit/code/learning/service/LearningProgressRateServiceUnitTest.java
+++ b/src/test/java/gravit/code/learning/service/LearningProgressRateServiceUnitTest.java
@@ -138,7 +138,7 @@ class LearningProgressRateServiceUnitTest {
             // given
             long userId = 1L;
 
-            when(lessonSubmissionRepository.countByUserId(userId)).thenReturn(0L);
+            when(lessonSubmissionRepository.countDistinctLessonByUserId(userId)).thenReturn(0L);
 
             // when
             int result = learningProgressRateService.getPlanetConquestRate(userId);
@@ -152,7 +152,7 @@ class LearningProgressRateServiceUnitTest {
             // given
             long userId = 1L;
 
-            when(lessonSubmissionRepository.countByUserId(userId)).thenReturn(1L);
+            when(lessonSubmissionRepository.countDistinctLessonByUserId(userId)).thenReturn(1L);
             when(lessonRepository.count()).thenReturn(3L);
 
             // when
@@ -167,7 +167,7 @@ class LearningProgressRateServiceUnitTest {
             // given
             long userId = 1L;
 
-            when(lessonSubmissionRepository.countByUserId(userId)).thenReturn(3L);
+            when(lessonSubmissionRepository.countDistinctLessonByUserId(userId)).thenReturn(3L);
             when(lessonRepository.count()).thenReturn(3L);
 
             // when

--- a/src/test/java/gravit/code/lesson/service/LessonSubmissionCommandServiceIntegrationTest.java
+++ b/src/test/java/gravit/code/lesson/service/LessonSubmissionCommandServiceIntegrationTest.java
@@ -16,9 +16,12 @@ import org.junit.jupiter.api.Nested;
 import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
 
+import java.util.List;
+
 import static gravit.code.global.exception.domain.CustomErrorCode.LESSON_NOT_FOUND;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static org.assertj.core.api.Assertions.tuple;
 import static org.assertj.core.api.SoftAssertions.assertSoftly;
 
 @TCSpringBootTest
@@ -53,31 +56,31 @@ class LessonSubmissionCommandServiceIntegrationTest {
             LessonSubmissionSaveRequest request = new LessonSubmissionSaveRequest(lesson.getId(), 120, 80);
 
             // when
-            lessonSubmissionCommandService.saveLessonSubmission(userId, request, true);
+            lessonSubmissionCommandService.saveLessonSubmission(userId, request);
 
             // then
             assertThat(lessonSubmissionRepository.existsByLessonIdAndUserId(lesson.getId(), userId)).isTrue();
         }
 
         @Test
-        void 재풀이면_기존_기록을_업데이트한다() {
+        void 재풀이면_새_행을_저장한다() {
             // given
             long userId = 1L;
             Chapter chapter = chapterRepository.save(Chapter.create("운영체제", "운영체제 기초 개념"));
             Unit unit = unitRepository.save(Unit.create("프로세스", "프로세스 개념", chapter.getId()));
             Lesson lesson = lessonRepository.save(Lesson.create("레슨1", unit.getId()));
-            LessonSubmission saved = lessonSubmissionRepository.save(LessonSubmission.create(120, 80, lesson.getId(), userId));
-            LessonSubmissionSaveRequest request = new LessonSubmissionSaveRequest(lesson.getId(), 90, 85);
 
             // when
-            lessonSubmissionCommandService.saveLessonSubmission(userId, request, false);
+            lessonSubmissionCommandService.saveLessonSubmission(userId, new LessonSubmissionSaveRequest(lesson.getId(), 120, 80));
+            lessonSubmissionCommandService.saveLessonSubmission(userId, new LessonSubmissionSaveRequest(lesson.getId(), 90, 85));
 
             // then
-            LessonSubmission updated = lessonSubmissionRepository.findById(saved.getId()).get();
+            List<LessonSubmission> submissions = lessonSubmissionRepository.findAll();
             assertSoftly(softly -> {
-                softly.assertThat(updated.getLearningTime()).isEqualTo(90);
-                softly.assertThat(updated.getTryCount()).isEqualTo(2);
-                softly.assertThat(updated.getAccuracy()).isEqualTo(85);
+                softly.assertThat(submissions).hasSize(2);
+                softly.assertThat(submissions)
+                        .extracting(LessonSubmission::getLearningTime, LessonSubmission::getAccuracy)
+                        .containsExactlyInAnyOrder(tuple(120, 80), tuple(90, 85));
             });
         }
 
@@ -88,7 +91,7 @@ class LessonSubmissionCommandServiceIntegrationTest {
             LessonSubmissionSaveRequest request = new LessonSubmissionSaveRequest(999L, 120, 80);
 
             // when & then
-            assertThatThrownBy(() -> lessonSubmissionCommandService.saveLessonSubmission(userId, request, true))
+            assertThatThrownBy(() -> lessonSubmissionCommandService.saveLessonSubmission(userId, request))
                     .isInstanceOf(RestApiException.class)
                     .extracting(e -> ((RestApiException) e).getErrorCode())
                     .isEqualTo(LESSON_NOT_FOUND);

--- a/src/test/java/gravit/code/lesson/service/LessonSubmissionCommandServiceUnitTest.java
+++ b/src/test/java/gravit/code/lesson/service/LessonSubmissionCommandServiceUnitTest.java
@@ -13,11 +13,7 @@ import org.mockito.InjectMocks;
 import org.mockito.Mock;
 import org.mockito.junit.jupiter.MockitoExtension;
 
-import java.util.Optional;
-
 import static gravit.code.global.exception.domain.CustomErrorCode.LESSON_NOT_FOUND;
-import static gravit.code.global.exception.domain.CustomErrorCode.LESSON_SUBMISSION_NOT_FOUND;
-import static gravit.code.lesson.fixture.LessonSubmissionFixture.기본_레슨_제출;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.Mockito.*;
@@ -46,30 +42,24 @@ class LessonSubmissionCommandServiceUnitTest {
             when(lessonRepository.existsById(1L)).thenReturn(true);
 
             // when
-            lessonSubmissionCommandService.saveLessonSubmission(userId, request, true);
+            lessonSubmissionCommandService.saveLessonSubmission(userId, request);
 
             // then
             verify(lessonSubmissionRepository).save(any(LessonSubmission.class));
-            verify(lessonSubmissionRepository, never()).findByLessonIdAndUserId(anyLong(), anyLong());
         }
 
         @Test
-        void 재풀이면_기존_기록을_업데이트한다() {
+        void 재풀이면_새_행을_저장한다() {
             // given
             long userId = 1L;
             LessonSubmissionSaveRequest request = new LessonSubmissionSaveRequest(1L, 90, 85);
-            LessonSubmission existing = 기본_레슨_제출(1L, userId);
-
             when(lessonRepository.existsById(1L)).thenReturn(true);
-            when(lessonSubmissionRepository.findByLessonIdAndUserId(1L, userId))
-                    .thenReturn(Optional.of(existing));
 
             // when
-            lessonSubmissionCommandService.saveLessonSubmission(userId, request, false);
+            lessonSubmissionCommandService.saveLessonSubmission(userId, request);
 
             // then
-            verify(lessonSubmissionRepository).findByLessonIdAndUserId(1L, userId);
-            verify(lessonSubmissionRepository).save(existing);
+            verify(lessonSubmissionRepository).save(any(LessonSubmission.class));
         }
 
         @Test
@@ -80,26 +70,10 @@ class LessonSubmissionCommandServiceUnitTest {
             when(lessonRepository.existsById(999L)).thenReturn(false);
 
             // when & then
-            assertThatThrownBy(() -> lessonSubmissionCommandService.saveLessonSubmission(userId, request, true))
+            assertThatThrownBy(() -> lessonSubmissionCommandService.saveLessonSubmission(userId, request))
                     .isInstanceOf(RestApiException.class)
                     .extracting(e -> ((RestApiException) e).getErrorCode())
                     .isEqualTo(LESSON_NOT_FOUND);
-        }
-
-        @Test
-        void 재풀이인데_기존_기록이_없으면_예외를_던진다() {
-            // given
-            long userId = 1L;
-            LessonSubmissionSaveRequest request = new LessonSubmissionSaveRequest(1L, 120, 80);
-            when(lessonRepository.existsById(1L)).thenReturn(true);
-            when(lessonSubmissionRepository.findByLessonIdAndUserId(1L, userId))
-                    .thenReturn(Optional.empty());
-
-            // when & then
-            assertThatThrownBy(() -> lessonSubmissionCommandService.saveLessonSubmission(userId, request, false))
-                    .isInstanceOf(RestApiException.class)
-                    .extracting(e -> ((RestApiException) e).getErrorCode())
-                    .isEqualTo(LESSON_SUBMISSION_NOT_FOUND);
         }
     }
 }

--- a/src/test/java/gravit/code/lesson/service/LessonSubmissionCommandServiceUnitTest.java
+++ b/src/test/java/gravit/code/lesson/service/LessonSubmissionCommandServiceUnitTest.java
@@ -52,14 +52,16 @@ class LessonSubmissionCommandServiceUnitTest {
         void 재풀이면_새_행을_저장한다() {
             // given
             long userId = 1L;
-            LessonSubmissionSaveRequest request = new LessonSubmissionSaveRequest(1L, 90, 85);
+            LessonSubmissionSaveRequest firstRequest = new LessonSubmissionSaveRequest(1L, 120, 80);
+            LessonSubmissionSaveRequest retryRequest = new LessonSubmissionSaveRequest(1L, 90, 85);
             when(lessonRepository.existsById(1L)).thenReturn(true);
 
             // when
-            lessonSubmissionCommandService.saveLessonSubmission(userId, request);
+            lessonSubmissionCommandService.saveLessonSubmission(userId, firstRequest);
+            lessonSubmissionCommandService.saveLessonSubmission(userId, retryRequest);
 
             // then
-            verify(lessonSubmissionRepository).save(any(LessonSubmission.class));
+            verify(lessonSubmissionRepository, times(2)).save(any(LessonSubmission.class));
         }
 
         @Test

--- a/src/test/java/gravit/code/lesson/service/LessonSubmissionQueryServiceIntegrationTest.java
+++ b/src/test/java/gravit/code/lesson/service/LessonSubmissionQueryServiceIntegrationTest.java
@@ -71,6 +71,24 @@ class LessonSubmissionQueryServiceIntegrationTest {
         }
 
         @Test
+        void 같은_레슨을_여러_번_제출하면_제출한_횟수를_반환한다() {
+            // given
+            long userId = 1L;
+            Chapter chapter = chapterRepository.save(Chapter.create("운영체제", "운영체제 기초 개념"));
+            Unit unit = unitRepository.save(Unit.create("프로세스", "프로세스 개념", chapter.getId()));
+            Lesson lesson = lessonRepository.save(Lesson.create("레슨1", unit.getId()));
+            lessonSubmissionRepository.save(LessonSubmission.create(120, 60, lesson.getId(), userId));
+            lessonSubmissionRepository.save(LessonSubmission.create(120, 80, lesson.getId(), userId));
+            lessonSubmissionRepository.save(LessonSubmission.create(120, 100, lesson.getId(), userId));
+
+            // when
+            int result = lessonSubmissionQueryService.getLessonSubmissionTryCount(userId, lesson.getId());
+
+            // then
+            assertThat(result).isEqualTo(3);
+        }
+
+        @Test
         void 제출_기록이_없으면_0을_반환한다() {
             // given
             long userId = 1L;
@@ -145,6 +163,24 @@ class LessonSubmissionQueryServiceIntegrationTest {
         }
 
         @Test
+        void 같은_레슨을_여러_번_제출해도_1개로_집계된다() {
+            // given
+            long userId = 1L;
+            Chapter chapter = chapterRepository.save(Chapter.create("운영체제", "운영체제 기초 개념"));
+            Unit unit = unitRepository.save(Unit.create("프로세스", "프로세스 개념", chapter.getId()));
+            Lesson lesson = lessonRepository.save(Lesson.create("레슨1", unit.getId()));
+            lessonSubmissionRepository.save(LessonSubmission.create(120, 60, lesson.getId(), userId));
+            lessonSubmissionRepository.save(LessonSubmission.create(120, 80, lesson.getId(), userId));
+            lessonSubmissionRepository.save(LessonSubmission.create(120, 100, lesson.getId(), userId));
+
+            // when
+            int result = lessonSubmissionQueryService.getCompletedLessonCount(userId);
+
+            // then
+            assertThat(result).isEqualTo(1);
+        }
+
+        @Test
         void 제출_기록이_없으면_0을_반환한다() {
             // given
             long userId = 1L;
@@ -197,6 +233,40 @@ class LessonSubmissionQueryServiceIntegrationTest {
         }
 
         @Test
+        void 같은_레슨을_재시도하면_시도마다_학습_시간이_합산된다() {
+            // given
+            long userId = 1L;
+            Chapter chapter = chapterRepository.save(Chapter.create("운영체제", "운영체제 기초 개념"));
+            Unit unit = unitRepository.save(Unit.create("프로세스", "프로세스 개념", chapter.getId()));
+            Lesson lesson = lessonRepository.save(Lesson.create("레슨1", unit.getId()));
+            lessonSubmissionRepository.save(LessonSubmission.create(3600, 80, lesson.getId(), userId));
+            lessonSubmissionRepository.save(LessonSubmission.create(1800, 90, lesson.getId(), userId));
+
+            // when
+            double result = lessonSubmissionQueryService.getTotalLearningHours(userId);
+
+            // then
+            assertThat(result).isEqualTo(1.5);
+        }
+
+        @Test
+        void 딱_떨어지지_않으면_소수점_첫째자리로_반올림하여_반환한다() {
+            // given
+            long userId = 1L;
+            Chapter chapter = chapterRepository.save(Chapter.create("운영체제", "운영체제 기초 개념"));
+            Unit unit = unitRepository.save(Unit.create("프로세스", "프로세스 개념", chapter.getId()));
+            Lesson lesson = lessonRepository.save(Lesson.create("레슨1", unit.getId()));
+            // 4600초 = 1.2777...시간 → 1.3
+            lessonSubmissionRepository.save(LessonSubmission.create(4600, 80, lesson.getId(), userId));
+
+            // when
+            double result = lessonSubmissionQueryService.getTotalLearningHours(userId);
+
+            // then
+            assertThat(result).isEqualTo(1.3);
+        }
+
+        @Test
         void 학습_기록이_없으면_0을_반환한다() {
             // given
             long userId = 1L;
@@ -246,6 +316,23 @@ class LessonSubmissionQueryServiceIntegrationTest {
 
             // then
             assertThat(result).isEqualTo(90);
+        }
+
+        @Test
+        void 같은_레슨을_재시도하면_시도마다_평균에_반영된다() {
+            // given
+            long userId = 1L;
+            Chapter chapter = chapterRepository.save(Chapter.create("운영체제", "운영체제 기초 개념"));
+            Unit unit = unitRepository.save(Unit.create("프로세스", "프로세스 개념", chapter.getId()));
+            Lesson lesson = lessonRepository.save(Lesson.create("레슨1", unit.getId()));
+            lessonSubmissionRepository.save(LessonSubmission.create(120, 40, lesson.getId(), userId));
+            lessonSubmissionRepository.save(LessonSubmission.create(120, 100, lesson.getId(), userId));
+
+            // when
+            int result = lessonSubmissionQueryService.getAverageAccuracy(userId);
+
+            // then
+            assertThat(result).isEqualTo(70);
         }
 
         @Test
@@ -346,6 +433,33 @@ class LessonSubmissionQueryServiceIntegrationTest {
         }
 
         @Test
+        void 같은_레슨을_여러_번_제출해도_풀이_수가_부풀지_않는다() {
+            // given
+            long userId = 1L;
+            Chapter chapter = chapterRepository.save(Chapter.create("자료구조", "자료구조 기초"));
+            Unit unit = unitRepository.save(Unit.create("연결리스트", "linked list", chapter.getId()));
+            Lesson lesson1 = lessonRepository.save(Lesson.create("레슨1", unit.getId()));
+            Lesson lesson2 = lessonRepository.save(Lesson.create("레슨2", unit.getId()));
+
+            // lesson1은 3번 제출했지만 푼 레슨은 lesson1, lesson2 두 개다
+            lessonSubmissionRepository.save(LessonSubmission.create(60, 40, lesson1.getId(), userId));
+            lessonSubmissionRepository.save(LessonSubmission.create(60, 70, lesson1.getId(), userId));
+            lessonSubmissionRepository.save(LessonSubmission.create(60, 90, lesson1.getId(), userId));
+            lessonSubmissionRepository.save(LessonSubmission.create(60, 80, lesson2.getId(), userId));
+
+            // when
+            List<TopChapterResponse> result = lessonSubmissionQueryService.getTopChapters(userId);
+
+            // then
+            assertSoftly(softly -> {
+                softly.assertThat(result).hasSize(1);
+                softly.assertThat(result.get(0).chapterTitle()).isEqualTo("자료구조");
+                softly.assertThat(result.get(0).solvedLessonCount()).isEqualTo(2);
+                softly.assertThat(result.get(0).ratio()).isEqualTo(100);
+            });
+        }
+
+        @Test
         void 풀이_기록이_없으면_빈_리스트를_반환한다() {
             // given
             long userId = 1L;
@@ -421,6 +535,33 @@ class LessonSubmissionQueryServiceIntegrationTest {
                 softly.assertThat(result.get(1).rank()).isEqualTo(2);
                 softly.assertThat(result.get(1).wrongAnswerCount()).isEqualTo(1);
                 softly.assertThat(result.get(1).wrongAnswerRate()).isEqualTo(10);
+            });
+        }
+
+        @Test
+        void 같은_레슨을_재제출해도_레슨이_중복되지_않는다() {
+            // given
+            long userId = 1L;
+            Chapter chapter = chapterRepository.save(Chapter.create("자료구조", "자료구조 기초"));
+            Unit unit = unitRepository.save(Unit.create("연결리스트", "linked list", chapter.getId()));
+            Lesson lesson = lessonRepository.save(Lesson.create("레슨1", unit.getId()));
+            Problem problem = problemRepository.save(Problem.create(ProblemType.SUBJECTIVE, "지문1", "내용1", lesson.getId()));
+
+            lessonSubmissionRepository.save(LessonSubmission.create(60, 20, lesson.getId(), userId));
+            lessonSubmissionRepository.save(LessonSubmission.create(60, 50, lesson.getId(), userId));
+            lessonSubmissionRepository.save(LessonSubmission.create(60, 90, lesson.getId(), userId));
+
+            problemSubmissionRepository.save(ProblemSubmission.create(false, problem.getId(), userId, null, "오답1"));
+
+            // when
+            List<WeakConceptResponse> result = lessonSubmissionQueryService.getWeakConcepts(userId);
+
+            // then
+            assertSoftly(softly -> {
+                softly.assertThat(result).hasSize(1);
+                softly.assertThat(result.get(0).rank()).isEqualTo(1);
+                softly.assertThat(result.get(0).wrongAnswerCount()).isEqualTo(1);
+                softly.assertThat(result.get(0).wrongAnswerRate()).isEqualTo(100);
             });
         }
 


### PR DESCRIPTION
## PR Summary

레슨 제출을 유저와 레슨당 1행 덮어쓰기에서, 제출마다 새 행을 쌓는 이력 누적 구조로 전환했습니다. 총 학습 시간과 평균 정확도, 주간 리포트가 실제 시도 이력을 반영하도록 1행을 전제로 깔고 있던 집계 쿼리를 함께 재설계했습니다.

<br>

## Problem

**문제 1 - 재시도가 이전 시도를 덮어써 학습 지표가 왜곡됨**

`LessonSubmission`은 유저와 레슨당 1행이라, 재시도하면 학습 시간과 정확도가 누적이 아니라 대입으로 갱신됐습니다. 총 학습 시간은 마지막 시도분만 더해져 반복 학습한 사용자일수록 오히려 적게 잡혔습니다. 평균 정확도도 마지막 시도들의 평균이라, 40점에서 100점으로 성장한 사용자와 처음부터 100점이던 사용자가 구분되지 않았습니다.

**문제 2 - 주간 리포트의 기준 시각이 흔들림**

주간 집계가 전부 `updatedAt` 기준이었습니다. 3주 전에 푼 레슨을 오늘 재시도하면 그 기록이 3주 전에서 사라지고 이번 주로 옮겨옵니다. 이미 지나간 주의 리포트를 다시 조회하면 값이 달라지는 상태였습니다.

**문제 3 - 시도 횟수를 두 곳에서 다르게 셈**

시도 횟수가 엔티티의 `tryCount` 필드와 행 개수를 세는 쿼리, 두 가지로 존재했습니다. 실제로 읽히는 쪽은 행 개수인데 행이 1개뿐이라 이 값은 0 또는 1에 머물렀고, 이를 전제로 둔 미션 적립 가드는 한 번도 발동한 적이 없었습니다.

**문제 4 - 이력 전환 시 행 수 기반 집계가 부풀어 오름**

완료 레슨 수와 학습률 랭킹, 주간 풀이 수는 제출 행 수를 그대로 세고 있었습니다. 이력 구조로 바꾸면 같은 레슨을 세 번 푼 사용자의 완료 레슨이 3개로 잡히므로, 이 조회들을 그대로 두면 지표가 지금보다 더 틀어집니다.

**문제 5 - 총 학습 시간 응답의 소수점 자리수가 정해지지 않음**

총 학습 시간은 초를 시간으로 나눈 값을 그대로 반환해, 1.2777...처럼 자리수가 제한되지 않은 실수가 클라이언트로 나갔습니다.

<br>

## Solution

**해결 1 - 제출마다 새 행을 적재하는 이력 구조로 전환**

저장 로직에서 첫 풀이와 재풀이 분기를 없애고 항상 INSERT하도록 바꿨습니다. `learningTime`과 `accuracy`가 시도 1건의 값이 되면서 대입인지 누적인지 판단할 필요가 사라지고, 총합과 평균은 이력을 집계하면 맞는 값이 나옵니다. 갱신 대상 행을 잡으려고 걸어두던 `@Lock(PESSIMISTIC_WRITE)`도 함께 걷어냈습니다.

**해결 2 - 집계 기준 시각을 createdAt으로 이동**

주간 리포트와 최다 학습 시간대 쿼리의 기준을 `createdAt`으로 옮겼습니다. 행이 더 이상 갱신되지 않으므로 한 번 적재된 기록의 소속 주차가 고정되고, 지난 리포트를 다시 뽑아도 같은 값이 나옵니다. `createdAt`이 비어 있던 과거 행은 마이그레이션에서 `updatedAt` 값으로 백필했습니다.

**해결 3 - tryCount 필드를 제거하고 행 개수로 일원화**

죽어 있던 `tryCount` 필드를 지우고 시도 횟수를 행 개수 하나로 통일했습니다. 이제 이 값은 실제 시도 횟수를 정확히 반환합니다. 다만 이벤트 발행 조건이 첫 풀이로 제한돼 있어 미션 가드 자체는 여전히 발동하지 않는데, 이벤트 게이트가 바뀌어도 미션이 중복 적립되지 않도록 이중 방어로 남겨뒀습니다.

**해결 4 - 1행 전제 조회를 DISTINCT 기준으로 재설계**

완료 레슨 수와 학습률 랭킹, 주간 풀이 수를 `COUNT(DISTINCT lesson_id)` 기준으로 바꿔 재시도가 수치를 부풀리지 않게 했습니다. 취약 개념 조회는 제출 테이블을 기준으로 조인하고 있어 재시도 횟수만큼 같은 레슨이 중복 반환되는 문제가 있었습니다. 레슨을 기준 테이블로 두고 제출 이력은 EXISTS 조건으로만 쓰도록 다시 썼습니다.

**해결 5 - 총 학습 시간을 소수점 첫째 자리로 반올림**

총 학습 시간을 소수점 첫째 자리까지 반올림해 반환하도록 했습니다. 화면에 그 이상의 정밀도가 필요하지 않고, 클라이언트마다 다르게 자르는 것보다 서버가 한 자리로 맞춰 내려주는 편이 응답이 일정합니다.

<br>

## Related Issue
- close #450


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **새로운 기능**
  - 레슨을 재제출할 때마다 제출 기록이 새로 저장됩니다.
  - 제출별 학습 시간과 정확도 이력을 확인할 수 있습니다.
  - 총 학습 시간은 제출 기록을 합산하고, 완료 레슨 수는 중복 없이 집계됩니다.

- **버그 수정**
  - 반복 제출로 완료 레슨, TOP 챕터, 취약 개념 통계가 부풀려지던 문제를 개선했습니다.
  - 학습률 및 통계 계산의 시간 기준과 반올림 처리를 일관되게 조정했습니다.

- **데이터 마이그레이션**
  - 기존 제출 기록의 시간 정보를 보완하고, 불필요한 시도 횟수 정보 처리를 정리했습니다.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->