### PR TITLE
fix: 마이그레이션 버전 번호 충돌 해소(#443)

### DIFF
--- a/src/main/resources/db/migration/V35__add_user_league_user_id_index.sql
+++ b/src/main/resources/db/migration/V35__add_user_league_user_id_index.sql
@@ -1,4 +1,4 @@
--- V34__add_user_league_user_id_index.sql
+-- V35__add_user_league_user_id_index.sql
 
 -- LP 적립의 진입 조회(findByUserId)와 /ranking/me 가 user_id 로 행을 찾는데 인덱스가 없어
 -- 매번 테이블 전체를 훑고 있었다. 유저 100만 기준 쓰기 최대 TPS 315 → 32,100.

--- a/src/main/resources/db/migration/V36__drop_user_league_rank_index.sql
+++ b/src/main/resources/db/migration/V36__drop_user_league_rank_index.sql
@@ -1,4 +1,4 @@
--- V35__drop_user_league_rank_index.sql
+-- V36__drop_user_league_rank_index.sql
 
 -- 순위 계산이 Redis Sorted Set 으로 이관되어 이 인덱스를 읽는 쿼리가 남지 않는다.
 -- league_point 가 인덱스 키에 있어 LP 갱신마다 HOT update 를 막고 있었다(HOT 0% → 95.46%).


### PR DESCRIPTION
## PR Summary

`dev`에 V34 마이그레이션이 두 개 존재해 `flywayValidate`가 실패하고 있습니다. 유저 리그 인덱스 마이그레이션 두 개의 버전을 V35, V36으로 밀어 충돌을 해소했습니다.

<br>

## Problem

#477과 #478이 각각 다른 브랜치에서 V34를 잡은 채 9분 간격으로 머지되어, `dev`에 같은 버전의 마이그레이션이 두 개 남았습니다.

```
V34__add_wrong_answered_note_user_problem_unique_index.sql   (#477)
V34__add_user_league_user_id_index.sql                       (#478)
```

Flyway는 중복 버전을 허용하지 않으므로 `flywayValidate`가 `Found more than one migration with version 34`로 실패합니다. 빌드 단계에서 막히기 때문에 **현재 `dev`의 테스트 서버 배포가 전부 실패합니다.** #478 머지 직후 CD부터 실패하고 있습니다.

<br>

## Solution

충돌한 두 파일 중 **유저 리그 쪽(#478)의 버전을 밀었습니다.**

| 이전 | 이후 |
|---|---|
| `V34__add_user_league_user_id_index.sql` | `V35__add_user_league_user_id_index.sql` |
| `V35__drop_user_league_rank_index.sql` | `V36__drop_user_league_rank_index.sql` |

오답노트 쪽(#477)을 그대로 둔 이유는 **이미 적용된 마이그레이션이기 때문**입니다. #477 머지 직후의 CD는 성공했으므로 해당 V34는 테스트 서버 DB에 적용되고 체크섬이 기록된 상태입니다. 이 파일의 버전이나 내용을 바꾸면 Flyway 체크섬 검증이 깨집니다.

반대로 유저 리그 쪽은 `flywayValidate`가 `migrate` 이전에 실패했으므로 어느 DB에도 적용된 적이 없습니다. 버전을 바꿔도 기록과 어긋나지 않습니다.

이어지는 `V35__drop_user_league_rank_index.sql`도 함께 밀어 번호를 연속으로 유지했습니다. 두 파일 최상단의 파일명 주석도 새 버전에 맞췄습니다. 인덱스 정의와 실행 순서는 그대로입니다.

로컬에서 `./gradlew flywayValidate` 통과를 확인했습니다.

<br>

## Related Issue
- #443 (인덱스 마이그레이션 버전 정정입니다. 이슈 close는 후속 Redis 이관 PR에서 합니다)
