### PR TITLE
refactor: 랭킹 조회의 유저 존재 확인 중복 제거

### DIFF
--- a/src/main/java/gravit/code/friend/service/FriendService.java
+++ b/src/main/java/gravit/code/friend/service/FriendService.java
@@ -126,10 +126,6 @@ public class FriendService {
 
     @Transactional(readOnly = true)
     public FollowCountsResponse getFollowAndFollowingCounts(long userId){
-        if(!userRepository.existsById(userId)){
-            throw new RestApiException(CustomErrorCode.USER_NOT_FOUND);
-        }
-
         long followerCount = friendRepository.countByFolloweeId(userId);
         long followeeCount = friendRepository.countByFollowerId(userId);
 

--- a/src/main/java/gravit/code/userLeague/service/UserLeagueQueryService.java
+++ b/src/main/java/gravit/code/userLeague/service/UserLeagueQueryService.java
@@ -5,7 +5,6 @@ import gravit.code.global.exception.domain.CustomErrorCode;
 import gravit.code.global.exception.domain.RestApiException;
 import gravit.code.season.domain.SeasonStatus;
 import gravit.code.season.repository.SeasonRepository;
-import gravit.code.user.repository.UserRepository;
 import gravit.code.userLeague.dto.internal.LeagueRankEntry;
 import gravit.code.userLeague.dto.internal.LeagueRankProfileDto;
 import gravit.code.userLeague.dto.internal.LeagueRankRowDto;
@@ -32,7 +31,6 @@ public class UserLeagueQueryService {
     private static final int NEXT_PAGE_PROBE = 1;
     private static final int FIRST_PAGE = 0;
 
-    private final UserRepository userRepository;
     private final UserLeagueRepository userLeagueRepository;
     private final SeasonRepository seasonRepository;
 
@@ -40,10 +38,6 @@ public class UserLeagueQueryService {
 
     @Transactional(readOnly = true)
     public MyLeagueRankWithProfileResponse getMyLeagueRankWithProfile(long userId) {
-
-        if(!userRepository.existsById(userId)){
-            throw new RestApiException(CustomErrorCode.USER_NOT_FOUND);
-        }
 
         MyLeagueProfileDto profile = userLeagueRepository.findLeagueProfile(userId)
                 .orElseThrow(() -> new RestApiException(CustomErrorCode.USER_LEAGUE_NOT_FOUND));
@@ -76,10 +70,6 @@ public class UserLeagueQueryService {
             int page
     ){
         int safePage = Math.max(FIRST_PAGE, page);
-
-        if(!userRepository.existsById(userId)){
-            throw new RestApiException(CustomErrorCode.USER_NOT_FOUND);
-        }
 
         return userLeagueRepository.findLeagueProfile(userId)
                 .map(profile -> findRankingPage(profile.seasonId(), profile.leagueId(), safePage))

--- a/src/test/java/gravit/code/userLeague/service/UserLeagueQueryServiceIntegrationTest.java
+++ b/src/test/java/gravit/code/userLeague/service/UserLeagueQueryServiceIntegrationTest.java
@@ -19,7 +19,6 @@ import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
 
 import static gravit.code.global.exception.domain.CustomErrorCode.USER_LEAGUE_NOT_FOUND;
-import static gravit.code.global.exception.domain.CustomErrorCode.USER_NOT_FOUND;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
 import static org.assertj.core.api.SoftAssertions.assertSoftly;
@@ -75,7 +74,7 @@ class UserLeagueQueryServiceIntegrationTest {
         }
 
         @Test
-        void 존재하지_않는_유저이면_예외를_던진다() {
+        void 존재하지_않는_유저이면_리그_정보가_없다는_예외를_던진다() {
             // given
             long nonExistentUserId = 999L;
 
@@ -83,7 +82,7 @@ class UserLeagueQueryServiceIntegrationTest {
             assertThatThrownBy(() -> userLeagueQueryService.getMyLeagueRankWithProfile(nonExistentUserId))
                     .isInstanceOf(RestApiException.class)
                     .extracting(e -> ((RestApiException) e).getErrorCode())
-                    .isEqualTo(USER_NOT_FOUND);
+                    .isEqualTo(USER_LEAGUE_NOT_FOUND);
         }
 
         @Test
@@ -335,15 +334,18 @@ class UserLeagueQueryServiceIntegrationTest {
         }
 
         @Test
-        void 존재하지_않는_유저이면_예외를_던진다() {
+        void 존재하지_않는_유저이면_빈_페이지를_반환한다() {
             // given
             long nonExistentUserId = 999L;
 
-            // when & then
-            assertThatThrownBy(() -> userLeagueQueryService.findLeagueRankingByUser(nonExistentUserId, 0))
-                    .isInstanceOf(RestApiException.class)
-                    .extracting(e -> ((RestApiException) e).getErrorCode())
-                    .isEqualTo(USER_NOT_FOUND);
+            // when
+            SliceResponse<LeagueRankRowDto> result = userLeagueQueryService.findLeagueRankingByUser(nonExistentUserId, 0);
+
+            // then
+            assertSoftly(softly -> {
+                softly.assertThat(result.contents()).isEmpty();
+                softly.assertThat(result.hasNextPage()).isFalse();
+            });
         }
 
         @Test


### PR DESCRIPTION
## PR Summary

인증을 통과한 요청이 서비스 계층에서 같은 유저의 존재를 다시 확인하던 조회를 제거했습니다. 리그 랭킹 조회 두 곳과 팔로우 수 조회 한 곳이 대상입니다.

<br>

## Problem

`UserLeagueQueryService`의 랭킹 조회 두 메서드가 본문 첫 줄에서 `userRepository.existsById(userId)`로 유저 존재를 확인했습니다. 그런데 이 시점은 `JwtAuthFilter`가 같은 유저를 이미 조회해 인증을 통과시킨 뒤입니다. 인증을 통과했다는 사실 자체가 유저가 존재한다는 증거이므로, 이 확인은 같은 정보를 얻기 위한 두 번째 조회였습니다.

부하 측정에서 `select count(*) from users where id=?`가 요청당 0.50회로 관측됐습니다. 랭킹 관련 두 엔드포인트에서만 발생하는 값이라, 해당 요청 기준으로는 매번 한 번씩 실린 셈입니다.

이 확인이 실제로 무언가를 막아주려면 인증 주체가 아닌 유저의 id가 인자로 들어올 수 있어야 합니다. 호출 경로를 확인해 보니 세 곳 모두 `@AuthenticationPrincipal`에서 꺼낸 인증 주체의 id만 넘기고 있었습니다. 경로 변수나 요청 파라미터로 유저 id를 받는 경로는 없어, 존재하지 않는 유저의 id가 서비스까지 도달할 방법이 없었습니다.

<br>

## Solution

세 메서드에서 존재 확인 블록을 제거했습니다. 함께 판단하기로 했던 `FriendService`의 팔로우 수 조회도 같은 패턴이고 호출처가 인증 주체 하나뿐이라 포함했습니다. `UserLeagueQueryService`는 `UserRepository`를 이 확인에만 쓰고 있었으므로 의존성 자체를 걷어냈고, `FriendService`는 팔로우 대상 조회에서 계속 쓰기 때문에 남겼습니다.

응답 계약이 깨지지 않는 근거는 필터에 있습니다. `User` 엔티티에 `@SQLRestriction("deleted_at IS NULL")`이 걸려 있어 인증 단계의 조회가 탈퇴 유저를 동일하게 걸러내고, 그 경우 `AuthTokenProvider`가 `USER_NOT_FOUND`를 던집니다. `CustomAuthenticationEntryPoint`가 에러 코드의 상태값을 그대로 쓰므로, 존재하지 않거나 탈퇴한 유저는 서비스에 닿기 전에 같은 404 `USER_NOT_FOUND`를 받습니다.

<br>

**서비스 계층 계약 변화**

| 호출 | Before | After |
|---|---|---|
| `getMyLeagueRankWithProfile(없는 id)` | `USER_NOT_FOUND` | `USER_LEAGUE_NOT_FOUND` |
| `findLeagueRankingByUser(없는 id)` | `USER_NOT_FOUND` | 빈 페이지 반환 |

<br>

다만 서비스를 직접 호출할 때의 동작은 위 표처럼 달라집니다. HTTP 경로에서는 필터가 먼저 막기 때문에 관측되지 않지만, 계약이 바뀐 것은 사실이므로 이를 검증하던 기존 테스트 두 건을 새 계약에 맞춰 갱신했습니다.

바뀌지 않은 쪽이 더 중요합니다. "유저는 존재하지만 리그에 참여하지 않은" 경우는 이전과 동일하게 `USER_LEAGUE_NOT_FOUND`와 빈 결과를 냅니다. 이 경우를 검증하는 테스트 두 건이 수정 없이 통과하는 것으로 확인했습니다.

<br>

**요청당 `users` 존재 확인 조회 횟수**

| 대상 | Before | After | 변화 |
|---|---|---|---|
| 랭킹 조회 요청 | 0.50 | 0 | -100% |

<br>

Before는 PLAN-443 부하 측정값입니다. After는 코드 경로상 해당 쿼리가 사라진 것을 근거로 한 값이며, **부하 테스트 재측정은 하지 않았으므로 p95나 처리량 같은 지표의 변화는 확인되지 않았습니다.**

<br>

## Related Issue
- close #484
