### PR TITLE
refactor: 리그 이력 조회 인덱스 추가(#485)

### DIFF
--- a/src/main/resources/db/migration/V37__add_user_league_history_user_season_index.sql
+++ b/src/main/resources/db/migration/V37__add_user_league_history_user_season_index.sql
@@ -1,0 +1,17 @@
+-- V37__add_user_league_history_user_season_index.sql
+
+-- user_league_history에는 PK 인덱스만 있어 user_id로 행을 찾는 조회가 전부 풀스캔이었다.
+-- FK 제약이 걸려 있지만 PostgreSQL은 참조 측 컬럼에 인덱스를 만들어 주지 않는다.
+-- 시즌이 닫힐 때마다 유저 수만큼 행이 쌓이는 테이블이라(4개월 주기 기준 1년이면 유저당 3행)
+-- 방치하면 스캔 비용이 시즌 수에 비례해 커진다.
+--
+-- 선두 키는 등호 조건인 user_id다. 리그 이력 조회(findAllByUserIdOrderBySeason)가 user_id만으로 필터하므로
+-- 이 컬럼이 앞에 있어야 두 조회 형태를 하나의 인덱스로 받을 수 있다.
+-- season_id를 두 번째 키로 붙이는 이유는 리그 홈의 지난 시즌 팝업 판정이
+-- (user_id, season_id)로 존재 확인과 단건 조회를 연달아 하기 때문이다. 둘 다 등호 조건이라
+-- 선두 키만으로 좁힌 뒤 남는 행을 season_id로 바로 지목할 수 있다.
+--
+-- 정렬 키인 season.starts_at은 조인된 테이블의 컬럼이라 이 인덱스로 해소되지 않는다.
+-- 유저당 행 수가 시즌 수만큼이라 정렬 대상이 애초에 작으므로 컬럼을 더 늘리지 않는다.
+CREATE INDEX IF NOT EXISTS ix_user_league_history_user_season
+    ON user_league_history (user_id, season_id);


### PR DESCRIPTION
## PR Summary

`user_league_history`에 `(user_id, season_id)` 인덱스를 추가했습니다. 이 테이블을 읽는 세 조회가 모두 풀스캔이던 것을 인덱스 스캔으로 바꿉니다.

<br>

## Problem

`user_league_history`에는 PK 인덱스만 있었습니다. `user_id`에 FK 제약이 걸려 있지만 PostgreSQL은 참조 측 컬럼에 인덱스를 자동으로 만들어 주지 않기 때문에, `user_id`로 행을 찾는 조회는 전부 테이블을 통째로 훑고 있었습니다.

이 테이블을 읽는 경로는 세 곳입니다. 리그 이력 조회가 `user_id`만으로 필터하고, 리그 홈의 지난 시즌 팝업 판정이 `(user_id, season_id)`로 존재 확인과 단건 조회를 연달아 합니다. 팝업 판정은 리그 홈 진입 경로라 이력 조회보다 호출 빈도가 높습니다.

방치하면 비용이 계속 커지는 구조라는 점이 문제였습니다. 이 테이블은 시즌이 닫힐 때마다 유저 수만큼 행이 쌓입니다. 4개월 주기 기준으로 1년이면 유저당 3행이므로, 유저가 늘지 않아도 시즌 수에 비례해 스캔 대상이 증가합니다.

<br>

## Solution

`(user_id, season_id)` 복합 인덱스를 추가했습니다.

선두 키를 `user_id`로 둔 이유는 세 조회가 공통으로 쓰는 등호 조건이기 때문입니다. 이 컬럼이 앞에 있어야 `user_id`만 넘기는 이력 조회와 두 컬럼을 모두 넘기는 팝업 판정을 인덱스 하나로 함께 받을 수 있습니다. 반대 순서로 두면 이력 조회가 인덱스를 타지 못합니다.

`season_id`를 두 번째 키로 붙인 것은 팝업 판정 때문입니다. 두 조건 모두 등호이므로 선두 키로 한 유저의 행을 좁힌 뒤 남는 몇 행을 `season_id`로 바로 지목할 수 있습니다.

정렬 키인 `season.starts_at`은 조인된 테이블의 컬럼이라 이 인덱스로 해소되지 않습니다. 다만 유저당 행 수가 시즌 수만큼으로 애초에 작아 정렬 비용이 문제가 되지 않으므로, 커버링으로 컬럼을 더 싣지 않았습니다.

`(user_id, season_id)`를 UNIQUE로 만드는 안도 검토했습니다. 스냅샷 배치가 유저당 시즌당 한 행만 넣으므로 의미상 유일하고 중복 삽입을 막아주는 이점이 있지만, 운영 데이터에 이미 중복이 있으면 배포 시점에 마이그레이션이 실패합니다. 제약 변경은 이 PR의 범위를 넘어서므로 넣지 않았습니다.

<br>

**이력 조회** (`WHERE user_id = ?`, 30만 행 기준)

| 항목 | Before | After | 변화 |
|---|---|---|---|
| 실행 계획 | Parallel Seq Scan | Index Scan | - |
| 필터로 버린 행 | 99,999 (워커당) | 0 | - |
| buffers | 6,186 | 13 | -99.8% |
| 실행시간 | 13.972 ms | 0.073 ms | -99.5% |

<br>

**지난 시즌 팝업 판정** (`WHERE user_id = ? AND season_id = ?`, 30만 행 기준)

| 항목 | Before | After | 변화 |
|---|---|---|---|
| 실행 계획 | Parallel Seq Scan | Index Scan | - |
| buffers | 6,186 | 4 | -99.9% |
| 실행시간 | 9.491 ms | 0.006 ms | -99.9% |

<br>

측정은 로컬 컨테이너에 임시 데이터베이스를 만들어 `V1`부터 `V37`까지 순서대로 적용한 뒤, 10만 유저 곱하기 3시즌으로 30만 행을 넣고 `ANALYZE` 후 `EXPLAIN (ANALYZE, BUFFERS)`로 인덱스 유무를 비교한 값입니다. 두 쿼리 모두 `Index Cond`에 조건이 그대로 실리는 것을 확인했습니다. 실행시간은 로컬 하드웨어에 의존하므로 개선 판정은 실행 계획 전환과 buffers 감소로 했습니다. 100만 유저 300만 행 규모의 부하 테스트는 하지 않았습니다.

<br>

## Related Issue
- close #485
