### PR TITLE
refactor: 레벨 XP 구간표 중복 선언 제거(#455)

### DIFF
--- a/.claude/resources/plans/PLAN-455.md
+++ b/.claude/resources/plans/PLAN-455.md
@@ -119,8 +119,10 @@ private double calculateLevelRate(int xp) {
 
 정상 경로로는 도달할 수 없다(`level`은 `updateXp` -> `updateLevel`로만 갱신되어 항상 1~10). 도달한다면 QA 데이터 초기화, 어드민 도구, 직접 SQL 등으로 데이터가 깨진 경우이며, 깨진 데이터를 조용히 감추기보다 드러내는 편이 낫다고 판단해 이 변경을 수용한다.
 
-## 범위 밖 (별도 이슈 후보)
-- `UserLevelResponse.create`가 `nextLevel = level + 1`로 계산해, 최고 레벨 10에서 존재하지 않는 11을 응답한다. 이번 리팩토링과 맞닿아 있지만 응답 스펙 변경이라 여기서 다루지 않는다.
+## 추가 반영 (당초 범위 밖이었으나 이번 작업에 포함)
+- `UserLevelResponse.create`가 `nextLevel = level + 1`로 계산해, 최고 레벨 10에서 존재하지 않는 11을 응답하고 있었다. 레슨 제출 완료 응답에 실려 나가는 값이라 유저에게 그대로 노출된다.
+- 상한 판단이 `Level`로 모인 김에 같이 고친다. `Level.next()`를 추가해 최고 레벨이면 자기 자신을 반환하게 하고, `UserLevelResponse.create`가 이를 사용한다. 상한이 다시 DTO에 하드코딩되지 않도록 구간표와 같은 출처를 쓰는 것이 핵심이다.
+- 응답 필드 타입과 필수 여부는 그대로다(`int nextLevel`, REQUIRED). 최고 레벨에서 11 대신 10이 나가는 값 변경만 있다.
 
 ## 결정 필요 (Decisions needed)
 - [x] `Level` enum이 구간을 선언하는 방식 -> **A) `(level, startXp)`만 선언하고 끝 XP는 다음 상수에서 파생.** 경계값이 코드 전체에 한 번만 등장해 시작과 끝이 어긋날 여지가 원천 차단되고, 최고 레벨은 다음 상수가 없다는 사실로 `isMax()`가 자연히 결정된다. (이슈 본문의 `(level, startXp, endXp)` 표현에서 한 단계 더 줄인 형태)

--- a/.claude/resources/plans/PLAN-455.md
+++ b/.claude/resources/plans/PLAN-455.md
@@ -1,0 +1,136 @@
+# [PLAN-455] 레벨 XP 구간표 중복 선언 제거
+
+> 이슈: #455
+> 브랜치: refactor/455-user-level-xp-table
+
+## 목표
+`UserLevel`의 네 곳(`calculateLevel`, `calculateLevelRate`, `getMaxXp`, `getUserLevelDetail`의 상한 10)에 흩어진 XP 구간표를 `Level` enum 한 곳으로 모아, 레벨 추가나 구간 조정 시 한 곳만 고치면 되게 한다.
+
+## 영향 범위
+### 신규 파일
+- `src/main/java/gravit/code/user/domain/Level.java` — 레벨과 XP 구간의 단일 출처 enum
+- `src/test/java/gravit/code/user/domain/UserLevelTest.java` — 구간 경계, 최고 레벨 진행률 검증
+
+### 수정 파일
+- `src/main/java/gravit/code/user/domain/UserLevel.java` — 구간 판단을 전부 `Level` 조회로 위임. `calculateLevel`, `getMaxXp` 제거, `calculateLevelRate`는 private으로 축소
+
+`User`, `UserService`, `MissionService`, `UserFacade`는 `updateXp` / `getUserLevelDetail` / `getLevel`만 호출하므로 시그니처 변화가 없어 수정하지 않는다.
+
+## 구현 계획
+> 레이어 순으로, 클래스·메서드 단위까지 구체적으로. "적절히 구현한다" 같은 추상 표현 금지.
+
+1. **Entity / Flyway**: DB 변경 없음. `level`, `xp` 컬럼과 매핑은 그대로다. 구간표는 코드 상수일 뿐 스키마가 아니므로 마이그레이션이 필요 없다.
+
+2. **Repository**: 변경 없음.
+
+3. **Service**: 변경 없음.
+
+4. **Facade**: 불필요 - 도메인 객체 내부 리팩토링이라 서비스 조합이 없다.
+
+5. **DTO**: 변경 없음. `UserLevelDetailResponse.of(level, currentXp, maxXp, levelRate)`의 필드와 값 의미가 그대로 유지된다.
+
+6. **Controller**: 변경 없음. 응답 스펙이 바뀌지 않는다.
+
+### 6-1. 신규 `Level` enum (`user/domain/Level.java`)
+
+`MissionType`과 같은 패턴(`@Getter` + `@AllArgsConstructor`)을 따른다. 각 레벨은 자신의 **시작 XP만** 선언하고, 끝 XP는 다음 레벨의 시작 XP에서 파생한다. 경계값을 두 번 적지 않아 시작과 끝이 어긋날 여지 자체를 없앤다.
+
+```java
+@Getter
+@AllArgsConstructor(access = AccessLevel.PRIVATE)
+public enum Level {
+
+    LEVEL_1(1, 0),
+    LEVEL_2(2, 100),
+    LEVEL_3(3, 200),
+    LEVEL_4(4, 400),
+    LEVEL_5(5, 700),
+    LEVEL_6(6, 1100),
+    LEVEL_7(7, 1600),
+    LEVEL_8(8, 2200),
+    LEVEL_9(9, 2900),
+    LEVEL_10(10, 3700);
+
+    private final int level;
+    private final int startXp;
+}
+```
+
+메서드:
+
+- `public static Level fromXp(int totalXp)` — `startXp <= totalXp`를 만족하는 마지막 상수를 반환한다. 음수 XP는 `LEVEL_1`로 떨어져 기존 `totalXp < 100 -> 1` 동작과 같다.
+- `public static Level fromLevel(int level)` — `level` 값이 일치하는 상수를 반환하고, 없으면 `IllegalArgumentException`을 던진다.
+- `public boolean isMax()` — `ordinal() == values().length - 1`. 상한 10이 코드에서 사라지고 enum 마지막 값으로 결정된다.
+- `public int getEndXp()` — `values()[ordinal() + 1].startXp`. 최고 레벨은 상한이 없으므로 `IllegalStateException`을 던진다. 두 호출부 모두 `isMax()`로 먼저 걸러내며, 예외는 도달 불가능한 내부 불변식 위반을 드러내기 위한 방어다. 사용자에게 노출되는 오류가 아니므로 `RestApiException`을 쓰지 않는다.
+
+`values()`는 호출마다 배열을 복제하므로 `private static final Level[] VALUES = values();`를 선언해 재사용한다.
+
+### 6-2. `UserLevel` 수정
+
+`calculateLevel(Integer)`와 `getMaxXp(int)`는 삭제한다. 각각 `Level.fromXp(...).getLevel()`, `Level.getEndXp()` 한 줄로 흡수되어 별도 메서드로 남길 이유가 없다.
+
+```java
+private static final double MAX_RATE = 100.0;
+
+public UserLevelDetailResponse getUserLevelDetail() {
+    Level currentLevel = Level.fromLevel(this.level);
+    int maxXp = currentLevel.isMax() ? this.xp : currentLevel.getEndXp();
+
+    return UserLevelDetailResponse.of(
+            this.level,
+            this.xp,
+            maxXp,
+            calculateLevelRate(this.xp)
+    );
+}
+
+private void updateLevel(int totalXp) {
+    this.level = Level.fromXp(totalXp).getLevel();
+}
+
+private double calculateLevelRate(int xp) {
+    Level currentLevel = Level.fromXp(xp);
+    if (currentLevel.isMax()) {
+        return MAX_RATE;
+    }
+
+    int startXp = currentLevel.getStartXp();
+    double rate = ((double) (xp - startXp) / (currentLevel.getEndXp() - startXp)) * MAX_RATE;
+    return Math.round(rate * 10) / 10.0;
+}
+```
+
+- `calculateLevelRate`는 `public` -> `private`. 전체 검색 결과 `getUserLevelDetail` 외 호출부가 없어 공개할 이유가 없다.
+- `getUserLevelDetail`은 기존과 동일하게 `this.level` 기준으로 `maxXp`를 구한다(`this.xp` 기준으로 바꾸지 않는다). `level`은 `updateXp` -> `updateLevel` 경로로만 갱신되어 `xp`와 항상 일치하므로 결과는 같지만, 기준을 바꾸지 않아야 회귀 여지가 없다.
+- `calculateLevel`의 반환 타입이 `Integer`였던 불필요한 박싱도 함께 사라진다.
+
+### 6-3. 동작 보존 확인표
+
+| 입력 | 기존 | 변경 후 |
+|---|---|---|
+| xp 0 | level 1, rate 0.0 | 동일 |
+| xp 99 -> 100 | level 1 -> 2 | 동일 |
+| xp 3699 -> 3700 | level 9 -> 10 | 동일 |
+| xp 5000 (레벨 10) | rate 100.0, maxXp = xp | 동일 |
+| level 9, xp 2900 | maxXp 3700, rate 0.0 | 동일 |
+| **level 0 또는 11 이상 (범위 밖)** | **`getMaxXp`가 fall-through로 3700 반환, 예외 없음** | **`Level.fromLevel`이 `IllegalArgumentException`** |
+
+마지막 행은 유일한 동작 변경이다. 기존 `getMaxXp`는 `if` 사슬을 전부 빠져나가면 `return 3700`으로 떨어져, DB에 범위 밖 레벨이 들어와도 조용히 잘못된 `maxXp`를 응답했다. 변경 후에는 예외가 올라가 `@ExceptionHandler(Exception.class)`가 `INTERNAL_SERVER_ERROR`로 응답한다.
+
+정상 경로로는 도달할 수 없다(`level`은 `updateXp` -> `updateLevel`로만 갱신되어 항상 1~10). 도달한다면 QA 데이터 초기화, 어드민 도구, 직접 SQL 등으로 데이터가 깨진 경우이며, 깨진 데이터를 조용히 감추기보다 드러내는 편이 낫다고 판단해 이 변경을 수용한다.
+
+## 범위 밖 (별도 이슈 후보)
+- `UserLevelResponse.create`가 `nextLevel = level + 1`로 계산해, 최고 레벨 10에서 존재하지 않는 11을 응답한다. 이번 리팩토링과 맞닿아 있지만 응답 스펙 변경이라 여기서 다루지 않는다.
+
+## 결정 필요 (Decisions needed)
+- [x] `Level` enum이 구간을 선언하는 방식 -> **A) `(level, startXp)`만 선언하고 끝 XP는 다음 상수에서 파생.** 경계값이 코드 전체에 한 번만 등장해 시작과 끝이 어긋날 여지가 원천 차단되고, 최고 레벨은 다음 상수가 없다는 사실로 `isMax()`가 자연히 결정된다. (이슈 본문의 `(level, startXp, endXp)` 표현에서 한 단계 더 줄인 형태)
+
+## 검증
+- 대상 테스트: `UserLevelTest` (신규, `InquiryTest`와 같은 순수 POJO 도메인 테스트 형식 - Spring 컨텍스트와 Mockito 없이 `@Nested` + `@DisplayName` + AssertJ)
+  - `@DisplayName("XP로 레벨을 계산할 때")` — 구간 경계 0/99/100/3699/3700, 최고 레벨 초과 XP
+  - `@DisplayName("레벨 상세를 조회할 때")` — 중간 레벨의 `maxXp`와 `levelRate`, 최고 레벨의 `maxXp == xp`와 `levelRate == 100.0`
+  - `@DisplayName("XP를 누적할 때")` — `updateXp` 호출로 레벨이 올라가는지, 누적 XP가 유지되는지
+- 회귀 확인: `./gradlew test --tests "*UserLevel*" --tests "*LessonFacade*" --tests "*UserServiceIntegration*"` 이후 `./gradlew build`
+
+## Deviation Log
+> implement 스킬이 구현 중 계획을 벗어난 지점을 여기에 기록한다. (작성 시점엔 비워둔다)

--- a/src/main/java/gravit/code/user/domain/Level.java
+++ b/src/main/java/gravit/code/user/domain/Level.java
@@ -1,0 +1,61 @@
+package gravit.code.user.domain;
+
+import lombok.AccessLevel;
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+
+@Getter
+@AllArgsConstructor(access = AccessLevel.PRIVATE)
+public enum Level {
+
+    LEVEL_1(1, 0),
+    LEVEL_2(2, 100),
+    LEVEL_3(3, 200),
+    LEVEL_4(4, 400),
+    LEVEL_5(5, 700),
+    LEVEL_6(6, 1100),
+    LEVEL_7(7, 1600),
+    LEVEL_8(8, 2200),
+    LEVEL_9(9, 2900),
+    LEVEL_10(10, 3700);
+
+    private static final Level[] VALUES = values();
+
+    private final int level;
+    private final int startXp;
+
+    public static Level fromXp(int totalXp) {
+        Level found = VALUES[0];
+
+        for (Level candidate : VALUES) {
+            if (totalXp < candidate.startXp) {
+                break;
+            }
+            found = candidate;
+        }
+
+        return found;
+    }
+
+    public static Level fromLevel(int level) {
+        for (Level candidate : VALUES) {
+            if (candidate.level == level) {
+                return candidate;
+            }
+        }
+
+        throw new IllegalArgumentException("존재하지 않는 레벨입니다: " + level);
+    }
+
+    public boolean isMax() {
+        return ordinal() == VALUES.length - 1;
+    }
+
+    public int getEndXp() {
+        if (isMax()) {
+            throw new IllegalStateException("최고 레벨은 상한 XP가 없습니다: " + this.level);
+        }
+
+        return VALUES[ordinal() + 1].startXp;
+    }
+}

--- a/src/main/java/gravit/code/user/domain/Level.java
+++ b/src/main/java/gravit/code/user/domain/Level.java
@@ -51,6 +51,10 @@ public enum Level {
         return ordinal() == VALUES.length - 1;
     }
 
+    public Level next() {
+        return isMax() ? this : VALUES[ordinal() + 1];
+    }
+
     public int getEndXp() {
         if (isMax()) {
             throw new IllegalStateException("최고 레벨은 상한 XP가 없습니다: " + this.level);

--- a/src/main/java/gravit/code/user/domain/UserLevel.java
+++ b/src/main/java/gravit/code/user/domain/UserLevel.java
@@ -13,6 +13,8 @@ import lombok.NoArgsConstructor;
 @Getter
 public class UserLevel {
 
+    private static final double MAX_RATE = 100.0;
+
     @Column(name = "level", nullable = false)
     private int level;
 
@@ -44,7 +46,9 @@ public class UserLevel {
     }
 
     public UserLevelDetailResponse getUserLevelDetail() {
-        int maxXp = (this.level == 10) ? this.xp : getMaxXp(this.level);
+        Level currentLevel = Level.fromLevel(this.level);
+        int maxXp = currentLevel.isMax() ? this.xp : currentLevel.getEndXp();
+
         return UserLevelDetailResponse.of(
                 this.level,
                 this.xp,
@@ -54,70 +58,17 @@ public class UserLevel {
     }
 
     private void updateLevel(int totalXp){
-        this.level = calculateLevel(totalXp);
+        this.level = Level.fromXp(totalXp).getLevel();
     }
 
-    private Integer calculateLevel(Integer totalXp){
-        if(totalXp < 100) return 1;
-        if(totalXp < 200) return 2;
-        if(totalXp < 400) return 3;
-        if(totalXp < 700) return 4;
-        if(totalXp < 1100) return 5;
-        if(totalXp < 1600) return 6;
-        if(totalXp < 2200) return 7;
-        if(totalXp < 2900) return 8;
-        if(totalXp < 3700) return 9;
-        else return 10;
-    }
-
-    public double calculateLevelRate(int xp){
-        int levelStart;
-        int levelEnd;
-
-        if(xp < 100) {
-            levelStart = 0;
-            levelEnd = 100;
-        } else if(xp < 200) {
-            levelStart = 100;
-            levelEnd = 200;
-        } else if(xp < 400) {
-            levelStart = 200;
-            levelEnd = 400;
-        } else if(xp < 700) {
-            levelStart = 400;
-            levelEnd = 700;
-        } else if(xp < 1100) {
-            levelStart = 700;
-            levelEnd = 1100;
-        } else if(xp < 1600) {
-            levelStart = 1100;
-            levelEnd = 1600;
-        } else if(xp < 2200) {
-            levelStart = 1600;
-            levelEnd = 2200;
-        } else if(xp < 2900) {
-            levelStart = 2200;
-            levelEnd = 2900;
-        } else if(xp < 3700) {
-            levelStart = 2900;
-            levelEnd = 3700;
-        } else {
-            return 100.0;
+    private double calculateLevelRate(int xp){
+        Level currentLevel = Level.fromXp(xp);
+        if (currentLevel.isMax()) {
+            return MAX_RATE;
         }
 
-        double rate = ((double)(xp - levelStart) / (levelEnd - levelStart)) * 100;
+        int startXp = currentLevel.getStartXp();
+        double rate = ((double)(xp - startXp) / (currentLevel.getEndXp() - startXp)) * MAX_RATE;
         return Math.round(rate * 10) / 10.0;
-    }
-
-    private int getMaxXp(int level){
-        if(level == 1) return 100;
-        if(level == 2) return 200;
-        if(level == 3) return 400;
-        if(level == 4) return 700;
-        if(level == 5) return 1100;
-        if(level == 6) return 1600;
-        if(level == 7) return 2200;
-        if(level == 8) return 2900;
-        return 3700;
     }
 }

--- a/src/main/java/gravit/code/user/dto/response/UserLevelResponse.java
+++ b/src/main/java/gravit/code/user/dto/response/UserLevelResponse.java
@@ -1,5 +1,6 @@
 package gravit.code.user.dto.response;
 
+import gravit.code.user.domain.Level;
 import io.swagger.v3.oas.annotations.media.Schema;
 import lombok.AccessLevel;
 import lombok.Builder;
@@ -15,7 +16,7 @@ public record UserLevelResponse(
         int currentLevel,
 
         @Schema(
-                description = "다음 레벨",
+                description = "다음 레벨 (최고 레벨이면 현재 레벨과 동일)",
                 example = "4",
                 requiredMode = Schema.RequiredMode.REQUIRED
         )
@@ -34,7 +35,7 @@ public record UserLevelResponse(
     ){
         return UserLevelResponse.builder()
                 .currentLevel(level)
-                .nextLevel(level+1)
+                .nextLevel(Level.fromLevel(level).next().getLevel())
                 .xp(xp)
                 .build();
     }

--- a/src/test/java/gravit/code/user/domain/LevelTest.java
+++ b/src/test/java/gravit/code/user/domain/LevelTest.java
@@ -1,0 +1,155 @@
+package gravit.code.user.domain;
+
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Nested;
+import org.junit.jupiter.api.Test;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static org.assertj.core.api.SoftAssertions.assertSoftly;
+
+@DisplayName("Level enum")
+class LevelTest {
+
+    @Nested
+    @DisplayName("XP로 레벨을 찾을 때")
+    class FromXp {
+
+        @Test
+        void 구간에_해당하는_레벨을_반환한다() {
+            // given & when & then
+            assertSoftly(softly -> {
+                softly.assertThat(Level.fromXp(0)).isEqualTo(Level.LEVEL_1);
+                softly.assertThat(Level.fromXp(99)).isEqualTo(Level.LEVEL_1);
+                softly.assertThat(Level.fromXp(100)).isEqualTo(Level.LEVEL_2);
+                softly.assertThat(Level.fromXp(399)).isEqualTo(Level.LEVEL_3);
+                softly.assertThat(Level.fromXp(400)).isEqualTo(Level.LEVEL_4);
+                softly.assertThat(Level.fromXp(3699)).isEqualTo(Level.LEVEL_9);
+                softly.assertThat(Level.fromXp(3700)).isEqualTo(Level.LEVEL_10);
+            });
+        }
+
+        @Test
+        void 최고_레벨의_시작_XP를_넘어도_최고_레벨을_반환한다() {
+            // given & when & then
+            assertThat(Level.fromXp(Integer.MAX_VALUE)).isEqualTo(Level.LEVEL_10);
+        }
+
+        @Test
+        void 음수_XP는_최저_레벨을_반환한다() {
+            // given & when & then
+            assertThat(Level.fromXp(-1)).isEqualTo(Level.LEVEL_1);
+        }
+    }
+
+    @Nested
+    @DisplayName("레벨 값으로 레벨을 찾을 때")
+    class FromLevel {
+
+        @Test
+        void 일치하는_레벨을_반환한다() {
+            // given & when & then
+            assertSoftly(softly -> {
+                softly.assertThat(Level.fromLevel(1)).isEqualTo(Level.LEVEL_1);
+                softly.assertThat(Level.fromLevel(7)).isEqualTo(Level.LEVEL_7);
+                softly.assertThat(Level.fromLevel(10)).isEqualTo(Level.LEVEL_10);
+            });
+        }
+
+        @Test
+        void 존재하지_않는_레벨이면_예외를_던진다() {
+            // given & when & then
+            assertThatThrownBy(() -> Level.fromLevel(11))
+                    .isInstanceOf(IllegalArgumentException.class)
+                    .hasMessageContaining("11");
+        }
+
+        @Test
+        void 레벨이_0_이하면_예외를_던진다() {
+            // given & when & then
+            assertThatThrownBy(() -> Level.fromLevel(0))
+                    .isInstanceOf(IllegalArgumentException.class);
+        }
+    }
+
+    @Nested
+    @DisplayName("최고 레벨을 판별할 때")
+    class IsMax {
+
+        @Test
+        void 마지막_상수만_최고_레벨이다() {
+            // given & when & then
+            assertSoftly(softly -> {
+                softly.assertThat(Level.LEVEL_10.isMax()).isTrue();
+                softly.assertThat(Level.LEVEL_9.isMax()).isFalse();
+                softly.assertThat(Level.LEVEL_1.isMax()).isFalse();
+            });
+        }
+    }
+
+    @Nested
+    @DisplayName("구간 끝 XP를 구할 때")
+    class GetEndXp {
+
+        @Test
+        void 다음_레벨의_시작_XP를_반환한다() {
+            // given & when & then
+            assertSoftly(softly -> {
+                softly.assertThat(Level.LEVEL_1.getEndXp()).isEqualTo(Level.LEVEL_2.getStartXp());
+                softly.assertThat(Level.LEVEL_1.getEndXp()).isEqualTo(100);
+                softly.assertThat(Level.LEVEL_4.getEndXp()).isEqualTo(700);
+                softly.assertThat(Level.LEVEL_9.getEndXp()).isEqualTo(3700);
+            });
+        }
+
+        @Test
+        void 최고_레벨은_상한이_없어_예외를_던진다() {
+            // given & when & then
+            assertThatThrownBy(Level.LEVEL_10::getEndXp)
+                    .isInstanceOf(IllegalStateException.class);
+        }
+    }
+
+    @Nested
+    @DisplayName("구간표 자체를 검증할 때")
+    class Table {
+
+        @Test
+        void 레벨_값은_1부터_1씩_증가한다() {
+            // given & when & then
+            assertSoftly(softly -> {
+                Level[] levels = Level.values();
+                for (int i = 0; i < levels.length; i++) {
+                    softly.assertThat(levels[i].getLevel()).isEqualTo(i + 1);
+                }
+            });
+        }
+
+        @Test
+        void 시작_XP는_순증가한다() {
+            // given & when & then
+            assertSoftly(softly -> {
+                Level[] levels = Level.values();
+                for (int i = 1; i < levels.length; i++) {
+                    softly.assertThat(levels[i].getStartXp())
+                            .as("%s의 시작 XP는 %s보다 커야 한다", levels[i], levels[i - 1])
+                            .isGreaterThan(levels[i - 1].getStartXp());
+                }
+            });
+        }
+
+        @Test
+        void 모든_XP는_어떤_레벨엔가_속한다() {
+            // given & when & then
+            assertSoftly(softly -> {
+                for (Level level : Level.values()) {
+                    softly.assertThat(Level.fromXp(level.getStartXp())).isEqualTo(level);
+
+                    if (!level.isMax()) {
+                        softly.assertThat(Level.fromXp(level.getEndXp() - 1)).isEqualTo(level);
+                    }
+                }
+            });
+        }
+    }
+}

--- a/src/test/java/gravit/code/user/domain/LevelTest.java
+++ b/src/test/java/gravit/code/user/domain/LevelTest.java
@@ -88,6 +88,26 @@ class LevelTest {
     }
 
     @Nested
+    @DisplayName("다음 레벨을 구할 때")
+    class Next {
+
+        @Test
+        void 바로_다음_레벨을_반환한다() {
+            // given & when & then
+            assertSoftly(softly -> {
+                softly.assertThat(Level.LEVEL_1.next()).isEqualTo(Level.LEVEL_2);
+                softly.assertThat(Level.LEVEL_9.next()).isEqualTo(Level.LEVEL_10);
+            });
+        }
+
+        @Test
+        void 최고_레벨은_자기_자신을_반환한다() {
+            // given & when & then
+            assertThat(Level.LEVEL_10.next()).isEqualTo(Level.LEVEL_10);
+        }
+    }
+
+    @Nested
     @DisplayName("구간 끝 XP를 구할 때")
     class GetEndXp {
 

--- a/src/test/java/gravit/code/user/domain/UserLevelTest.java
+++ b/src/test/java/gravit/code/user/domain/UserLevelTest.java
@@ -1,0 +1,163 @@
+package gravit.code.user.domain;
+
+import gravit.code.user.dto.response.UserLevelDetailResponse;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Nested;
+import org.junit.jupiter.api.Test;
+
+import static org.assertj.core.api.SoftAssertions.assertSoftly;
+
+@DisplayName("UserLevel VO")
+class UserLevelTest {
+
+    private static UserLevel 레벨_1_상태() {
+        return UserLevel.create(1, 0);
+    }
+
+    @Nested
+    @DisplayName("XP로 레벨을 계산할 때")
+    class CalculateLevel {
+
+        @Test
+        void 구간_경계_XP에서_레벨이_바뀐다() {
+            // given & when & then
+            assertSoftly(softly -> {
+                softly.assertThat(레벨(0)).isEqualTo(1);
+                softly.assertThat(레벨(99)).isEqualTo(1);
+                softly.assertThat(레벨(100)).isEqualTo(2);
+                softly.assertThat(레벨(199)).isEqualTo(2);
+                softly.assertThat(레벨(200)).isEqualTo(3);
+                softly.assertThat(레벨(2899)).isEqualTo(8);
+                softly.assertThat(레벨(2900)).isEqualTo(9);
+                softly.assertThat(레벨(3699)).isEqualTo(9);
+                softly.assertThat(레벨(3700)).isEqualTo(10);
+            });
+        }
+
+        @Test
+        void 최고_레벨_구간을_넘는_XP도_레벨_10에_머문다() {
+            // given
+            UserLevel userLevel = 레벨_1_상태();
+
+            // when
+            userLevel.updateXp(99999);
+
+            // then
+            assertSoftly(softly -> {
+                softly.assertThat(userLevel.getLevel()).isEqualTo(10);
+                softly.assertThat(userLevel.getXp()).isEqualTo(99999);
+            });
+        }
+
+        private int 레벨(int totalXp) {
+            UserLevel userLevel = 레벨_1_상태();
+            userLevel.updateXp(totalXp);
+            return userLevel.getLevel();
+        }
+    }
+
+    @Nested
+    @DisplayName("XP를 누적할 때")
+    class UpdateXp {
+
+        @Test
+        void 기존_XP에_더해진_값으로_레벨이_다시_계산된다() {
+            // given
+            UserLevel userLevel = 레벨_1_상태();
+
+            // when
+            userLevel.updateXp(60);
+            userLevel.updateXp(60);
+
+            // then
+            assertSoftly(softly -> {
+                softly.assertThat(userLevel.getXp()).isEqualTo(120);
+                softly.assertThat(userLevel.getLevel()).isEqualTo(2);
+            });
+        }
+
+        @Test
+        void 구간을_넘지_못하면_레벨은_그대로다() {
+            // given
+            UserLevel userLevel = 레벨_1_상태();
+
+            // when
+            userLevel.updateXp(50);
+
+            // then
+            assertSoftly(softly -> {
+                softly.assertThat(userLevel.getXp()).isEqualTo(50);
+                softly.assertThat(userLevel.getLevel()).isEqualTo(1);
+            });
+        }
+    }
+
+    @Nested
+    @DisplayName("레벨 상세를 조회할 때")
+    class GetUserLevelDetail {
+
+        @Test
+        void 구간_시작_XP면_진행률은_0이고_maxXp는_구간_끝이다() {
+            // given
+            UserLevel userLevel = UserLevel.create(3, 200);
+
+            // when
+            UserLevelDetailResponse response = userLevel.getUserLevelDetail();
+
+            // then
+            assertSoftly(softly -> {
+                softly.assertThat(response.level()).isEqualTo(3);
+                softly.assertThat(response.currentXp()).isEqualTo(200);
+                softly.assertThat(response.maxXp()).isEqualTo(400);
+                softly.assertThat(response.levelRate()).isEqualTo(0.0);
+            });
+        }
+
+        @Test
+        void 구간_중간_XP면_구간_내_비율로_진행률이_계산된다() {
+            // given - 레벨 3 구간(200~400)의 절반
+            UserLevel userLevel = UserLevel.create(3, 300);
+
+            // when
+            UserLevelDetailResponse response = userLevel.getUserLevelDetail();
+
+            // then
+            assertSoftly(softly -> {
+                softly.assertThat(response.maxXp()).isEqualTo(400);
+                softly.assertThat(response.levelRate()).isEqualTo(50.0);
+            });
+        }
+
+        @Test
+        void 진행률은_소수점_첫째자리까지_반올림된다() {
+            // given - 레벨 4 구간(400~700)에서 2/300 진행 -> 0.666...%
+            UserLevel userLevel = UserLevel.create(4, 402);
+
+            // when
+            UserLevelDetailResponse response = userLevel.getUserLevelDetail();
+
+            // then
+            assertSoftly(softly -> {
+                softly.assertThat(response.maxXp()).isEqualTo(700);
+                softly.assertThat(response.levelRate()).isEqualTo(0.7);
+            });
+        }
+
+        @Test
+        void 최고_레벨이면_maxXp는_보유_XP이고_진행률은_100이다() {
+            // given
+            UserLevel userLevel = UserLevel.create(10, 5000);
+
+            // when
+            UserLevelDetailResponse response = userLevel.getUserLevelDetail();
+
+            // then
+            assertSoftly(softly -> {
+                softly.assertThat(response.level()).isEqualTo(10);
+                softly.assertThat(response.currentXp()).isEqualTo(5000);
+                softly.assertThat(response.maxXp()).isEqualTo(5000);
+                softly.assertThat(response.levelRate()).isEqualTo(100.0);
+            });
+        }
+    }
+}

--- a/src/test/java/gravit/code/user/dto/response/UserLevelResponseTest.java
+++ b/src/test/java/gravit/code/user/dto/response/UserLevelResponseTest.java
@@ -1,0 +1,42 @@
+package gravit.code.user.dto.response;
+
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Nested;
+import org.junit.jupiter.api.Test;
+
+import static org.assertj.core.api.SoftAssertions.assertSoftly;
+
+@DisplayName("UserLevelResponse")
+class UserLevelResponseTest {
+
+    @Nested
+    @DisplayName("학습 종료 후 레벨 정보를 만들 때")
+    class Create {
+
+        @Test
+        void 중간_레벨이면_다음_레벨은_현재보다_하나_높다() {
+            // given & when
+            UserLevelResponse response = UserLevelResponse.create(3, 250);
+
+            // then
+            assertSoftly(softly -> {
+                softly.assertThat(response.currentLevel()).isEqualTo(3);
+                softly.assertThat(response.nextLevel()).isEqualTo(4);
+                softly.assertThat(response.xp()).isEqualTo(250);
+            });
+        }
+
+        @Test
+        void 최고_레벨이면_존재하지_않는_다음_레벨_대신_현재_레벨을_반환한다() {
+            // given & when
+            UserLevelResponse response = UserLevelResponse.create(10, 5000);
+
+            // then
+            assertSoftly(softly -> {
+                softly.assertThat(response.currentLevel()).isEqualTo(10);
+                softly.assertThat(response.nextLevel()).isEqualTo(10);
+                softly.assertThat(response.xp()).isEqualTo(5000);
+            });
+        }
+    }
+}


### PR DESCRIPTION
## PR Summary

`UserLevel`에 네 곳으로 흩어져 하드코딩되어 있던 XP 구간표를 `Level` enum 한 곳으로 모았습니다. 레벨을 추가하거나 구간을 조정할 때 이제 한 곳만 고치면 됩니다.

<br>

## Problem

같은 XP 구간표가 `UserLevel` 안에서 네 번 반복되고 있었습니다. 레벨을 계산하는 곳에서 구간의 끝값을, 진행률을 계산하는 곳에서 구간의 시작값과 끝값을 다시, 최대 XP를 구하는 곳에서 또 한 번 나열했고, 레벨 상한 10은 상세 조회 메서드 안에 네 번째로 박혀 있었습니다.

진짜 문제는 이 중복이 깨져도 아무도 모른다는 점입니다. 레벨 11을 추가하려면 네 곳을 동시에 고쳐야 하는데, 한 곳이라도 놓치면 예외가 나지 않고 레벨과 진행률만 조용히 어긋납니다. 실제로 이번에 테스트를 작성하면서 레벨 4의 구간을 400~700이 아닌 700~1100으로 착각했는데, 구간표가 흩어져 있으면 사람이 눈으로 읽어도 틀린다는 걸 그대로 보여준 사례입니다.

<br>

## Solution

각 레벨이 자신의 시작 XP만 선언하고, 구간의 끝은 다음 레벨의 시작 XP에서 파생하는 `Level` enum을 두었습니다. 이슈에서는 `(레벨, 시작 XP, 끝 XP)` 세 값을 선언하는 안을 제시했지만, 그러면 100 같은 경계값이 앞 레벨의 끝과 뒤 레벨의 시작으로 두 번 등장해 둘이 어긋날 여지가 남습니다. 시작 XP만 선언하면 경계값이 코드 전체에 딱 한 번만 나타나 그 여지가 원천 차단됩니다.

레벨 상한도 별도 상수 없이 해결됩니다. 최고 레벨을 "다음 상수가 없는 레벨"로 정의했기 때문에, 나중에 레벨을 추가하면 상한이 저절로 따라옵니다. 기존에 상세 조회 메서드에 박혀 있던 `level == 10` 비교가 사라진 자리입니다.

**동작 변경 한 가지** - 기존 코드는 DB에 범위 밖 레벨 값이 들어와도 `if` 사슬을 빠져나가 조용히 3700을 반환했지만, 이제는 예외가 발생해 500으로 응답합니다. 정상 경로로는 도달할 수 없고(레벨은 XP 누적 시에만 갱신됩니다), 데이터가 깨진 상황이라면 잘못된 진행률을 보여주기보다 드러나는 편이 낫다고 판단했습니다. 판단 근거는 계획서의 동작 보존 확인표에 남겨두었습니다.

**함께 고친 것** - 레슨 제출 완료 응답이 다음 레벨을 `현재 레벨 + 1`로 계산하고 있어, 최고 레벨 10인 유저에게 존재하지 않는 레벨 11이 노출되고 있었습니다. 상한 판단이 `Level`로 모인 김에 같이 처리했습니다. 최고 레벨이면 자기 자신을 반환하는 방식이라 상한값이 응답 DTO에 다시 하드코딩되지 않습니다. 응답 필드의 타입과 필수 여부는 그대로이고, 최고 레벨에서 11 대신 10이 나가는 값 변경만 있습니다.

구간 경계와 최고 레벨 진행률, 그리고 구간표 자체의 불변식(레벨 값이 1씩 증가하는지, 시작 XP가 순증가하는지)을 검증하는 테스트를 함께 추가했습니다. 마지막 항목은 나중에 레벨을 추가하다 오타가 나면 바로 잡히도록 하려는 목적입니다.

<br>

## Related Issue
- close #455
