### PR TITLE
hotfix: 레슨 조회 응답에 챕터 정보 추가(#480)

### DIFF
--- a/.claude/resources/plans/PLAN-480.md
+++ b/.claude/resources/plans/PLAN-480.md
@@ -1,0 +1,113 @@
+# [PLAN-480] 레슨 조회 응답에 챕터 정보 추가
+
+> 이슈: #480
+> 브랜치: hotfix/480-lesson-chapter-info
+
+## 목표
+
+레슨 페이지 디자인이 변경되어 화면에 유닛이 속한 챕터명을 함께 보여줘야 한다.
+`GET /api/v1/lessons/{unitId}` 응답에 챕터의 id, title만 담은 중첩 객체 `chapterSummary`를 추가한다.
+
+## 영향 범위
+
+### 신규 파일
+
+- `src/main/java/gravit/code/chapter/dto/response/ChapterBriefResponse.java` — 챕터 id, title만 담는 응답 DTO
+
+### 수정 파일
+
+- `src/main/java/gravit/code/chapter/repository/ChapterRepository.java` — 유닛 아이디로 챕터 요약을 조회하는 쿼리 추가
+- `src/main/java/gravit/code/chapter/service/ChapterQueryService.java` — 위 쿼리를 호출하는 조회 메서드 추가
+- `src/main/java/gravit/code/lesson/dto/response/LessonDetailResponse.java` — `chapterSummary` 필드를 맨 앞에 추가
+- `src/main/java/gravit/code/lesson/facade/LessonFacade.java` — `ChapterQueryService` 주입, 챕터 조회 결과를 응답에 조합
+- `src/main/java/gravit/code/lesson/controller/LessonControllerDocs.java` — 레슨 목록 조회에 챕터 조회 실패 404 예시 추가
+- `src/test/java/gravit/code/lesson/facade/LessonFacadeUnitTest.java` — `ChapterQueryService` mock 추가, 챕터 필드 검증
+- `src/test/java/gravit/code/lesson/facade/LessonFacadeIntegrationTest.java` — 챕터 id, title 반환 검증
+- `src/test/java/gravit/code/chapter/service/ChapterQueryServiceIntegrationTest.java` — 유닛 기준 챕터 조회 성공, 실패 케이스 추가
+
+서비스 정책(`.claude/spec/service-policy/content.md`) 변경 없음. 응답 필드 추가일 뿐 판정 기준이나 구조 규칙은 그대로다.
+
+## 구현 계획
+
+1. **Entity / Flyway**: DB 변경 없음. `Unit.chapterId`가 이미 존재해 조인만으로 해결된다.
+
+2. **Repository**: `ChapterRepository.findChapterBriefByUnitId(long unitId)` → `Optional<ChapterBriefResponse>`
+
+   ```java
+   @Query("""
+       SELECT new gravit.code.chapter.dto.response.ChapterBriefResponse(c.id, c.title)
+       FROM Chapter c
+       JOIN Unit u ON u.chapterId = c.id
+       WHERE u.id = :unitId
+   """)
+   Optional<ChapterBriefResponse> findChapterBriefByUnitId(@Param("unitId") long unitId);
+   ```
+
+   반환 타입이 챕터 데이터이므로 `ChapterRepository`에 둔다. `UnitRepository.findRecommendedUnitsByIds`가 이미
+   `JOIN Chapter c ON c.id = u.chapterId` 형태를 쓰고 있어 조인 방식은 기존 패턴과 같다.
+
+3. **Service**: `ChapterQueryService.getChapterBriefByUnitId(long unitId)` → `ChapterBriefResponse`
+
+   ```java
+   @Transactional(readOnly = true)
+   public ChapterBriefResponse getChapterBriefByUnitId(long unitId) {
+       return chapterRepository.findChapterBriefByUnitId(unitId)
+               .orElseThrow(() -> new RestApiException(CustomErrorCode.CHAPTER_NOT_FOUND));
+   }
+   ```
+
+4. **Facade**: 필요함 — `LessonFacade`가 이미 여러 도메인 Service를 조합한다.
+   `ChapterQueryService`를 필드로 추가하고(`unitQueryService`와 같은 콘텐츠 도메인 그룹에 배치),
+   `getAllLessonInUnit`에서 유닛 조회 직후 챕터를 조회해 `LessonDetailResponse.create`에 넘긴다.
+
+   ```java
+   UnitSummaryResponse unitSummaryResponse = unitQueryService.getUnitSummaryByUnitId(unitId);
+
+   ChapterBriefResponse chapterSummary = chapterQueryService.getChapterBriefByUnitId(unitId);
+   ```
+
+   유닛 조회가 먼저이므로 없는 유닛은 `UNIT_NOT_FOUND`로 먼저 걸러진다.
+   요청당 쿼리는 4개에서 5개로 늘어난다. 챕터 PK 조인 단건 조회라 비용은 무시할 수준이다.
+
+5. **DTO**
+
+   - 신규 `ChapterBriefResponse(long chapterId, String title)` — `@Schema`는 `ChapterSummaryResponse`와 같은 표기를 쓴다.
+     이름은 기존 `ChapterSummaryResponse`(id, title, description)와 구분하기 위한 것이다.
+   - `LessonDetailResponse`에 `ChapterBriefResponse chapterSummary`를 **첫 번째 컴포넌트**로 추가한다.
+     JSON 필드 순서가 확정된 응답 형태와 같아진다.
+     `create(...)`의 파라미터도 같은 순서로 `chapterSummary`를 맨 앞에 추가한다.
+
+   ```json
+   {
+     "chapterSummary": { "chapterId": 3, "title": "자료구조" },
+     "unitSummaryResponse": { ... },
+     "bookmarkAccessible": true,
+     "wrongAnsweredNoteAccessible": true,
+     "unitId": 1,
+     "lessonSummaries": [ ... ]
+   }
+   ```
+
+6. **Controller**: `GET /api/v1/lessons/{unitId} → LessonController.getAllLessonInUnit` — 시그니처 변경 없음.
+   `LessonControllerDocs.getAllLessonInUnit`의 404 응답에 `CHAPTER_4041` 예시만 추가한다.
+
+## 결정 필요 (Decisions needed)
+
+- [x] 응답 형태 — 중첩 객체 `chapterSummary`(chapterId, title). 기존 `ChapterSummaryResponse` 재사용은
+      요청에 없는 `description`이 함께 나가므로 제외했다.
+- [x] 신규 DTO 이름 — `ChapterBriefResponse`. `ChapterSummaryResponse`가 이미 description을 포함해 이름을 나눴다.
+- [x] 챕터 조회 위치 — 별도 쿼리(`ChapterRepository`). 유닛 조회 쿼리에 챕터를 조인해 붙이면 쿼리 1개를 아끼지만
+      `UnitSummaryResponse` 반환 경로에 챕터 정보가 섞여 도메인 경계가 흐려진다. 핫픽스 범위에선 별도 조회를 택한다.
+
+## 검증
+
+- `LessonFacadeIntegrationTest.GetAllLessonInUnit` — 응답의 `chapterSummary().chapterId()`, `title()`이
+  저장한 챕터와 일치하는지 검증 추가
+- `LessonFacadeUnitTest.GetAllLessonInUnit` — `ChapterQueryService` mock 추가 후 챕터 필드 검증
+  (mock 미추가 시 `@InjectMocks`가 null을 주입해 NPE로 깨진다)
+- `ChapterQueryServiceIntegrationTest` — `@Nested GetChapterBriefByUnitId` 추가
+  - 유닛이 속한 챕터의 id, title을 반환한다
+  - 존재하지 않는 유닛이면 `CHAPTER_NOT_FOUND`를 던진다
+- 전체 확인: `./gradlew test`
+
+## Deviation Log

--- a/src/main/java/gravit/code/chapter/dto/response/ChapterBriefResponse.java
+++ b/src/main/java/gravit/code/chapter/dto/response/ChapterBriefResponse.java
@@ -1,0 +1,21 @@
+package gravit.code.chapter.dto.response;
+
+import io.swagger.v3.oas.annotations.media.Schema;
+
+public record ChapterBriefResponse(
+
+        @Schema(
+                description = "챕터 아이디",
+                example = "1",
+                requiredMode = Schema.RequiredMode.REQUIRED
+        )
+        long chapterId,
+
+        @Schema(
+                description = "챕터명",
+                example = "자료구조",
+                requiredMode = Schema.RequiredMode.REQUIRED
+        )
+        String title
+) {
+}

--- a/src/main/java/gravit/code/chapter/repository/ChapterRepository.java
+++ b/src/main/java/gravit/code/chapter/repository/ChapterRepository.java
@@ -1,6 +1,7 @@
 package gravit.code.chapter.repository;
 
 import gravit.code.chapter.domain.Chapter;
+import gravit.code.chapter.dto.response.ChapterBriefResponse;
 import gravit.code.chapter.dto.response.ChapterSummaryResponse;
 import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.data.jpa.repository.Query;
@@ -25,4 +26,12 @@ public interface ChapterRepository extends JpaRepository<Chapter, Long> {
         WHERE c.id = :chapterId
     """)
     Optional<ChapterSummaryResponse> findChapterSummaryByChapterId(@Param("chapterId") long chapterId);
+
+    @Query("""
+        SELECT new gravit.code.chapter.dto.response.ChapterBriefResponse(c.id, c.title)
+        FROM Chapter c
+        JOIN Unit u ON u.chapterId = c.id
+        WHERE u.id = :unitId
+    """)
+    Optional<ChapterBriefResponse> findChapterBriefByUnitId(@Param("unitId") long unitId);
 }

--- a/src/main/java/gravit/code/chapter/service/ChapterQueryService.java
+++ b/src/main/java/gravit/code/chapter/service/ChapterQueryService.java
@@ -1,6 +1,7 @@
 package gravit.code.chapter.service;
 
 import gravit.code.chapter.domain.Chapter;
+import gravit.code.chapter.dto.response.ChapterBriefResponse;
 import gravit.code.chapter.dto.response.ChapterSummaryResponse;
 import gravit.code.chapter.repository.ChapterRepository;
 import gravit.code.global.exception.domain.CustomErrorCode;
@@ -25,6 +26,12 @@ public class ChapterQueryService {
     @Transactional(readOnly = true)
     public ChapterSummaryResponse getChapterSummary(long chapterId) {
         return chapterRepository.findChapterSummaryByChapterId(chapterId)
+                .orElseThrow(() -> new RestApiException(CustomErrorCode.CHAPTER_NOT_FOUND));
+    }
+
+    @Transactional(readOnly = true)
+    public ChapterBriefResponse getChapterBriefByUnitId(long unitId) {
+        return chapterRepository.findChapterBriefByUnitId(unitId)
                 .orElseThrow(() -> new RestApiException(CustomErrorCode.CHAPTER_NOT_FOUND));
     }
 

--- a/src/main/java/gravit/code/lesson/controller/LessonControllerDocs.java
+++ b/src/main/java/gravit/code/lesson/controller/LessonControllerDocs.java
@@ -37,6 +37,16 @@ public interface LessonControllerDocs {
                                     )
                             },
                             schema = @Schema(implementation = ErrorResponse.class))
+            ),
+            @ApiResponse(responseCode = "404", description = "🚨 챕터 조회 실패",
+                    content = @Content(mediaType = MediaType.APPLICATION_JSON_VALUE,
+                            examples = {
+                                    @ExampleObject(
+                                            name = "챕터 조회 실패",
+                                            value = "{\"error\" : \"CHAPTER_4041\", \"message\" : \"챕터 조회에 실패하였습니다.\"}"
+                                    )
+                            },
+                            schema = @Schema(implementation = ErrorResponse.class))
             )
     })
     @GetMapping("/{unitId}")

--- a/src/main/java/gravit/code/lesson/dto/response/LessonDetailResponse.java
+++ b/src/main/java/gravit/code/lesson/dto/response/LessonDetailResponse.java
@@ -1,5 +1,6 @@
 package gravit.code.lesson.dto.response;
 
+import gravit.code.chapter.dto.response.ChapterBriefResponse;
 import gravit.code.unit.dto.response.UnitSummaryResponse;
 import io.swagger.v3.oas.annotations.media.Schema;
 import lombok.AccessLevel;
@@ -10,6 +11,12 @@ import java.util.List;
 @Builder(access = AccessLevel.PRIVATE)
 @Schema(description = "레슨 페이지 조회 Response")
 public record LessonDetailResponse(
+
+        @Schema(
+                description = "챕터 요약 정보",
+                requiredMode = Schema.RequiredMode.REQUIRED
+        )
+        ChapterBriefResponse chapterSummary,
 
         @Schema(
                 description = "유닛 요약 정보",
@@ -45,6 +52,7 @@ public record LessonDetailResponse(
         List<LessonSummaryResponse> lessonSummaries
 ) {
     public static LessonDetailResponse create(
+            ChapterBriefResponse chapterSummary,
             UnitSummaryResponse unitSummaryResponse,
             boolean bookmarkAccessible,
             boolean wrongAnsweredNoteAccessible,
@@ -52,6 +60,7 @@ public record LessonDetailResponse(
             List<LessonSummaryResponse> lessonSummaries
     ){
         return LessonDetailResponse.builder()
+                .chapterSummary(chapterSummary)
                 .unitSummaryResponse(unitSummaryResponse)
                 .bookmarkAccessible(bookmarkAccessible)
                 .wrongAnsweredNoteAccessible(wrongAnsweredNoteAccessible)

--- a/src/main/java/gravit/code/lesson/facade/LessonFacade.java
+++ b/src/main/java/gravit/code/lesson/facade/LessonFacade.java
@@ -1,6 +1,8 @@
 package gravit.code.lesson.facade;
 
 import gravit.code.bookmark.service.BookmarkService;
+import gravit.code.chapter.dto.response.ChapterBriefResponse;
+import gravit.code.chapter.service.ChapterQueryService;
 import gravit.code.global.annotation.Facade;
 import gravit.code.global.event.LessonCompletedEvent;
 import gravit.code.learning.dto.internal.ConsecutiveSolvedDto;
@@ -38,6 +40,7 @@ public class LessonFacade {
     private final LessonSubmissionCommandService lessonSubmissionCommandService;
     private final LessonSubmissionQueryService lessonSubmissionQueryService;
 
+    private final ChapterQueryService chapterQueryService;
     private final UnitQueryService unitQueryService;
     private final ProblemSubmissionCommandService problemSubmissionCommandService;
     private final WrongAnsweredNoteService wrongAnsweredNoteService;
@@ -57,12 +60,15 @@ public class LessonFacade {
     ) {
         UnitSummaryResponse unitSummaryResponse = unitQueryService.getUnitSummaryByUnitId(unitId);
 
+        ChapterBriefResponse chapterSummary = chapterQueryService.getChapterBriefByUnitId(unitId);
+
         List<LessonSummaryResponse> lessonSummaries = lessonQueryService.getAllLessonInUnit(userId, unitId);
 
         boolean bookmarkAccessible = bookmarkService.checkBookmarkedProblemExists(userId, unitId);
         boolean wrongAnsweredNoteAccessible = wrongAnsweredNoteService.checkWrongAnsweredProblemExists(userId, unitId);
 
         return LessonDetailResponse.create(
+                chapterSummary,
                 unitSummaryResponse,
                 bookmarkAccessible,
                 wrongAnsweredNoteAccessible,

--- a/src/test/java/gravit/code/chapter/service/ChapterQueryServiceIntegrationTest.java
+++ b/src/test/java/gravit/code/chapter/service/ChapterQueryServiceIntegrationTest.java
@@ -1,10 +1,13 @@
 package gravit.code.chapter.service;
 
 import gravit.code.chapter.domain.Chapter;
+import gravit.code.chapter.dto.response.ChapterBriefResponse;
 import gravit.code.chapter.dto.response.ChapterSummaryResponse;
 import gravit.code.chapter.repository.ChapterRepository;
 import gravit.code.global.exception.domain.RestApiException;
 import gravit.code.support.TCSpringBootTest;
+import gravit.code.unit.domain.Unit;
+import gravit.code.unit.repository.UnitRepository;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Nested;
 import org.junit.jupiter.api.Test;
@@ -25,6 +28,9 @@ class ChapterQueryServiceIntegrationTest {
 
     @Autowired
     private ChapterRepository chapterRepository;
+
+    @Autowired
+    private UnitRepository unitRepository;
 
     @Nested
     @DisplayName("전체 챕터를 조회할 때")
@@ -111,6 +117,36 @@ class ChapterQueryServiceIntegrationTest {
         void 존재하지_않으면_예외를_던진다() {
             // when & then
             assertThatThrownBy(() -> chapterQueryService.getChapter(999L))
+                    .isInstanceOf(RestApiException.class)
+                    .extracting(e -> ((RestApiException) e).getErrorCode())
+                    .isEqualTo(CHAPTER_NOT_FOUND);
+        }
+    }
+
+    @Nested
+    @DisplayName("유닛이 속한 챕터를 조회할 때")
+    class GetChapterBriefByUnitId {
+
+        @Test
+        void 챕터_아이디와_이름을_반환한다() {
+            // given
+            Chapter chapter = chapterRepository.save(Chapter.create("운영체제", "운영체제 기초 개념"));
+            Unit unit = unitRepository.save(Unit.create("프로세스", "프로세스 개념", chapter.getId()));
+
+            // when
+            ChapterBriefResponse result = chapterQueryService.getChapterBriefByUnitId(unit.getId());
+
+            // then
+            assertSoftly(softly -> {
+                softly.assertThat(result.chapterId()).isEqualTo(chapter.getId());
+                softly.assertThat(result.title()).isEqualTo("운영체제");
+            });
+        }
+
+        @Test
+        void 유닛이_존재하지_않으면_예외를_던진다() {
+            // when & then
+            assertThatThrownBy(() -> chapterQueryService.getChapterBriefByUnitId(999L))
                     .isInstanceOf(RestApiException.class)
                     .extracting(e -> ((RestApiException) e).getErrorCode())
                     .isEqualTo(CHAPTER_NOT_FOUND);

--- a/src/test/java/gravit/code/lesson/facade/LessonFacadeIntegrationTest.java
+++ b/src/test/java/gravit/code/lesson/facade/LessonFacadeIntegrationTest.java
@@ -79,6 +79,8 @@ class LessonFacadeIntegrationTest {
 
             // then
             assertSoftly(softly -> {
+                softly.assertThat(result.chapterSummary().chapterId()).isEqualTo(chapter.getId());
+                softly.assertThat(result.chapterSummary().title()).isEqualTo("운영체제");
                 softly.assertThat(result.unitSummaryResponse().title()).isEqualTo("프로세스");
                 softly.assertThat(result.lessonSummaries()).hasSize(2);
                 softly.assertThat(result.lessonSummaries().get(0).isSolved()).isTrue();

--- a/src/test/java/gravit/code/lesson/facade/LessonFacadeUnitTest.java
+++ b/src/test/java/gravit/code/lesson/facade/LessonFacadeUnitTest.java
@@ -1,6 +1,8 @@
 package gravit.code.lesson.facade;
 
 import gravit.code.bookmark.service.BookmarkService;
+import gravit.code.chapter.dto.response.ChapterBriefResponse;
+import gravit.code.chapter.service.ChapterQueryService;
 import gravit.code.global.event.LessonCompletedEvent;
 import gravit.code.learning.dto.internal.ConsecutiveSolvedDto;
 import gravit.code.learning.dto.internal.LearningIdsDto;
@@ -55,6 +57,9 @@ class LessonFacadeUnitTest {
     private LessonSubmissionQueryService lessonSubmissionQueryService;
 
     @Mock
+    private ChapterQueryService chapterQueryService;
+
+    @Mock
     private UnitQueryService unitQueryService;
 
     @Mock
@@ -87,11 +92,13 @@ class LessonFacadeUnitTest {
             // given
             long userId = 1L;
             long unitId = 1L;
+            ChapterBriefResponse chapterSummary = new ChapterBriefResponse(10L, "운영체제");
             UnitSummaryResponse unitSummaryResponse = new UnitSummaryResponse(unitId, "프로세스", "프로세스 개념");
             List<LessonSummaryResponse> lessons = List.of(
                     new LessonSummaryResponse(1L, "레슨1", 5, true)
             );
 
+            when(chapterQueryService.getChapterBriefByUnitId(unitId)).thenReturn(chapterSummary);
             when(unitQueryService.getUnitSummaryByUnitId(unitId)).thenReturn(unitSummaryResponse);
             when(lessonQueryService.getAllLessonInUnit(userId, unitId)).thenReturn(lessons);
             when(bookmarkService.checkBookmarkedProblemExists(userId, unitId)).thenReturn(true);
@@ -102,6 +109,8 @@ class LessonFacadeUnitTest {
 
             // then
             assertSoftly(softly -> {
+                softly.assertThat(result.chapterSummary().chapterId()).isEqualTo(10L);
+                softly.assertThat(result.chapterSummary().title()).isEqualTo("운영체제");
                 softly.assertThat(result.unitSummaryResponse().title()).isEqualTo("프로세스");
                 softly.assertThat(result.lessonSummaries()).hasSize(1);
                 softly.assertThat(result.bookmarkAccessible()).isTrue();
@@ -116,6 +125,7 @@ class LessonFacadeUnitTest {
             long unitId = 1L;
             UnitSummaryResponse unitSummaryResponse = new UnitSummaryResponse(unitId, "프로세스", "프로세스 개념");
 
+            when(chapterQueryService.getChapterBriefByUnitId(unitId)).thenReturn(new ChapterBriefResponse(10L, "운영체제"));
             when(unitQueryService.getUnitSummaryByUnitId(unitId)).thenReturn(unitSummaryResponse);
             when(lessonQueryService.getAllLessonInUnit(userId, unitId)).thenReturn(List.of());
             when(bookmarkService.checkBookmarkedProblemExists(userId, unitId)).thenReturn(false);


### PR DESCRIPTION
## PR Summary

레슨 목록 조회(`GET /api/v1/lessons/{unitId}`) 응답에 해당 유닛이 속한 챕터의 id와 title을 담은 `chapterSummary` 객체를 추가했습니다.

<br>

## Problem

레슨 페이지 디자인이 변경되면서 화면 상단에 유닛명과 함께 상위 챕터명을 노출해야 합니다. 그런데 기존 응답은 유닛 요약, 레슨 목록, 북마크와 오답노트 접근 여부만 담고 있어 챕터 정보를 얻을 방법이 없었습니다.

클라이언트가 이 상태로 화면을 구성하려면 챕터 조회 API를 별도로 한 번 더 호출해야 합니다. 레슨 페이지는 학습 진입 경로마다 열리는 화면이라 왕복이 한 번 늘어나는 비용이 그대로 체감됩니다.

<br>

## Solution

응답에 `chapterSummary` 중첩 객체를 추가해 챕터의 id와 title을 함께 내려줍니다. 기존 필드는 이름과 순서를 그대로 두고 새 필드만 앞에 붙였기 때문에 클라이언트의 기존 파싱은 영향을 받지 않습니다.

챕터 정보를 담을 DTO는 기존 `ChapterSummaryResponse`를 재사용하지 않고 id와 title만 가진 `ChapterBriefResponse`를 새로 만들었습니다. 기존 DTO에는 화면에서 쓰지 않는 `description`이 들어 있어, 재사용하면 필요 없는 필드가 응답에 함께 나가기 때문입니다.

조회는 `Unit.chapterId`를 조인하는 단건 쿼리로 `ChapterRepository`에 두고 `ChapterQueryService`에서 호출합니다. 유닛 조회 쿼리에 챕터를 함께 조인하면 요청당 쿼리를 하나 아낄 수 있지만, 유닛 조회 경로의 반환값에 챕터 정보가 섞여 도메인 경계가 흐려집니다. 추가되는 쿼리가 챕터 기본키 조인 단건이라 비용이 무시할 수준이므로, 조회 책임을 챕터 쪽에 그대로 두고 `LessonFacade`에서 조합하는 쪽을 택했습니다.

<br>

## Related Issue
- close #480


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **새로운 기능**
  * 단원별 레슨 조회 응답에 챕터 요약 정보가 추가되었습니다.
  * 챕터 ID와 챕터명이 함께 제공됩니다.

* **문서**
  * 챕터 조회 실패 시 발생하는 404 오류 응답 예시가 API 문서에 추가되었습니다.

* **테스트**
  * 챕터 요약 조회 및 단원별 레슨 응답에 포함되는 챕터 정보에 대한 검증이 강화되었습니다.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->