### PR TITLE
refactor: JWT 인증의 유저 중복 조회 제거(#483)

### DIFF
--- a/src/main/java/gravit/code/auth/service/AuthTokenProvider.java
+++ b/src/main/java/gravit/code/auth/service/AuthTokenProvider.java
@@ -60,8 +60,7 @@ public class AuthTokenProvider {
         jwtProvider.validateToken(token);
     }
 
-    public Authentication getAuthUser(String token){
-        User user = parseUser(token);
+    public Authentication getAuthUser(User user){
         return jwtProvider.getAuthentication(user);
     }
 

--- a/src/main/java/gravit/code/security/filter/JwtAuthFilter.java
+++ b/src/main/java/gravit/code/security/filter/JwtAuthFilter.java
@@ -5,6 +5,7 @@ import gravit.code.global.exception.domain.ErrorCode;
 import gravit.code.global.exception.domain.RestApiException;
 import gravit.code.security.exception.CustomAuthenticationEntryPoint;
 import gravit.code.security.exception.CustomAuthenticationException;
+import gravit.code.user.domain.User;
 import jakarta.servlet.FilterChain;
 import jakarta.servlet.ServletException;
 import jakarta.servlet.http.HttpServletRequest;
@@ -13,7 +14,6 @@ import lombok.NonNull;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.http.HttpMethod;
-import org.springframework.security.core.Authentication;
 import org.springframework.security.core.context.SecurityContextHolder;
 import org.springframework.web.filter.OncePerRequestFilter;
 
@@ -23,6 +23,8 @@ import java.util.List;
 @Slf4j
 @RequiredArgsConstructor
 public class JwtAuthFilter extends OncePerRequestFilter {
+
+    private static final String USER_ID_ATTRIBUTE = "user_id";
 
     private static final List<HttpEndpoint> EXCLUDE_ENDPOINTS = List.of(
             /* swagger */
@@ -75,11 +77,11 @@ public class JwtAuthFilter extends OncePerRequestFilter {
                 String jwtToken = token.substring(7);
 
                 authTokenProvider.validateToken(jwtToken);
-                Authentication authentication = authTokenProvider.getAuthUser(jwtToken);
-                SecurityContextHolder.getContext().setAuthentication(authentication);
 
-                Long userId = authTokenProvider.parseUser(jwtToken).getId();
-                request.setAttribute("user_id", userId);
+                User user = authTokenProvider.parseUser(jwtToken);
+                SecurityContextHolder.getContext().setAuthentication(authTokenProvider.getAuthUser(user));
+
+                request.setAttribute(USER_ID_ATTRIBUTE, user.getId());
 
                 log.info("[doFilterInternal] 토큰 값 검증 완료");
             }

--- a/src/test/java/gravit/code/auth/service/AuthTokenProviderIntegrationTest.java
+++ b/src/test/java/gravit/code/auth/service/AuthTokenProviderIntegrationTest.java
@@ -1,0 +1,135 @@
+package gravit.code.auth.service;
+
+import gravit.code.auth.domain.LoginUser;
+import gravit.code.auth.domain.Subject;
+import gravit.code.auth.token.JwtProvider;
+import gravit.code.global.exception.domain.RestApiException;
+import gravit.code.support.TCSpringBootTest;
+import gravit.code.user.domain.User;
+import gravit.code.user.fixture.UserFixture;
+import gravit.code.user.repository.UserRepository;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Nested;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.security.core.Authentication;
+
+import java.time.Duration;
+import java.util.Map;
+
+import static gravit.code.global.exception.domain.CustomErrorCode.USER_NOT_FOUND;
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static org.assertj.core.api.SoftAssertions.assertSoftly;
+
+@TCSpringBootTest
+class AuthTokenProviderIntegrationTest {
+
+    @Autowired
+    private AuthTokenProvider authTokenProvider;
+
+    @Autowired
+    private JwtProvider jwtProvider;
+
+    @Autowired
+    private UserRepository userRepository;
+
+    @Autowired
+    private UserFixture userFixture;
+
+    @Nested
+    @DisplayName("토큰에서 유저를 조회할 때")
+    class ParseUser {
+
+        @Test
+        void 토큰_주체에_해당하는_유저를_반환한다() {
+            // given
+            User user = userFixture.일반_유저(1);
+            String token = 토큰(user.getId());
+
+            // when
+            User parsed = authTokenProvider.parseUser(token);
+
+            // then
+            assertSoftly(softly -> {
+                softly.assertThat(parsed.getId()).isEqualTo(user.getId());
+                softly.assertThat(parsed.getProviderId()).isEqualTo(user.getProviderId());
+            });
+        }
+
+        @Test
+        void 존재하지_않는_유저이면_예외를_던진다() {
+            // given
+            String token = 토큰(9_999_999L);
+
+            // when & then
+            assertThatThrownBy(() -> authTokenProvider.parseUser(token))
+                    .isInstanceOf(RestApiException.class)
+                    .extracting(e -> ((RestApiException) e).getErrorCode())
+                    .isEqualTo(USER_NOT_FOUND);
+        }
+
+        @Test
+        void 탈퇴한_유저이면_예외를_던진다() {
+            // given
+            User user = userFixture.일반_유저(1);
+            String token = 토큰(user.getId());
+            userRepository.delete(user);
+
+            // when & then
+            assertThatThrownBy(() -> authTokenProvider.parseUser(token))
+                    .isInstanceOf(RestApiException.class)
+                    .extracting(e -> ((RestApiException) e).getErrorCode())
+                    .isEqualTo(USER_NOT_FOUND);
+        }
+    }
+
+    @Nested
+    @DisplayName("유저로 인증 객체를 만들 때")
+    class GetAuthUser {
+
+        @Test
+        void principal로_LoginUser를_담는다() {
+            // given
+            User user = userFixture.일반_유저(1);
+
+            // when
+            Authentication authentication = authTokenProvider.getAuthUser(user);
+
+            // then
+            assertSoftly(softly -> {
+                softly.assertThat(authentication.getPrincipal()).isInstanceOf(LoginUser.class);
+
+                LoginUser loginUser = (LoginUser) authentication.getPrincipal();
+                softly.assertThat(loginUser.getId()).isEqualTo(user.getId());
+                softly.assertThat(loginUser.getProvider()).isEqualTo(user.getProviderId());
+                softly.assertThat(loginUser.getAuthorities())
+                        .extracting("authority")
+                        .containsExactly("ROLE_" + user.getRole().name());
+            });
+        }
+
+        @Test
+        void 조회한_유저와_같은_id로_인증_객체를_만든다() {
+            // given
+            User user = userFixture.일반_유저(1);
+            String token = 토큰(user.getId());
+
+            // when
+            User parsed = authTokenProvider.parseUser(token);
+            Authentication authentication = authTokenProvider.getAuthUser(parsed);
+
+            // then
+            LoginUser loginUser = (LoginUser) authentication.getPrincipal();
+            assertThat(loginUser.getId()).isEqualTo(user.getId());
+        }
+    }
+
+    private String 토큰(long userId) {
+        return jwtProvider.generateToken(
+                new Subject(String.valueOf(userId)),
+                Map.of("role", "USER"),
+                Duration.ofMinutes(15)
+        );
+    }
+}

--- a/src/test/java/gravit/code/security/filter/JwtAuthFilterIntegrationTest.java
+++ b/src/test/java/gravit/code/security/filter/JwtAuthFilterIntegrationTest.java
@@ -1,0 +1,303 @@
+package gravit.code.security.filter;
+
+import gravit.code.auth.domain.LoginUser;
+import gravit.code.auth.domain.Subject;
+import gravit.code.auth.service.AuthTokenProvider;
+import gravit.code.auth.token.JwtProvider;
+import gravit.code.security.exception.CustomAuthenticationEntryPoint;
+import gravit.code.support.TCSpringBootTest;
+import gravit.code.user.domain.User;
+import gravit.code.user.fixture.UserFixture;
+import gravit.code.user.repository.UserRepository;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Nested;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.mock.web.MockFilterChain;
+import org.springframework.mock.web.MockHttpServletRequest;
+import org.springframework.mock.web.MockHttpServletResponse;
+import org.springframework.security.core.Authentication;
+import org.springframework.security.core.context.SecurityContextHolder;
+import org.springframework.test.context.bean.override.mockito.MockitoSpyBean;
+
+import java.time.Duration;
+import java.util.Map;
+
+import static gravit.code.global.exception.domain.CustomErrorCode.TOKEN_EXPIRED;
+import static gravit.code.global.exception.domain.CustomErrorCode.USER_NOT_FOUND;
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.SoftAssertions.assertSoftly;
+import static org.mockito.ArgumentMatchers.anyString;
+import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.times;
+import static org.mockito.Mockito.verify;
+
+@TCSpringBootTest
+class JwtAuthFilterIntegrationTest {
+
+    private static final String AUTHORIZATION_HEADER = "Authorization";
+    private static final String BEARER_PREFIX = "Bearer ";
+    private static final String USER_ID_ATTRIBUTE = "user_id";
+
+    private static final String PROTECTED_URI = "/api/v1/users/me";
+    private static final String EXCLUDED_URI = "/api/v1/version";
+
+    @MockitoSpyBean
+    private AuthTokenProvider authTokenProvider;
+
+    @Autowired
+    private CustomAuthenticationEntryPoint authenticationEntryPoint;
+
+    @Autowired
+    private JwtProvider jwtProvider;
+
+    @Autowired
+    private UserRepository userRepository;
+
+    @Autowired
+    private UserFixture userFixture;
+
+    private JwtAuthFilter jwtAuthFilter;
+
+    @BeforeEach
+    void setUp() {
+        jwtAuthFilter = new JwtAuthFilter(authTokenProvider, authenticationEntryPoint);
+    }
+
+    @AfterEach
+    void tearDown() {
+        SecurityContextHolder.clearContext();
+    }
+
+    @Nested
+    @DisplayName("유효한 토큰으로 인증할 때")
+    class ValidToken {
+
+        @Test
+        void 유저를_한_번만_조회한다() throws Exception {
+            // given
+            User user = userFixture.일반_유저(1);
+            String token = 유효한_토큰(user);
+
+            MockHttpServletRequest request = 인증_요청(PROTECTED_URI, token);
+            MockHttpServletResponse response = new MockHttpServletResponse();
+            MockFilterChain filterChain = new MockFilterChain();
+
+            // when
+            jwtAuthFilter.doFilter(request, response, filterChain);
+
+            // then
+            verify(authTokenProvider, times(1)).parseUser(token);
+        }
+
+        @Test
+        void principal에_토큰_주체와_같은_LoginUser를_담는다() throws Exception {
+            // given
+            User user = userFixture.일반_유저(1);
+            String token = 유효한_토큰(user);
+
+            MockHttpServletRequest request = 인증_요청(PROTECTED_URI, token);
+            MockHttpServletResponse response = new MockHttpServletResponse();
+            MockFilterChain filterChain = new MockFilterChain();
+
+            // when
+            jwtAuthFilter.doFilter(request, response, filterChain);
+
+            // then
+            Authentication authentication = SecurityContextHolder.getContext().getAuthentication();
+            assertSoftly(softly -> {
+                softly.assertThat(authentication).isNotNull();
+                softly.assertThat(authentication.getPrincipal()).isInstanceOf(LoginUser.class);
+
+                LoginUser loginUser = (LoginUser) authentication.getPrincipal();
+                softly.assertThat(loginUser.getId()).isEqualTo(user.getId());
+                softly.assertThat(loginUser.getProvider()).isEqualTo(user.getProviderId());
+                softly.assertThat(loginUser.getAuthorities())
+                        .extracting("authority")
+                        .containsExactly("ROLE_" + user.getRole().name());
+            });
+        }
+
+        @Test
+        void user_id_속성에_유저의_id를_담는다() throws Exception {
+            // given
+            User user = userFixture.일반_유저(1);
+            String token = 유효한_토큰(user);
+
+            MockHttpServletRequest request = 인증_요청(PROTECTED_URI, token);
+            MockHttpServletResponse response = new MockHttpServletResponse();
+            MockFilterChain filterChain = new MockFilterChain();
+
+            // when
+            jwtAuthFilter.doFilter(request, response, filterChain);
+
+            // then
+            assertThat(request.getAttribute(USER_ID_ATTRIBUTE)).isEqualTo(user.getId());
+        }
+
+        @Test
+        void 다음_필터로_요청을_넘긴다() throws Exception {
+            // given
+            User user = userFixture.일반_유저(1);
+            String token = 유효한_토큰(user);
+
+            MockHttpServletRequest request = 인증_요청(PROTECTED_URI, token);
+            MockHttpServletResponse response = new MockHttpServletResponse();
+            MockFilterChain filterChain = new MockFilterChain();
+
+            // when
+            jwtAuthFilter.doFilter(request, response, filterChain);
+
+            // then
+            assertThat(filterChain.getRequest()).isSameAs(request);
+        }
+    }
+
+    @Nested
+    @DisplayName("인증에 실패할 때")
+    class InvalidToken {
+
+        @Test
+        void 만료된_토큰이면_TOKEN_EXPIRED를_응답한다() throws Exception {
+            // given
+            User user = userFixture.일반_유저(1);
+            String token = 만료된_토큰(user);
+
+            MockHttpServletRequest request = 인증_요청(PROTECTED_URI, token);
+            MockHttpServletResponse response = new MockHttpServletResponse();
+            MockFilterChain filterChain = new MockFilterChain();
+
+            // when
+            jwtAuthFilter.doFilter(request, response, filterChain);
+
+            // then
+            String body = response.getContentAsString();
+            assertSoftly(softly -> {
+                softly.assertThat(response.getStatus()).isEqualTo(TOKEN_EXPIRED.getHttpStatus().value());
+                softly.assertThat(body).contains(TOKEN_EXPIRED.getCode());
+                softly.assertThat(filterChain.getRequest()).isNull();
+                softly.assertThat(SecurityContextHolder.getContext().getAuthentication()).isNull();
+            });
+        }
+
+        @Test
+        void 존재하지_않는_유저의_토큰이면_USER_NOT_FOUND를_응답한다() throws Exception {
+            // given
+            String token = 토큰(9_999_999L);
+
+            MockHttpServletRequest request = 인증_요청(PROTECTED_URI, token);
+            MockHttpServletResponse response = new MockHttpServletResponse();
+            MockFilterChain filterChain = new MockFilterChain();
+
+            // when
+            jwtAuthFilter.doFilter(request, response, filterChain);
+
+            // then
+            String body = response.getContentAsString();
+            assertSoftly(softly -> {
+                softly.assertThat(response.getStatus()).isEqualTo(USER_NOT_FOUND.getHttpStatus().value());
+                softly.assertThat(body).contains(USER_NOT_FOUND.getCode());
+                softly.assertThat(filterChain.getRequest()).isNull();
+                softly.assertThat(SecurityContextHolder.getContext().getAuthentication()).isNull();
+            });
+        }
+
+        @Test
+        void 탈퇴한_유저의_토큰이면_USER_NOT_FOUND를_응답한다() throws Exception {
+            // given
+            User user = userFixture.일반_유저(1);
+            String token = 유효한_토큰(user);
+            userRepository.delete(user);
+
+            MockHttpServletRequest request = 인증_요청(PROTECTED_URI, token);
+            MockHttpServletResponse response = new MockHttpServletResponse();
+            MockFilterChain filterChain = new MockFilterChain();
+
+            // when
+            jwtAuthFilter.doFilter(request, response, filterChain);
+
+            // then
+            String body = response.getContentAsString();
+            assertSoftly(softly -> {
+                softly.assertThat(response.getStatus()).isEqualTo(USER_NOT_FOUND.getHttpStatus().value());
+                softly.assertThat(body).contains(USER_NOT_FOUND.getCode());
+                softly.assertThat(SecurityContextHolder.getContext().getAuthentication()).isNull();
+            });
+        }
+    }
+
+    @Nested
+    @DisplayName("유저를 조회하지 않는 요청일 때")
+    class NoLookup {
+
+        @Test
+        void 인증_제외_경로이면_토큰이_있어도_조회하지_않는다() throws Exception {
+            // given
+            User user = userFixture.일반_유저(1);
+            String token = 유효한_토큰(user);
+
+            MockHttpServletRequest request = 인증_요청(EXCLUDED_URI, token);
+            MockHttpServletResponse response = new MockHttpServletResponse();
+            MockFilterChain filterChain = new MockFilterChain();
+
+            // when
+            jwtAuthFilter.doFilter(request, response, filterChain);
+
+            // then
+            verify(authTokenProvider, never()).parseUser(anyString());
+            assertSoftly(softly -> {
+                softly.assertThat(filterChain.getRequest()).isSameAs(request);
+                softly.assertThat(SecurityContextHolder.getContext().getAuthentication()).isNull();
+            });
+        }
+
+        @Test
+        void Authorization_헤더가_없으면_조회하지_않고_통과시킨다() throws Exception {
+            // given
+            MockHttpServletRequest request = new MockHttpServletRequest("GET", PROTECTED_URI);
+            MockHttpServletResponse response = new MockHttpServletResponse();
+            MockFilterChain filterChain = new MockFilterChain();
+
+            // when
+            jwtAuthFilter.doFilter(request, response, filterChain);
+
+            // then
+            verify(authTokenProvider, never()).parseUser(anyString());
+            assertSoftly(softly -> {
+                softly.assertThat(filterChain.getRequest()).isSameAs(request);
+                softly.assertThat(SecurityContextHolder.getContext().getAuthentication()).isNull();
+            });
+        }
+    }
+
+    private MockHttpServletRequest 인증_요청(
+            String uri,
+            String token
+    ) {
+        MockHttpServletRequest request = new MockHttpServletRequest("GET", uri);
+        request.addHeader(AUTHORIZATION_HEADER, BEARER_PREFIX + token);
+        return request;
+    }
+
+    private String 유효한_토큰(User user) {
+        return 토큰(user.getId());
+    }
+
+    private String 토큰(long userId) {
+        return jwtProvider.generateToken(
+                new Subject(String.valueOf(userId)),
+                Map.of("role", "USER"),
+                Duration.ofMinutes(15)
+        );
+    }
+
+    private String 만료된_토큰(User user) {
+        return jwtProvider.generateToken(
+                new Subject(String.valueOf(user.getId())),
+                Map.of("role", "USER"),
+                Duration.ofSeconds(-10)
+        );
+    }
+}


### PR DESCRIPTION
## PR Summary

JWT 인증 필터가 요청마다 같은 유저를 두 번 조회하던 것을 한 번으로 줄였습니다. 인증이 걸린 모든 API에 적용되는 변경입니다.

<br>

## Problem

`JwtAuthFilter`는 토큰을 검증한 뒤 두 가지 일을 합니다. SecurityContext에 인증 객체를 넣는 일과, 로깅에 쓰이는 `user_id` 요청 속성을 채우는 일입니다. 그런데 이 두 작업이 각각 유저를 조회하고 있었습니다. 인증 객체를 만드는 `getAuthUser`가 내부에서 `parseUser`를 호출하고, 속성을 채우는 쪽이 `parseUser`를 한 번 더 호출하는 구조였습니다.

두 경로 모두 `userRepository.findById`로 이어지므로 요청 한 건에 `users` PK 조회가 두 번 발생합니다. PLAN-443 부하 측정에서 관측된 요청당 2.03회가 이 중복과 정확히 일치합니다.

영향 범위가 특정 도메인에 그치지 않는다는 점이 문제였습니다. 이 필터는 인증이 필요한 모든 엔드포인트를 거치므로, 랭킹이든 학습이든 무관하게 전 API에 불필요한 조회가 한 번씩 얹혀 있었습니다.

부수적으로 두 조회는 서로 다른 인스턴스를 반환하기 때문에, 그 사이에 유저 정보가 바뀌면 인증 객체와 `user_id`가 서로 다른 시점의 값을 참조할 수 있었습니다.

<br>

## Solution

`getAuthUser`가 토큰 대신 이미 조회한 `User`를 받도록 시그니처를 바꿨습니다. 필터는 `parseUser`를 한 번만 호출하고, 그 결과를 인증 객체 생성과 `user_id` 속성에 함께 재사용합니다.

오버로드를 추가하지 않고 시그니처를 교체한 이유는 `getAuthUser(String)`의 호출처가 이 필터 한 곳뿐이었기 때문입니다. 토큰을 받는 형태를 남겨두면 그 자체가 중복 조회를 다시 부르는 경로로 남습니다. 반면 `parseUser(String)`은 토큰 재발급과 테스트 지원 코드에서도 쓰이므로 그대로 뒀습니다.

인증 결과의 형태는 바꾸지 않았습니다. `User`를 `LoginUser`로 변환하는 책임은 `JwtProvider`에 그대로 있고, SecurityContext에 저장되는 principal은 변경 전후 모두 `LoginUser`입니다. `user_id` 속성도 동일하게 `User.getId()`입니다. 이 PR이 줄인 것은 조회 횟수뿐입니다.

<br>

**요청당 `users` PK 조회 횟수**

| 구간 | Before | After | 변화 |
|---|---|---|---|
| JwtAuthFilter | 2 | 1 | -50% |
| GET /api/v1/users 전체 (SELECT 2 + UPDATE 1 포함) | 4 | 3 | -25% |

<br>

After 값은 로컬 기동 후 실제 요청 로그로 확인했습니다. 필터가 마지막에 남기는 완료 로그를 기준선으로 삼으면, 그 앞의 `users` SELECT가 변경 전 2건에서 1건으로 줄어든 것이 드러납니다. 남은 조회는 응답 본문을 만드는 컨트롤러의 조회와 마지막 접속 시각 갱신이며 이 PR의 범위가 아닙니다. **부하 테스트 재측정은 하지 않았으므로 p95, 처리량 같은 지표의 변화는 확인되지 않았습니다.**

<br>

리팩토링이 되돌아가지 않도록 통합 테스트를 붙였습니다. 필터를 `SecurityConfig`와 같은 방식으로 직접 생성해 요청을 흘려보내고, 유저 조회가 정확히 한 번 일어나는지 검증합니다. 함께 principal이 `LoginUser`이고 토큰 주체와 id가 일치하는지, 만료 토큰과 탈퇴, 미존재 유저의 에러 코드가 유지되는지, 인증 제외 경로에서는 조회가 아예 없는지를 고정했습니다. 중복 조회를 일부러 되살려 의도한 테스트만 실패하는 것도 확인했습니다.

<br>

## Related Issue
- close #483


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **개선 사항**
  - JWT 인증 처리 흐름을 개선해 인증된 사용자 정보를 보다 일관되게 전달합니다.
  - 인증 과정에서 사용자 ID가 요청 정보에 안정적으로 설정됩니다.
  - 만료되었거나 존재하지 않는 사용자 및 탈퇴한 사용자의 인증 요청을 적절히 처리합니다.
  - 인증이 필요 없는 경로와 인증 정보가 없는 요청은 불필요한 사용자 조회 없이 정상적으로 통과합니다.

- **테스트**
  - 정상·예외 인증 시나리오와 필터 동작에 대한 통합 테스트를 추가했습니다.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->