### PR TITLE
refactor: 유저 리그 쓰기 경로 인덱스 재구성(#443)

### DIFF
--- a/src/main/resources/db/migration/V34__add_user_league_user_id_index.sql
+++ b/src/main/resources/db/migration/V34__add_user_league_user_id_index.sql
@@ -1,0 +1,5 @@
+-- V34__add_user_league_user_id_index.sql
+
+-- LP 적립의 진입 조회(findByUserId)와 /ranking/me 가 user_id 로 행을 찾는데 인덱스가 없어
+-- 매번 테이블 전체를 훑고 있었다. 유저 100만 기준 쓰기 최대 TPS 315 → 32,100.
+CREATE INDEX IF NOT EXISTS ix_ul_user_id ON user_league (user_id);

--- a/src/main/resources/db/migration/V35__drop_user_league_rank_index.sql
+++ b/src/main/resources/db/migration/V35__drop_user_league_rank_index.sql
@@ -1,0 +1,6 @@
+-- V35__drop_user_league_rank_index.sql
+
+-- 순위 계산이 Redis Sorted Set 으로 이관되어 이 인덱스를 읽는 쿼리가 남지 않는다.
+-- league_point 가 인덱스 키에 있어 LP 갱신마다 HOT update 를 막고 있었다(HOT 0% → 95.46%).
+-- Redis 장애 시 쓰는 폴백 쿼리는 이 인덱스 없이도 동일하게 동작한다(실측: 목록 51,146 → 51,106 페이지).
+DROP INDEX IF EXISTS ix_ul_league_rank;


### PR DESCRIPTION
## PR Summary

`user_league`의 인덱스 구성을 조회 기준에서 쓰기 기준으로 재구성했습니다. `user_id` 인덱스를 추가하고, 랭킹 조회에 기여하지 않으면서 LP 갱신마다 HOT update를 막고 있던 `ix_ul_league_rank`를 제거해 LP 적립 최대 처리량을 101배로 올렸습니다.

<br>

## Problem

**문제 1 - LP 적립 진입 조회의 풀스캔** (100만 행, LP 적립 UPDATE 기준)

`user_league`에 `user_id` 인덱스가 없었습니다. LP 적립은 대상 행을 `user_id = ?`로 찾는 것에서 시작하는데, 이 조회가 매번 테이블 전체를 훑고 있었습니다. 10만 행에서 이미 1,031페이지를 읽으며 `Rows Removed by Filter: 99,999`가 찍혔고, 비용이 행 수에 정확히 비례해 커졌습니다.

그 결과 LP 적립이 100만 행에서 **최대 지속 315 TPS**에 눕고 단건 지연 p95가 **165.9 ms**였습니다. 레슨 첫 제출마다 타는 경로이므로 학습 트래픽 전체가 여기에 묶여 있었습니다.

<br>

**문제 2 - 조회에 기여하지 않으면서 쓰기를 막던 랭킹 인덱스**

`ix_ul_league_rank (league_id, league_point DESC, user_id)`는 랭킹 조회를 위해 만들어졌지만, 정작 랭킹 목록 조회에서 정렬에 쓰이지 않았습니다. 100만 행 실행 계획에는 이 인덱스가 아예 나타나지 않고 병렬 Seq Scan 위에 별도 Sort가 붙었으며, 10만 행에서는 인덱스를 타긴 했으나 `league_id = ?` 필터 용도로만 썼습니다. `users`와의 조인이 인덱스 순서를 깨뜨리기 때문입니다.

반면 비용은 확실히 내고 있었습니다. `league_point`가 인덱스 키에 있어 LP를 갱신할 때마다 인덱스 갱신이 따라붙고, 그래서 **HOT update 비율이 0.00%**로 고정됐습니다. LP 적립 1건마다 인덱스가 49.0 B 늘고 dead tuple이 1개씩 쌓였습니다. 조회 이득 없이 쓰기 비용만 내는 인덱스였습니다.

<br>

## Solution

**해결 1 - `user_id` 단일 컬럼 인덱스 추가**

```sql
CREATE INDEX IF NOT EXISTS ix_ul_user_id ON user_league (user_id);
```

`user_id` 하나만 둔 이유는 이 인덱스를 쓰는 쿼리가 모두 `user_id = ?` 등호 조건으로 단일 행을 찾기 때문입니다. `user_league`는 유저당 1행이라 등호 조건만으로 선택도가 최대가 되고, 뒤에 붙일 범위 조건이나 정렬 키가 없어 컬럼을 더 둘 이유가 없습니다.

`league_point`를 `INCLUDE`로 넣으면 커버링 인덱스가 되어 heap 접근을 없앨 수 있지만 넣지 않았습니다. LP 갱신마다 인덱스에 걸린 값이 바뀌어 HOT update가 다시 불가능해지고, 그것이 해결 2에서 되찾으려는 이득 전부이기 때문입니다. 인덱스 키는 값이 바뀌지 않는 컬럼으로만 채웠습니다.

<br>

**해결 2 - 랭킹 인덱스 제거**

```sql
DROP INDEX IF EXISTS ix_ul_league_rank;
```

문제 2에서 확인한 대로 조회 이득이 없으므로, 대체 인덱스를 두지 않고 제거했습니다. `league_id`만 남긴 인덱스도 고려했지만 후속 작업에서 순위 계산이 `user_league`를 `league_id`로 뒤지지 않게 되므로 함께 뺐습니다.

두 변경을 합치면 `user_league`에 남는 인덱스는 PK와 `ix_ul_user_id` 둘뿐이고, 둘 다 LP 갱신 시 값이 바뀌지 않습니다. HOT update 조건이 완전히 성립합니다.

<br>

**쓰기 처리량과 지연** (100만 행, LP 적립 UPDATE, pgbench c=32, 30초)

| 지표 | BEFORE (현행) | AFTER (이 PR) | 변화 |
|---|---:|---:|---:|
| 최대 지속 TPS | 315 | 31,714 | **101배** |
| 단건 지연 p50 (c=1) | 12.46 ms | 0.261 ms | -97.9% |
| p95 | 165.9 ms | 1.351 ms | -99.2% |
| p99 | 186.8 ms | 1.695 ms | -99.1% |

<br>

**인덱스 제거만의 몫** (인덱스 추가만 적용한 상태와 비교, LP 적립 1건당 정규화)

두 변경의 효과가 섞이지 않게, 추가만 적용한 상태를 따로 측정해 비교했습니다. 처리량은 이미 인덱스 추가로 천장에 닿아 있어 거의 같고, 차이는 1건당 쓰기 비용에서 드러납니다.

| 지표 | 추가만 적용 | 추가 + 제거 (이 PR) | 변화 |
|---|---:|---:|---:|
| HOT 비율 | 0.00% | 95.46% | **+95.46%p** |
| WAL / 1건 | 787.5 B | 355.5 B | -54.9% |
| 인덱스 증가 / 1건 | 49.0 B | 0.0 B | **완전 소멸** |
| dead tuple / 1건 | 약 1.00 | 0.058 | -94.2% |

dead tuple이 17배 줄어 vacuum 부담도 그만큼 내려갑니다. 인덱스 디스크 사용량은 970,114명 기준 60 MB에서 43 MB로 17 MB 줄었습니다.

<br>

**감수하는 조회 손실과 배포 순서**

인덱스 제거는 순위 계산이 Redis로 이관되는 것을 전제로 한 결정입니다. 순위 계산이 DB에 남아 있는 동안에는 `/ranking/me`의 상위권 유저 경로가 악화됩니다. `league_point`가 인덱스 키에 있으면 "나보다 위인 사람" 범위 탐색이 3페이지를 읽고 조기 종료하는데, 인덱스가 없으면 파티션 전체를 훑고 걸러내기 때문입니다.

| 경로 | 인덱스 있음 | 인덱스 없음 | 변화 |
|---|---|---|---:|
| 내 순위, 상위권 | 19 페이지 / 0.14 ms | 11,420 페이지 / 28.4 ms | **601배 악화** |
| 내 순위, 하위권 | 32,079 페이지 / 308 ms | 31,763 페이지 / 313 ms | 동일 |
| 랭킹 목록 | 51,146 페이지 / 297 ms | 51,146 페이지 / 298 ms | 동일 |
| 리그 히스토리 현재 순위 | 959,016 페이지 / 745 ms | 10,319 페이지 / 704 ms | 페이지 93배 개선, 시간 동일 |

악화되는 경로는 상위권 내 순위 조회 하나뿐이고, 나머지는 동일하거나 개선됩니다. 후속 Redis 이관 PR이 머지되면 순위 계산이 DB를 타지 않으므로 이 손실은 사라집니다. **후속 PR보다 이 PR이 먼저 배포되면 그 기간 동안 위 악화가 남습니다.** 배포 간격을 짧게 두는 것을 전제로 합니다.

위 조회 수치는 `ix_ul_league_user (league_id, user_id)`를 대체로 남긴 상태에서 측정한 값입니다. 이 PR은 대체 인덱스를 두지 않으므로 악화 폭은 최소 이 값이며, 대체 인덱스가 없는 상태의 조회는 직접 측정하지 않았습니다.

<br>

**측정 조건**

Postgres 15.18 컨테이너(shared_buffers 128 MB, work_mem 4 MB, CPU 14, autovacuum on)에서 로컬 측정했습니다. 데이터는 10만 및 100만(970,114명) 규모이고 LP 분포는 평균 300의 지수분포, 최대 파티션은 브론즈 3의 27,657명입니다. 쓰기는 pgbench로 c=1에서 32까지 올려 각 상태의 천장을 찾았고, 조회는 `EXPLAIN (ANALYZE, BUFFERS)`의 warm 값입니다. 로컬 측정이므로 처리량과 응답시간의 절대값은 하드웨어에 의존하며, 개선 판정은 같은 실행에서 상태를 번갈아 측정한 상태 간 배수로 했습니다. 산출물은 `benchmark/league-ranking/RESULTS.md`에 있습니다(로컬 전용, git 미추적).

<br>

## Related Issue
- #443 (인덱스 부분만 반영했습니다. 이슈 close는 후속 Redis 이관 PR에서 합니다)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **성능 개선**
  * 사용자별 리그 조회가 인덱스를 활용하도록 개선되어 `/ranking/me` 및 관련 조회 성능이 향상되었습니다.
  * 더 이상 사용되지 않는 순위 관련 인덱스를 제거해 데이터 변경 작업의 효율성을 높였습니다.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->