### PR TITLE
refactor: 오답노트 물리 삭제를 상태 전환으로 변경(#453)

### DIFF
--- a/.claude/resources/plans/PLAN-453.md
+++ b/.claude/resources/plans/PLAN-453.md
@@ -1,0 +1,220 @@
+# [PLAN-453] 오답노트 물리 삭제를 상태 전환으로 변경
+
+> 이슈: #453
+> 브랜치: refactor/453-wrong-answered-note-resolve
+
+## 목표
+
+`WrongAnsweredNote`를 "현재 틀린 상태인가"만 담는 존재 여부 테이블에서, 오답 이력을 남기는 상태 테이블로 바꾼다.
+`BaseEntity` 상속으로 시각 정보를 남기고 `wrongCount`, `resolvedAt`을 추가해, 삭제 API가 행을 지우는 대신 `resolvedAt`을 기록하도록 전환한다.
+조회는 `resolvedAt IS NULL` 필터를 더해 현재 화면 동작을 그대로 유지한다.
+
+## 영향 범위
+
+### 신규 파일
+- `src/main/resources/db/migration/V30__convert_wrong_answered_note_to_resolvable.sql` — created_at, updated_at, wrong_count, resolved_at 추가
+
+### 수정 파일
+- `src/main/java/gravit/code/wrongAnsweredNote/domain/WrongAnsweredNote.java` — `BaseEntity` 상속, `wrongCount`, `resolvedAt` 필드와 상태 전환 메서드 추가
+- `src/main/java/gravit/code/wrongAnsweredNote/repository/WrongAnsweredNoteRepository.java` — `deleteByProblemIdAndUserId` 제거, 조회 2건에 미극복 필터 추가
+- `src/main/java/gravit/code/wrongAnsweredNote/service/WrongAnsweredNoteService.java` — `saveWrongAnsweredNote`에 재오답 처리 추가, `deleteWrongAnsweredProblem` → `resolveWrongAnsweredNote`
+- `src/main/java/gravit/code/wrongAnsweredNote/controller/WrongAnsweredNoteController.java` — 변경된 Service 메서드명으로 호출 교체
+- `src/test/java/gravit/code/wrongAnsweredNote/fixture/WrongAnsweredNoteFixture.java` — 극복된 노트, 누적 오답 노트 픽스처 추가
+- `src/test/java/gravit/code/wrongAnsweredNote/service/WrongAnsweredNoteServiceUnitTest.java` — 삭제 검증을 상태 전환 검증으로 교체
+- `src/test/java/gravit/code/wrongAnsweredNote/service/WrongAnsweredNoteServiceIntegrationTest.java` — 행 존속, 재오답 복귀, 극복분 조회 제외 시나리오 추가
+
+### 확인만 하고 변경하지 않는 파일
+- `src/main/java/gravit/code/wrongAnsweredNote/controller/WrongAnsweredNoteControllerDocs.java` — HTTP 계약(DELETE, 204)이 그대로라 시그니처 변경 없음. `@Operation` 설명 문구만 "오답노트에서 내림"으로 다듬는다
+- `src/main/java/gravit/code/problem/service/ProblemSubmissionCommandService.java` — `saveWrongAnsweredNote` 호출부 시그니처가 유지되므로 변경 없음
+- `src/main/java/gravit/code/lesson/facade/LessonFacade.java` — `checkWrongAnsweredProblemExists` 시그니처가 유지되므로 변경 없음
+- `src/test/java/gravit/code/problem/service/ProblemSubmissionCommandServiceIntegrationTest.java` — 오답 생성/미생성만 검증하므로 통과 예상. 실행으로 확인한다
+
+## 구현 계획
+
+### 1. Entity / Flyway
+
+**`WrongAnsweredNote`** — `BaseEntity` 상속으로 전환
+
+```java
+@Entity
+@Getter
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+public class WrongAnsweredNote extends BaseEntity {
+
+    private static final int INITIAL_WRONG_COUNT = 1;
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Long id;
+
+    @Column(name = "problem_id", nullable = false)
+    private long problemId;
+
+    @Column(name = "user_id", nullable = false)
+    private long userId;
+
+    @Column(name = "wrong_count", nullable = false)
+    private int wrongCount;
+
+    @Column(name = "resolved_at")
+    private LocalDateTime resolvedAt;
+    ...
+}
+```
+
+- `create(long problemId, long userId)` — `wrongCount = INITIAL_WRONG_COUNT`, `resolvedAt`은 채우지 않는다(미극복)
+- `markWrong()` 추가 — `wrongCount++`, `resolvedAt = null`. 극복 처리된 문제를 다시 틀리면 오답노트로 복귀시킨다
+- `resolve()` 추가 — 이미 `resolvedAt`이 있으면 그대로 두고 반환한다. 없으면 `LocalDateTime.now(TimeZoneConst.KST)`를 채운다. 중복 호출로 극복 시점이 뒤로 밀리지 않게 하기 위함이다
+- `isResolved()` 추가 — `resolvedAt != null`. 테스트와 `resolve()` 내부 가드에서 쓴다
+
+> `createdAt`, `updatedAt`은 `BaseEntity`의 `@PrePersist`, `@PreUpdate`가 채운다. 별도 필드를 만들지 않는다.
+
+**`V30__convert_wrong_answered_note_to_resolvable.sql`**
+
+```sql
+-- V30__convert_wrong_answered_note_to_resolvable.sql
+-- 오답노트를 물리 삭제 대상에서 극복 여부를 남기는 상태 테이블로 전환
+
+-- BaseEntity 공통 컬럼. 기존 행은 최초 오답 시점을 알 수 없어 NULL을 허용한다
+ALTER TABLE wrong_answered_note
+    ADD COLUMN created_at TIMESTAMP(6),
+    ADD COLUMN updated_at TIMESTAMP(6);
+
+-- 같은 문제를 몇 번 틀렸는지 누적한다. 기존 행은 최소 1회 오답이므로 1로 채운다
+ALTER TABLE wrong_answered_note
+    ADD COLUMN wrong_count INTEGER NOT NULL DEFAULT 1;
+
+-- NULL이면 오답노트에 노출되고, 값이 있으면 극복 처리되어 노출되지 않는다
+-- 기존 행은 전부 미극복 상태이므로 NULL로 둔다
+ALTER TABLE wrong_answered_note
+    ADD COLUMN resolved_at TIMESTAMP(6);
+```
+
+> `wrong_count`의 `DEFAULT 1`은 백필용이자 롤링 배포 안전장치다. 구버전 인스턴스가 이 컬럼을 모른 채 INSERT해도 실패하지 않는다.
+
+### 2. Repository — `WrongAnsweredNoteRepository`
+
+| 메서드 | 변경 |
+|---|---|
+| `findByProblemIdAndUserId` | 변경 없음. 극복 여부와 무관하게 행을 찾아야 재오답 복귀와 극복 처리 양쪽에 쓸 수 있다 |
+| `findWrongAnsweredProblemDetailByUnitIdAndUserId` | `WHERE` 절에 `AND wan.resolvedAt IS NULL` 추가 |
+| `countByUnitIdAndUserId` | `WHERE` 절에 `AND wan.resolvedAt IS NULL` 추가 |
+| `deleteByProblemIdAndUserId` | **삭제**. 물리 삭제 경로를 남겨두면 상태 전환을 우회할 수 있다 |
+
+조회 쿼리 변경 후 `WHERE` 절:
+
+```
+WHERE wan.userId = :userId AND u.id = :unitId AND wan.resolvedAt IS NULL
+```
+
+```
+WHERE u.id = :unitId AND wan.userId = :userId AND wan.resolvedAt IS NULL
+```
+
+### 3. Service — `WrongAnsweredNoteService`
+
+`saveWrongAnsweredNote(long userId, long problemId)` — 기존 행이 있으면 재오답 처리한다
+
+```java
+@Transactional
+public void saveWrongAnsweredNote(
+        long userId,
+        long problemId
+) {
+    WrongAnsweredNote wrongAnsweredNote = wrongAnsweredNoteRepository.findByProblemIdAndUserId(problemId, userId)
+            .map(WrongAnsweredNote::markWrong)
+            .orElseGet(() -> WrongAnsweredNote.create(problemId, userId));
+
+    wrongAnsweredNoteRepository.save(wrongAnsweredNote);
+}
+```
+
+- `markWrong()`이 `this`를 반환하게 해 `map`으로 이어 쓴다
+- 기존에는 찾은 행을 그대로 다시 저장하는 무의미한 호출이었다. 이제 오답 횟수가 누적된다
+
+`deleteWrongAnsweredProblem` → `resolveWrongAnsweredNote(long userId, long problemId)`로 이름과 동작을 함께 바꾼다
+
+```java
+@Transactional
+public void resolveWrongAnsweredNote(
+        long userId,
+        long problemId
+) {
+    wrongAnsweredNoteRepository.findByProblemIdAndUserId(problemId, userId)
+            .ifPresent(WrongAnsweredNote::resolve);
+}
+```
+
+- 대상 행이 없으면 아무것도 하지 않는다. 현재 `deleteByProblemIdAndUserId`도 없는 행에 대해 조용히 통과했고, DELETE 요청은 멱등해야 하므로 404를 새로 던지지 않는다
+- 영속 상태 엔티티의 dirty checking으로 반영되므로 `save` 호출을 두지 않는다
+- `getAllWrongAnsweredProblemInUnit`, `checkWrongAnsweredProblemExists`는 시그니처와 본문 모두 변경 없다. Repository 쿼리 필터만으로 미극복 건만 세어진다
+
+### 4. Facade
+
+불필요 — `WrongAnsweredNoteFacade`는 조회 조합만 담당하며 이번 변경에 닿지 않는다.
+
+### 5. DTO
+
+변경 없음 — `WrongAnsweredNoteDeleteRequest`(problemId), `ProblemDetailResponse`, `WrongAnsweredProblemsResponse` 모두 그대로 쓴다.
+`wrongCount`는 이번 이슈에서 집계 데이터를 쌓기만 하고 응답에 노출하지 않는다.
+
+### 6. Controller
+
+`DELETE /api/v1/wrong-answered-notes` — 경로, 메서드명, 요청 본문, 204 응답 모두 유지한다.
+본문 한 줄만 교체한다.
+
+```java
+wrongAnsweredNoteService.resolveWrongAnsweredNote(loginUser.getId(), request.problemId());
+```
+
+`WrongAnsweredNoteControllerDocs`의 `@Operation` 설명을 "특정 문제를 오답노트에서 내립니다. 기록은 남으며 다시 틀리면 오답노트로 복귀합니다."로 다듬는다.
+
+## 범위 밖 (후속 과제)
+
+- **정답 재제출 시 자동 극복** — 이슈에 명시한 대로 제외한다. 현재 정답 처리 경로에 오답노트를 건드리는 코드가 없다
+- **`wrong_answered_note` 인덱스** — 이 테이블에는 지금 인덱스가 하나도 없다. `(user_id, resolved_at)` 부분 인덱스가 조회에 유리하지만, 스키마 의미 전환과 인덱스 튜닝을 한 PR에 섞지 않는다
+- **`(problem_id, user_id)` 유니크 제약** — 현재도 제약이 없어 중복 행이 생기면 `findByProblemIdAndUserId`가 터진다. 기존 문제이며 이번 변경이 악화시키지 않는다
+- **`wrongCount` 기반 취약 개념 집계 API** — 데이터를 쌓는 것까지가 이번 범위다
+
+## 결정 필요 (Decisions needed)
+
+없음 — 필드 구성(`lastWrongAt` 제외)과 자동 극복 제외는 이슈 발의 단계에서 확정했다.
+
+## 검증
+
+**단위 테스트** — `WrongAnsweredNoteServiceUnitTest`
+
+- `SaveWrongAnsweredNote`
+  - 기존 노트가 없으면 새로 생성한다 (유지)
+  - 기존 노트가 있으면 wrongCount가 증가한 채 저장된다 (기존 "중복 생성하지 않는다"를 대체)
+  - 극복된 노트를 다시 틀리면 resolvedAt이 해제된 채 저장된다 (신규)
+- `ResolveWrongAnsweredNote` (기존 `DeleteWrongAnsweredProblem` 대체)
+  - 노트가 있으면 resolvedAt이 채워진다
+  - 노트가 없으면 예외 없이 통과한다
+  - `deleteByProblemIdAndUserId`를 더 이상 호출하지 않는다
+
+**통합 테스트** — `WrongAnsweredNoteServiceIntegrationTest`
+
+- 삭제 API 경로 실행 후 행이 남아 있고 `resolvedAt`이 채워진다 (기존 `isEmpty()` 단언을 뒤집는다)
+- 극복된 노트는 `getAllWrongAnsweredProblemInUnit` 결과에서 빠진다
+- 극복된 노트만 있으면 `checkWrongAnsweredProblemExists`가 false다
+- 같은 문제를 두 번 틀리면 행은 1개이고 `wrongCount`가 2다
+- 극복 후 다시 틀리면 조회 목록에 복귀한다
+
+**픽스처** — `WrongAnsweredNoteFixture`
+
+- `극복된_오답노트(long problemId, long userId)` 추가 — `ReflectionTestUtils`로 `resolvedAt` 주입
+- `누적_오답노트(long problemId, long userId, int wrongCount)` 추가
+
+**회귀 확인**
+
+- `ProblemSubmissionCommandServiceIntegrationTest` — 오답 시 노트 생성, 정답 시 미생성 단언이 그대로 통과하는지 실행으로 확인
+- `WrongAnsweredNoteFacadeIntegrationTest`, `LessonFacadeUnitTest` — 시그니처 변경이 없어 통과 예상
+- `./gradlew build` — Flyway validate 포함
+
+## Deviation Log
+
+- `WrongAnsweredNoteServiceUnitTest`: 계획의 "`deleteByProblemIdAndUserId`를 더 이상 호출하지 않는다" 테스트를 넣지 않았다 — 이유: Repository에서 메서드를 제거해 컴파일러가 이미 보장하며, 존재하지 않는 메서드는 `verify`로 검증할 수 없다. 대신 "이미 극복된 노트는 극복 시각이 밀리지 않는다"로 `resolve()` 가드를 검증한다
+- `WrongAnsweredNoteServiceIntegrationTest`: 계획에 없던 "극복된 문제는 오답 문제 목록에서 빠진다"를 `ResolveWrongAnsweredNote`에 넣었다 — 이유: 극복 처리와 조회 필터가 한 시나리오로 이어져야 "화면 동작 유지"가 실제로 증명된다
+- 마이그레이션 번호를 V29에서 V30으로 변경 — 이유: `origin/dev`에 V28이 두 개(`V28__add_friend_search_indexes.sql` #451, `V28__convert_lesson_submission_to_history.sql` #450) 있어 `flywayValidate`가 이미 깨져 있었다. 충돌 해소로 #450 파일이 V29를 차지한다
+- `V28__convert_lesson_submission_to_history.sql` → `V29__convert_lesson_submission_to_history.sql` 재번호 (계획 범위 밖) — 이유: dev의 기존 파손을 풀지 않으면 이 브랜치에서 빌드 검증 자체가 불가능하다. #451이 먼저 머지되어 이미 적용됐을 수 있는 반면 #450 파일은 머지 직후부터 빌드가 깨져 어디에도 적용된 적이 없어, 옮겨도 `flyway_schema_history`와 어긋나지 않는다

--- a/src/main/java/gravit/code/wrongAnsweredNote/controller/WrongAnsweredNoteController.java
+++ b/src/main/java/gravit/code/wrongAnsweredNote/controller/WrongAnsweredNoteController.java
@@ -38,7 +38,7 @@ public class WrongAnsweredNoteController implements WrongAnsweredNoteControllerD
             @AuthenticationPrincipal LoginUser loginUser,
             @Valid @RequestBody WrongAnsweredNoteDeleteRequest request
     ){
-        wrongAnsweredNoteService.deleteWrongAnsweredProblem(loginUser.getId(), request.problemId());
+        wrongAnsweredNoteService.resolveWrongAnsweredNote(loginUser.getId(), request.problemId());
         return ResponseEntity.status(HttpStatus.NO_CONTENT).build();
     }
 }

--- a/src/main/java/gravit/code/wrongAnsweredNote/controller/WrongAnsweredNoteControllerDocs.java
+++ b/src/main/java/gravit/code/wrongAnsweredNote/controller/WrongAnsweredNoteControllerDocs.java
@@ -64,7 +64,8 @@ public interface WrongAnsweredNoteControllerDocs {
             @PathVariable("unitId") Long unitId
     );
 
-    @Operation(summary = "오답노트 삭제", description = "특정 문제의 오답노트를 삭제합니다.<br>" +
+    @Operation(summary = "오답노트 삭제", description = "특정 문제를 오답노트에서 내립니다.<br>" +
+            "기록은 남으며, 해당 문제를 다시 틀리면 오답노트로 복귀합니다.<br>" +
             "🔐 <strong>Jwt 필요</strong><br>")
     @ApiResponses({
             @ApiResponse(responseCode = "204", description = "✅ 오답노트 삭제 성공")

--- a/src/main/java/gravit/code/wrongAnsweredNote/domain/WrongAnsweredNote.java
+++ b/src/main/java/gravit/code/wrongAnsweredNote/domain/WrongAnsweredNote.java
@@ -1,5 +1,7 @@
 package gravit.code.wrongAnsweredNote.domain;
 
+import gravit.code.global.consts.TimeZoneConst;
+import gravit.code.global.entity.BaseEntity;
 import jakarta.persistence.Column;
 import jakarta.persistence.Entity;
 import jakarta.persistence.GeneratedValue;
@@ -10,10 +12,15 @@ import lombok.Builder;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
 
+import java.time.LocalDateTime;
+
 @Entity
 @Getter
 @NoArgsConstructor(access = AccessLevel.PROTECTED)
-public class WrongAnsweredNote {
+public class WrongAnsweredNote extends BaseEntity {
+
+    private static final int INITIAL_WRONG_COUNT = 1;
+
     @Id
     @GeneratedValue(strategy = GenerationType.IDENTITY)
     private Long id;
@@ -24,6 +31,12 @@ public class WrongAnsweredNote {
     @Column(name = "user_id", nullable = false)
     private long userId;
 
+    @Column(name = "wrong_count", nullable = false)
+    private int wrongCount;
+
+    @Column(name = "resolved_at")
+    private LocalDateTime resolvedAt;
+
     @Builder(access = AccessLevel.PRIVATE)
     private WrongAnsweredNote(
             long problemId,
@@ -31,6 +44,7 @@ public class WrongAnsweredNote {
     ) {
         this.problemId = problemId;
         this.userId = userId;
+        this.wrongCount = INITIAL_WRONG_COUNT;
     }
 
     public static WrongAnsweredNote create(
@@ -41,5 +55,23 @@ public class WrongAnsweredNote {
                 .problemId(problemId)
                 .userId(userId)
                 .build();
+    }
+
+    public WrongAnsweredNote markWrong() {
+        this.wrongCount++;
+        this.resolvedAt = null;
+
+        return this;
+    }
+
+    public void resolve() {
+        if (isResolved())
+            return;
+
+        this.resolvedAt = LocalDateTime.now(TimeZoneConst.KST);
+    }
+
+    public boolean isResolved() {
+        return resolvedAt != null;
     }
 }

--- a/src/main/java/gravit/code/wrongAnsweredNote/repository/WrongAnsweredNoteRepository.java
+++ b/src/main/java/gravit/code/wrongAnsweredNote/repository/WrongAnsweredNoteRepository.java
@@ -29,16 +29,11 @@ public interface WrongAnsweredNoteRepository extends JpaRepository<WrongAnswered
         JOIN Lesson l ON l.id = p.lessonId
         JOIN Unit u ON u.id = l.unitId
         LEFT JOIN Bookmark b on b.problemId = p.id AND b.userId = :userId
-        WHERE wan.userId = :userId AND u.id = :unitId
+        WHERE wan.userId = :userId AND u.id = :unitId AND wan.resolvedAt IS NULL
     """)
     List<ProblemDetailResponse> findWrongAnsweredProblemDetailByUnitIdAndUserId(
             @Param("unitId")long unitId,
             @Param("userId")long userId
-    );
-
-    void deleteByProblemIdAndUserId(
-            long problemId,
-            long userId
     );
 
     @Query("""
@@ -47,7 +42,7 @@ public interface WrongAnsweredNoteRepository extends JpaRepository<WrongAnswered
         JOIN Problem p ON p.id = wan.problemId
         JOIN Lesson l ON l.id = p.lessonId
         JOIN Unit u ON u.id = l.unitId
-        WHERE u.id = :unitId AND wan.userId = :userId
+        WHERE u.id = :unitId AND wan.userId = :userId AND wan.resolvedAt IS NULL
     """)
     int countByUnitIdAndUserId(
             @Param("unitId")long unitId,

--- a/src/main/java/gravit/code/wrongAnsweredNote/service/WrongAnsweredNoteService.java
+++ b/src/main/java/gravit/code/wrongAnsweredNote/service/WrongAnsweredNoteService.java
@@ -21,6 +21,7 @@ public class WrongAnsweredNoteService {
             long problemId
     ) {
         WrongAnsweredNote wrongAnsweredNote = wrongAnsweredNoteRepository.findByProblemIdAndUserId(problemId, userId)
+                .map(WrongAnsweredNote::markWrong)
                 .orElseGet(() -> WrongAnsweredNote.create(problemId, userId));
 
         wrongAnsweredNoteRepository.save(wrongAnsweredNote);
@@ -35,11 +36,12 @@ public class WrongAnsweredNoteService {
     }
 
     @Transactional
-    public void deleteWrongAnsweredProblem(
+    public void resolveWrongAnsweredNote(
             long userId,
             long problemId
     ) {
-        wrongAnsweredNoteRepository.deleteByProblemIdAndUserId(problemId, userId);
+        wrongAnsweredNoteRepository.findByProblemIdAndUserId(problemId, userId)
+                .ifPresent(WrongAnsweredNote::resolve);
     }
 
     @Transactional(readOnly = true)

--- a/src/main/resources/db/migration/V29__convert_lesson_submission_to_history.sql
+++ b/src/main/resources/db/migration/V29__convert_lesson_submission_to_history.sql
@@ -1,4 +1,4 @@
--- V28__convert_lesson_submission_to_history.sql
+-- V29__convert_lesson_submission_to_history.sql
 -- 레슨 제출을 유저+레슨당 1행 덮어쓰기에서 제출마다 새 행을 쌓는 이력 구조로 전환
 
 -- 시도 횟수는 엔티티 필드 대신 행 개수로 센다

--- a/src/main/resources/db/migration/V30__convert_wrong_answered_note_to_resolvable.sql
+++ b/src/main/resources/db/migration/V30__convert_wrong_answered_note_to_resolvable.sql
@@ -1,0 +1,16 @@
+-- V30__convert_wrong_answered_note_to_resolvable.sql
+-- 오답노트를 물리 삭제 대상에서 극복 여부를 남기는 상태 테이블로 전환
+
+-- BaseEntity 공통 컬럼. 기존 행은 최초 오답 시점을 알 수 없어 NULL을 허용한다
+ALTER TABLE wrong_answered_note
+    ADD COLUMN created_at TIMESTAMP(6),
+    ADD COLUMN updated_at TIMESTAMP(6);
+
+-- 같은 문제를 몇 번 틀렸는지 누적한다. 기존 행은 최소 1회 오답이므로 1로 채운다
+ALTER TABLE wrong_answered_note
+    ADD COLUMN wrong_count INTEGER NOT NULL DEFAULT 1;
+
+-- NULL이면 오답노트에 노출되고, 값이 있으면 극복 처리되어 노출되지 않는다
+-- 기존 행은 전부 미극복 상태이므로 NULL로 둔다
+ALTER TABLE wrong_answered_note
+    ADD COLUMN resolved_at TIMESTAMP(6);

--- a/src/test/java/gravit/code/wrongAnsweredNote/fixture/WrongAnsweredNoteFixture.java
+++ b/src/test/java/gravit/code/wrongAnsweredNote/fixture/WrongAnsweredNoteFixture.java
@@ -1,7 +1,10 @@
 package gravit.code.wrongAnsweredNote.fixture;
 
+import gravit.code.global.consts.TimeZoneConst;
 import gravit.code.wrongAnsweredNote.domain.WrongAnsweredNote;
 import org.springframework.test.util.ReflectionTestUtils;
+
+import java.time.LocalDateTime;
 
 public class WrongAnsweredNoteFixture {
 
@@ -21,6 +24,25 @@ public class WrongAnsweredNoteFixture {
     ) {
         WrongAnsweredNote note = WrongAnsweredNote.create(problemId, userId);
         ReflectionTestUtils.setField(note, "id", id);
+        return note;
+    }
+
+    public static WrongAnsweredNote 극복된_오답노트(
+            long problemId,
+            long userId
+    ) {
+        WrongAnsweredNote note = 기본_오답노트(problemId, userId);
+        ReflectionTestUtils.setField(note, "resolvedAt", LocalDateTime.now(TimeZoneConst.KST));
+        return note;
+    }
+
+    public static WrongAnsweredNote 누적_오답노트(
+            long problemId,
+            long userId,
+            int wrongCount
+    ) {
+        WrongAnsweredNote note = 기본_오답노트(problemId, userId);
+        ReflectionTestUtils.setField(note, "wrongCount", wrongCount);
         return note;
     }
 }

--- a/src/test/java/gravit/code/wrongAnsweredNote/service/WrongAnsweredNoteServiceIntegrationTest.java
+++ b/src/test/java/gravit/code/wrongAnsweredNote/service/WrongAnsweredNoteServiceIntegrationTest.java
@@ -78,7 +78,7 @@ class WrongAnsweredNoteServiceIntegrationTest {
         }
 
         @Test
-        void 이미_오답_노트가_있으면_중복_생성하지_않는다() {
+        void 이미_오답_노트가_있으면_중복_생성하지_않고_오답_횟수를_누적한다() {
             // given
             long userId = 1L;
             wrongAnsweredNoteRepository.save(WrongAnsweredNote.create(problem.getId(), userId));
@@ -87,10 +87,33 @@ class WrongAnsweredNoteServiceIntegrationTest {
             wrongAnsweredNoteService.saveWrongAnsweredNote(userId, problem.getId());
 
             // then
-            long count = wrongAnsweredNoteRepository.findAll().stream()
+            List<WrongAnsweredNote> notes = wrongAnsweredNoteRepository.findAll().stream()
                     .filter(w -> w.getProblemId() == problem.getId() && w.getUserId() == userId)
-                    .count();
-            assertThat(count).isEqualTo(1);
+                    .toList();
+
+            assertSoftly(softly -> {
+                softly.assertThat(notes).hasSize(1);
+                softly.assertThat(notes.get(0).getWrongCount()).isEqualTo(2);
+            });
+        }
+
+        @Test
+        void 극복된_문제를_다시_틀리면_오답노트에_복귀한다() {
+            // given
+            long userId = 1L;
+            wrongAnsweredNoteRepository.save(WrongAnsweredNote.create(problem.getId(), userId));
+            wrongAnsweredNoteService.resolveWrongAnsweredNote(userId, problem.getId());
+
+            // when
+            wrongAnsweredNoteService.saveWrongAnsweredNote(userId, problem.getId());
+
+            // then
+            List<ProblemDetailResponse> result = wrongAnsweredNoteService.getAllWrongAnsweredProblemInUnit(userId, unit.getId());
+
+            assertSoftly(softly -> {
+                softly.assertThat(result).hasSize(1);
+                softly.assertThat(result.get(0).id()).isEqualTo(problem.getId());
+            });
         }
     }
 
@@ -143,20 +166,39 @@ class WrongAnsweredNoteServiceIntegrationTest {
     }
 
     @Nested
-    @DisplayName("오답 문제를 삭제할 때")
-    class DeleteWrongAnsweredProblem {
+    @DisplayName("오답 문제를 오답노트에서 내릴 때")
+    class ResolveWrongAnsweredNote {
 
         @Test
-        void 오답_노트에서_삭제에_성공한다() {
+        void 행은_남고_극복_시각만_기록된다() {
             // given
             long userId = 1L;
             wrongAnsweredNoteRepository.save(WrongAnsweredNote.create(problem.getId(), userId));
 
             // when
-            wrongAnsweredNoteService.deleteWrongAnsweredProblem(userId, problem.getId());
+            wrongAnsweredNoteService.resolveWrongAnsweredNote(userId, problem.getId());
 
             // then
-            assertThat(wrongAnsweredNoteRepository.findByProblemIdAndUserId(problem.getId(), userId)).isEmpty();
+            assertThat(wrongAnsweredNoteRepository.findByProblemIdAndUserId(problem.getId(), userId))
+                    .isPresent()
+                    .get()
+                    .satisfies(note -> assertSoftly(softly -> {
+                        softly.assertThat(note.isResolved()).isTrue();
+                        softly.assertThat(note.getWrongCount()).isEqualTo(1);
+                    }));
+        }
+
+        @Test
+        void 극복된_문제는_오답_문제_목록에서_빠진다() {
+            // given
+            long userId = 1L;
+            wrongAnsweredNoteRepository.save(WrongAnsweredNote.create(problem.getId(), userId));
+
+            // when
+            wrongAnsweredNoteService.resolveWrongAnsweredNote(userId, problem.getId());
+
+            // then
+            assertThat(wrongAnsweredNoteService.getAllWrongAnsweredProblemInUnit(userId, unit.getId())).isEmpty();
         }
     }
 
@@ -181,6 +223,20 @@ class WrongAnsweredNoteServiceIntegrationTest {
         void 오답이_없으면_false를_반환한다() {
             // given
             long userId = 1L;
+
+            // when
+            boolean result = wrongAnsweredNoteService.checkWrongAnsweredProblemExists(userId, unit.getId());
+
+            // then
+            assertThat(result).isFalse();
+        }
+
+        @Test
+        void 극복된_오답만_있으면_false를_반환한다() {
+            // given
+            long userId = 1L;
+            wrongAnsweredNoteRepository.save(WrongAnsweredNote.create(problem.getId(), userId));
+            wrongAnsweredNoteService.resolveWrongAnsweredNote(userId, problem.getId());
 
             // when
             boolean result = wrongAnsweredNoteService.checkWrongAnsweredProblemExists(userId, unit.getId());

--- a/src/test/java/gravit/code/wrongAnsweredNote/service/WrongAnsweredNoteServiceUnitTest.java
+++ b/src/test/java/gravit/code/wrongAnsweredNote/service/WrongAnsweredNoteServiceUnitTest.java
@@ -13,10 +13,12 @@ import org.mockito.InjectMocks;
 import org.mockito.Mock;
 import org.mockito.junit.jupiter.MockitoExtension;
 
+import java.time.LocalDateTime;
 import java.util.List;
 import java.util.Optional;
 
 import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatCode;
 import static org.assertj.core.api.SoftAssertions.assertSoftly;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.Mockito.*;
@@ -51,7 +53,7 @@ class WrongAnsweredNoteServiceUnitTest {
         }
 
         @Test
-        void 기존_오답_노트가_있으면_새로_생성하지_않고_기존_것을_저장한다() {
+        void 기존_오답_노트가_있으면_새로_생성하지_않고_오답_횟수를_누적한다() {
             // given
             long userId = 1L;
             long problemId = 1L;
@@ -63,9 +65,30 @@ class WrongAnsweredNoteServiceUnitTest {
             // when
             wrongAnsweredNoteService.saveWrongAnsweredNote(userId, problemId);
 
-            // then — 새 WrongAnsweredNote를 생성하지 않고 기존 객체 그대로 저장
+            // then — 새 WrongAnsweredNote를 생성하지 않고 기존 객체의 오답 횟수만 올린다
+            assertThat(existing.getWrongCount()).isEqualTo(2);
             verify(wrongAnsweredNoteRepository).save(existing);
             verify(wrongAnsweredNoteRepository, never()).save(argThat(note -> note != existing));
+        }
+
+        @Test
+        void 극복된_오답_노트를_다시_틀리면_오답노트로_복귀시킨다() {
+            // given
+            long userId = 1L;
+            long problemId = 1L;
+            WrongAnsweredNote resolved = WrongAnsweredNoteFixture.극복된_오답노트(problemId, userId);
+
+            when(wrongAnsweredNoteRepository.findByProblemIdAndUserId(problemId, userId)).thenReturn(Optional.of(resolved));
+            when(wrongAnsweredNoteRepository.save(any())).thenReturn(resolved);
+
+            // when
+            wrongAnsweredNoteService.saveWrongAnsweredNote(userId, problemId);
+
+            // then
+            assertSoftly(softly -> {
+                softly.assertThat(resolved.isResolved()).isFalse();
+                softly.assertThat(resolved.getWrongCount()).isEqualTo(2);
+            });
         }
     }
 
@@ -111,20 +134,56 @@ class WrongAnsweredNoteServiceUnitTest {
     }
 
     @Nested
-    @DisplayName("오답 문제를 삭제할 때")
-    class DeleteWrongAnsweredProblem {
+    @DisplayName("오답 문제를 오답노트에서 내릴 때")
+    class ResolveWrongAnsweredNote {
 
         @Test
-        void 오답_노트에서_삭제에_성공한다() {
+        void 행을_지우지_않고_극복_시각을_기록한다() {
+            // given
+            long userId = 1L;
+            long problemId = 1L;
+            WrongAnsweredNote note = WrongAnsweredNoteFixture.기본_오답노트(problemId, userId);
+
+            when(wrongAnsweredNoteRepository.findByProblemIdAndUserId(problemId, userId)).thenReturn(Optional.of(note));
+
+            // when
+            wrongAnsweredNoteService.resolveWrongAnsweredNote(userId, problemId);
+
+            // then
+            assertSoftly(softly -> {
+                softly.assertThat(note.isResolved()).isTrue();
+                softly.assertThat(note.getResolvedAt()).isNotNull();
+            });
+        }
+
+        @Test
+        void 이미_극복된_노트는_극복_시각이_밀리지_않는다() {
+            // given
+            long userId = 1L;
+            long problemId = 1L;
+            WrongAnsweredNote resolved = WrongAnsweredNoteFixture.극복된_오답노트(problemId, userId);
+            LocalDateTime resolvedAt = resolved.getResolvedAt();
+
+            when(wrongAnsweredNoteRepository.findByProblemIdAndUserId(problemId, userId)).thenReturn(Optional.of(resolved));
+
+            // when
+            wrongAnsweredNoteService.resolveWrongAnsweredNote(userId, problemId);
+
+            // then
+            assertThat(resolved.getResolvedAt()).isEqualTo(resolvedAt);
+        }
+
+        @Test
+        void 오답_노트가_없으면_예외_없이_통과한다() {
             // given
             long userId = 1L;
             long problemId = 1L;
 
-            // when
-            wrongAnsweredNoteService.deleteWrongAnsweredProblem(userId, problemId);
+            when(wrongAnsweredNoteRepository.findByProblemIdAndUserId(problemId, userId)).thenReturn(Optional.empty());
 
-            // then
-            verify(wrongAnsweredNoteRepository).deleteByProblemIdAndUserId(problemId, userId);
+            // when & then
+            assertThatCode(() -> wrongAnsweredNoteService.resolveWrongAnsweredNote(userId, problemId))
+                    .doesNotThrowAnyException();
         }
     }
 


### PR DESCRIPTION
## PR Summary

오답노트를 "현재 틀린 상태인가"만 담는 존재 여부 테이블에서 오답 이력을 남기는 상태 테이블로 전환했습니다. 삭제 API가 행을 지우는 대신 극복 시각을 기록하도록 바꿔, 사용자가 문제를 극복해 나간 과정이 데이터로 남습니다.

<br>

## Problem

**문제 1 - 오답노트에서 내리는 순간 학습 기록이 사라짐**

오답노트가 가진 필드는 문제 식별자와 사용자 식별자뿐이었습니다. 북마크조차 갖고 있는 생성 시각도 없어, 사용자가 언제 틀렸는지 알 수 없었습니다. 여기에 삭제 API가 행을 물리 삭제해, 오답노트에서 문제를 내리는 순간 그 문제를 틀렸다는 사실 자체가 사라졌습니다.

그래서 같은 문제를 몇 번 반복해서 틀렸는지 집계할 수 없었고, 사용자가 어떤 개념에 취약한지 짚어줄 근거가 남지 않았습니다. 학습 서비스에서 가장 가치 있는 데이터인 극복의 과정이 삭제와 함께 유실되고 있었습니다.

**문제 2 - dev 브랜치의 마이그레이션 버전 충돌**

작업 도중 dev에서 `flywayValidate`가 실패하는 것을 발견했습니다. #451과 #450이 각각 V28 번호로 마이그레이션을 추가한 뒤 어느 쪽도 재번호하지 않은 채 머지되어, 같은 버전을 가진 파일이 두 개 존재했습니다. dev를 기준으로는 빌드 자체가 불가능한 상태였습니다.

<br>

## Solution

**해결 1 - 삭제를 상태 전환으로 변경**

`BaseEntity`를 상속해 생성, 수정 시각을 남기고 오답 횟수와 극복 시각을 필드로 추가했습니다. 극복 시각이 비어 있으면 오답노트에 노출되고 값이 있으면 노출되지 않으므로, 삭제 API는 행을 지우는 대신 이 값을 채웁니다. 조회 쿼리에 미극복 필터만 더하면 되기 때문에 기존 화면 동작은 그대로 유지됩니다.

같은 문제를 다시 틀리면 오답 횟수가 누적되고 극복 시각이 해제되어 오답노트로 복귀합니다. 기존에는 이미 존재하는 행을 그대로 다시 저장하는 무의미한 호출이었는데, 이제 반복 오답이 취약 개념 집계의 근거로 쌓입니다. 극복 처리는 멱등하게 두어, 이미 극복된 문제에 삭제 요청이 반복돼도 최초 극복 시각이 뒤로 밀리지 않습니다.

정답 재제출 시 서버가 자동으로 극복 처리하는 동작은 이번 범위에서 제외했습니다. 현재 정답 처리 경로에는 오답노트를 건드리는 코드가 아예 없어, 이를 증명할 사용자 시퀀스가 정리된 뒤 별도로 다루는 편이 안전하다고 판단했습니다.

**해결 2 - 적용 이력이 없는 마이그레이션을 재번호**

#450의 마이그레이션을 V29로 옮기고, 이번 오답노트 마이그레이션은 V30을 사용합니다. 재번호 대상은 배포 상태를 몰라도 결정됩니다. #451은 먼저 머지되어 그 시점에는 빌드가 정상이었으므로 이미 적용됐을 가능성이 있는 반면, #450 파일은 머지 직후부터 빌드가 깨져 어느 환경에도 적용된 적이 없습니다. 적용 이력이 없는 쪽을 옮겨야 `flyway_schema_history`와 어긋나지 않기 때문에 #450을 대상으로 골랐습니다.

<br>

## Related Issue
- close #453


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **새 기능**
  - 오답노트를 삭제하지 않고 ‘극복’ 상태로 전환할 수 있습니다.
  - 극복된 문제는 오답노트 목록과 존재 여부 확인에서 제외됩니다.
  - 극복한 문제를 다시 틀리면 오답노트에 자동으로 복귀합니다.
  - 동일 문제를 반복해서 틀리면 오답 횟수가 누적됩니다.

- **개선 사항**
  - 오답노트 기록을 유지해 과거 오답 이력을 보존합니다.
  - 오답노트 해결 API 안내가 실제 동작에 맞게 명확해졌습니다.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->