### PR TITLE
refactor: 챕터, 유닛 조회 N+1 쿼리 제거(#490)

### DIFF
--- a/.claude/resources/perf/490/chapters/k6-test-summary-0.json
+++ b/.claude/resources/perf/490/chapters/k6-test-summary-0.json
@@ -1,0 +1,51 @@
+{
+  "phase": "measure",
+  "target": "chapters",
+  "endpoint": "GET /api/v1/chapters",
+  "condition": {
+    "vus": 50,
+    "steady_state_duration": "1m",
+    "ramp_up": "30s",
+    "ramp_down": "30s",
+    "total_duration": "2m",
+    "redis_cache": "cold",
+    "db_cache": "제어하지 않음",
+    "user_id_start": 1001,
+    "user_count": 1000,
+    "chapter_count": 5
+  },
+  "requests": 47680,
+  "rps": 397.0506729592537,
+  "failed_rate": 0,
+  "checks_rate": 1,
+  "checks": [
+    {
+      "name": "status is 200",
+      "passes": 47680,
+      "fails": 0
+    },
+    {
+      "name": "body is not empty",
+      "passes": 47680,
+      "fails": 0
+    },
+    {
+      "name": "chapterSummaryResponse가 실린 배열이다",
+      "passes": 47680,
+      "fails": 0
+    }
+  ],
+  "duration_ms": {
+    "med": 83.6445,
+    "p95": 189.25139999999993,
+    "p99": 463.67911999999995,
+    "max": 2033.209
+  },
+  "waiting_ms": {
+    "med": 83.503,
+    "p95": 188.96684999999977,
+    "p99": 463.3072699999999,
+    "max": 2033.037
+  },
+  "bytes_received": 49740376
+}

--- a/.claude/resources/perf/490/chapters/k6-test-summary-1.json
+++ b/.claude/resources/perf/490/chapters/k6-test-summary-1.json
@@ -1,0 +1,65 @@
+{
+  "phase": "measure",
+  "target": "chapters",
+  "endpoint": "GET /api/v1/chapters",
+  "condition": {
+    "vus": 50,
+    "steady_state_duration": "1m",
+    "ramp_up": "30s",
+    "ramp_down": "30s",
+    "total_duration": "2m",
+    "redis_cache": "cold",
+    "db_cache": "제어하지 않음",
+    "user_id_start": 1001,
+    "user_count": 1000,
+    "chapter_count": 5
+  },
+  "requests": 70715,
+  "rps": 589.2846296260478,
+  "failed_rate": 0,
+  "checks_rate": 1,
+  "checks": [
+    {
+      "name": "status is 200",
+      "passes": 70715,
+      "fails": 0
+    },
+    {
+      "name": "body is not empty",
+      "passes": 70715,
+      "fails": 0
+    },
+    {
+      "name": "chapterSummaryResponse가 실린 배열이다",
+      "passes": 70715,
+      "fails": 0
+    }
+  ],
+  "duration_ms": {
+    "med": 52.239,
+    "p95": 125.61419999999995,
+    "p99": 328.7562199999998,
+    "max": 1323.085
+  },
+  "waiting_ms": {
+    "med": 52.105,
+    "p95": 125.13229999999984,
+    "p99": 328.4942999999999,
+    "max": 1322.949
+  },
+  "bytes_received": 73770969,
+  "delta_vs_prev": {
+    "from": "k6-test-summary-0.json",
+    "requests": { "before": 47680, "after": 70715 },
+    "rps": { "before": 397.0506729592537, "after": 589.2846296260478 },
+    "duration_med_ms": { "before": 83.6445, "after": 52.239 },
+    "duration_p95_ms": { "before": 189.25139999999993, "after": 125.61419999999995 },
+    "duration_p99_ms": { "before": 463.67911999999995, "after": 328.7562199999998 },
+    "duration_max_ms": { "before": 2033.209, "after": 1323.085 },
+    "failed_rate": { "before": 0, "after": 0 },
+    "checks_rate": { "before": 1, "after": 1 },
+    "queries_per_request": { "before": 12.8459941275167785, "after": 4.0 },
+    "roundtrips_per_request": { "before": 15.846140939597315, "after": 7.000169695255604 },
+    "db_exec_ms_per_request": { "before": 2.2125210943372, "after": 1.3445919 }
+  }
+}

--- a/.claude/resources/perf/490/chapters/query-plan-0.txt
+++ b/.claude/resources/perf/490/chapters/query-plan-0.txt
@@ -1,0 +1,81 @@
+BEGIN
+                                                                                         QUERY PLAN                                                                                          
+---------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
+ Aggregate  (cost=25.38..25.39 rows=1 width=8) (actual time=16.945..16.960 rows=1 loops=1)
+   Output: count(DISTINCT l1_0.id)
+   Buffers: shared hit=16
+   ->  Hash Join  (cost=9.91..25.22 rows=62 width=8) (actual time=16.133..16.369 rows=78 loops=1)
+         Output: l1_0.id
+         Hash Cond: (ls1_0.lesson_id = l1_0.id)
+         Buffers: shared hit=13
+         ->  Index Only Scan using ix_lesson_submission_user_created_at on public.lesson_submission ls1_0  (cost=0.42..13.94 rows=315 width=8) (actual time=14.533..14.707 rows=317 loops=1)
+               Output: ls1_0.user_id, ls1_0.created_at, ls1_0.lesson_id
+               Index Cond: (ls1_0.user_id = 1500)
+               Heap Fetches: 0
+               Buffers: shared hit=8
+         ->  Hash  (cost=8.92..8.92 rows=45 width=8) (actual time=0.318..0.322 rows=26 loops=1)
+               Output: l1_0.id
+               Buckets: 1024  Batches: 1  Memory Usage: 10kB
+               Buffers: shared hit=5
+               ->  Hash Join  (cost=2.99..8.92 rows=45 width=8) (actual time=0.249..0.291 rows=26 loops=1)
+                     Output: l1_0.id
+                     Inner Unique: true
+                     Hash Cond: (l1_0.unit_id = u1_0.id)
+                     Buffers: shared hit=5
+                     ->  Seq Scan on public.lesson l1_0  (cost=0.00..5.30 rows=230 width=16) (actual time=0.030..0.051 rows=230 loops=1)
+                           Output: l1_0.id, l1_0.title, l1_0.unit_id
+                           Buffers: shared hit=3
+                     ->  Hash  (cost=2.83..2.83 rows=13 width=8) (actual time=0.070..0.072 rows=13 loops=1)
+                           Output: u1_0.id
+                           Buckets: 1024  Batches: 1  Memory Usage: 9kB
+                           Buffers: shared hit=2
+                           ->  Seq Scan on public.unit u1_0  (cost=0.00..2.83 rows=13 width=8) (actual time=0.028..0.033 rows=13 loops=1)
+                                 Output: u1_0.id
+                                 Filter: (u1_0.chapter_id = 900003)
+                                 Rows Removed by Filter: 53
+                                 Buffers: shared hit=2
+ Query Identifier: 8828981176344940178
+ Planning:
+   Buffers: shared hit=181
+ Planning Time: 302.770 ms
+ Execution Time: 17.879 ms
+(38 rows)
+
+                                                             QUERY PLAN                                                              
+-------------------------------------------------------------------------------------------------------------------------------------
+ Aggregate  (cost=10.55..10.56 rows=1 width=8) (actual time=0.209..0.211 rows=1 loops=1)
+   Output: count(l1_0.id)
+   Buffers: shared hit=6
+   ->  Nested Loop  (cost=2.99..10.44 rows=45 width=8) (actual time=0.178..0.201 rows=26 loops=1)
+         Output: l1_0.id
+         Buffers: shared hit=6
+         ->  Seq Scan on public.chapter c1_0  (cost=0.00..1.06 rows=1 width=8) (actual time=0.042..0.043 rows=1 loops=1)
+               Output: c1_0.id, c1_0.description, c1_0.title
+               Filter: (c1_0.id = 900003)
+               Rows Removed by Filter: 4
+               Buffers: shared hit=1
+         ->  Hash Join  (cost=2.99..8.92 rows=45 width=16) (actual time=0.127..0.146 rows=26 loops=1)
+               Output: u1_0.chapter_id, l1_0.id
+               Inner Unique: true
+               Hash Cond: (l1_0.unit_id = u1_0.id)
+               Buffers: shared hit=5
+               ->  Seq Scan on public.lesson l1_0  (cost=0.00..5.30 rows=230 width=16) (actual time=0.006..0.026 rows=230 loops=1)
+                     Output: l1_0.id, l1_0.title, l1_0.unit_id
+                     Buffers: shared hit=3
+               ->  Hash  (cost=2.83..2.83 rows=13 width=16) (actual time=0.037..0.038 rows=13 loops=1)
+                     Output: u1_0.chapter_id, u1_0.id
+                     Buckets: 1024  Batches: 1  Memory Usage: 9kB
+                     Buffers: shared hit=2
+                     ->  Seq Scan on public.unit u1_0  (cost=0.00..2.83 rows=13 width=16) (actual time=0.011..0.017 rows=13 loops=1)
+                           Output: u1_0.chapter_id, u1_0.id
+                           Filter: (u1_0.chapter_id = 900003)
+                           Rows Removed by Filter: 53
+                           Buffers: shared hit=2
+ Query Identifier: 2481107859088926393
+ Planning:
+   Buffers: shared hit=58
+ Planning Time: 109.802 ms
+ Execution Time: 0.293 ms
+(33 rows)
+
+ROLLBACK

--- a/.claude/resources/perf/490/chapters/query-plan-1.txt
+++ b/.claude/resources/perf/490/chapters/query-plan-1.txt
@@ -1,0 +1,61 @@
+BEGIN
+                                                                                                 QUERY PLAN                                                                                                  
+-------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
+ GroupAggregate  (cost=43.10..46.31 rows=5 width=24) (actual time=1.266..1.386 rows=5 loops=1)
+   Output: c1_0.id, count(DISTINCT l1_0.id), count(DISTINCT ls1_0.lesson_id)
+   Group Key: c1_0.id
+   Buffers: shared hit=17
+   ->  Sort  (cost=43.10..43.89 rows=316 width=24) (actual time=1.123..1.159 rows=430 loops=1)
+         Output: c1_0.id, l1_0.id, ls1_0.lesson_id
+         Sort Key: c1_0.id
+         Sort Method: quicksort  Memory: 51kB
+         Buffers: shared hit=17
+         ->  Hash Right Join  (cost=13.20..29.98 rows=316 width=24) (actual time=0.513..0.964 rows=430 loops=1)
+               Output: c1_0.id, l1_0.id, ls1_0.lesson_id
+               Inner Unique: true
+               Hash Cond: (u1_0.chapter_id = c1_0.id)
+               Buffers: shared hit=14
+               ->  Hash Right Join  (cost=12.08..27.34 rows=316 width=24) (actual time=0.479..0.788 rows=430 loops=1)
+                     Output: u1_0.chapter_id, l1_0.id, ls1_0.lesson_id
+                     Inner Unique: true
+                     Hash Cond: (l1_0.unit_id = u1_0.id)
+                     Buffers: shared hit=13
+                     ->  Hash Right Join  (cost=8.60..22.97 rows=316 width=24) (actual time=0.415..0.594 rows=430 loops=1)
+                           Output: l1_0.id, l1_0.unit_id, ls1_0.lesson_id
+                           Inner Unique: true
+                           Hash Cond: (ls1_0.lesson_id = l1_0.id)
+                           Buffers: shared hit=11
+                           ->  Index Only Scan using ix_lesson_submission_user_created_at on public.lesson_submission ls1_0  (cost=0.42..13.95 rows=316 width=8) (actual time=0.281..0.342 rows=317 loops=1)
+                                 Output: ls1_0.user_id, ls1_0.created_at, ls1_0.lesson_id
+                                 Index Cond: (ls1_0.user_id = 1500)
+                                 Heap Fetches: 0
+                                 Buffers: shared hit=8
+                           ->  Hash  (cost=5.30..5.30 rows=230 width=16) (actual time=0.105..0.106 rows=230 loops=1)
+                                 Output: l1_0.id, l1_0.unit_id
+                                 Buckets: 1024  Batches: 1  Memory Usage: 19kB
+                                 Buffers: shared hit=3
+                                 ->  Seq Scan on public.lesson l1_0  (cost=0.00..5.30 rows=230 width=16) (actual time=0.005..0.043 rows=230 loops=1)
+                                       Output: l1_0.id, l1_0.unit_id
+                                       Buffers: shared hit=3
+                     ->  Hash  (cost=2.66..2.66 rows=66 width=16) (actual time=0.038..0.038 rows=66 loops=1)
+                           Output: u1_0.chapter_id, u1_0.id
+                           Buckets: 1024  Batches: 1  Memory Usage: 12kB
+                           Buffers: shared hit=2
+                           ->  Seq Scan on public.unit u1_0  (cost=0.00..2.66 rows=66 width=16) (actual time=0.003..0.015 rows=66 loops=1)
+                                 Output: u1_0.chapter_id, u1_0.id
+                                 Buffers: shared hit=2
+               ->  Hash  (cost=1.05..1.05 rows=5 width=8) (actual time=0.012..0.013 rows=5 loops=1)
+                     Output: c1_0.id
+                     Buckets: 1024  Batches: 1  Memory Usage: 9kB
+                     Buffers: shared hit=1
+                     ->  Seq Scan on public.chapter c1_0  (cost=0.00..1.05 rows=5 width=8) (actual time=0.005..0.007 rows=5 loops=1)
+                           Output: c1_0.id
+                           Buffers: shared hit=1
+ Query Identifier: 2279778615240038781
+ Planning:
+   Buffers: shared hit=234
+ Planning Time: 3.518 ms
+ Execution Time: 1.653 ms
+(55 rows)
+
+ROLLBACK

--- a/.claude/resources/perf/490/chapters/query-stats-summary-0.md
+++ b/.claude/resources/perf/490/chapters/query-stats-summary-0.md
@@ -1,0 +1,54 @@
+# query-stats-summary-0 — chapters
+
+상태: 0 = 아무것도 적용하지 않은 원본
+측정: VU 50 / ramp-up 30s + 유지 1m + ramp-down 30s (총 2m) / Redis 캐시 cold, DB 캐시 제어하지 않음 / 요청 47680건
+직전 상태 대비: - (기준선)
+
+| # | 요청당 | calls | mean_ms | total_ms | 비중 | 행/호출 | 출처 | 하는 일 |
+|---|---|---|---|---|---|---|---|---|
+| 1 | 5.0000000000000000 | 238400 | 0.3010765931082263 | 71776.65979699792 | 68.03926064083532% | 1.00000000000000000000 | `LessonSubmissionRepository.countSolvedLessonByChapterIdAndUserId` | 유저가 해당 챕터에서 푼 서로 다른 레슨 수를 센다. `lesson_submission` → `lesson` → `unit` 조인 |
+| 2 | 4.8459941275167785 | 231057 | 0.12106246924351827 | 27972.33095600065 | 26.515816172413153% | 1.00000000000000000000 | `LessonRepository.countTotalLessonByChapterId` | 해당 챕터의 전체 레슨 수를 센다. `chapter` → `unit` → `lesson` 조인 |
+| 3 | 1.00000000000000000000 | 47680 | 0.0346105702390938 | 1650.231988999988 | 1.5643046741792022% | 1.00000000000000000000 | `UserRepository.findById` (`JwtAuthFilter:81` → `AuthTokenProvider.parseUser:70`) | 토큰의 userId로 유저 엔티티 전체 컬럼을 읽는다 |
+| 4 | 2.0000000000000000 | 95360 | 0.014380062709731602 | 1371.2827800000582 | 1.2998803057232198% | 0.000000000000000000000000 | - | 트랜잭션 제어 |
+| 5 | 1.00000000000000000000 | 47680 | 0.02805992363674482 | 1337.8971589999896 | 1.2682330686505523% | 5.0000000000000000 | `ChapterRepository.findAllChapterSummary` | 전체 챕터의 id, title, description을 읽는다. 조건 없음 |
+| 6 | 1.00000000000000000000 | 47680 | 0.02800730006291952 | 1335.388066999983 | 1.2658546246683007% | 0.000000000000000000000000 | `UserRepository.updateLastAccessedAt` (`LastAccessInterceptor:30` → `UserAccessService:25`) | 오늘 첫 접근이면 `last_accessed_at`을 갱신한다 |
+| 7 | 1.00014681208053691275 | 47687 | 0.0010244429089689107 | 48.852608999995724 | 0.04630886148974224% | 0.000000000000000000000000 | - | 트랜잭션 제어 |
+| 8 | 0.00014681208053691275 | 7 | 0.043167000000000004 | 0.302169 | 0.00028643510866523315% | `SeasonRepository.findCloseableActiveByNowForUpdate` (`SeasonBatchScheduler.tryQuarterlyRollover` → `SeasonBatchService:48`) | 만료된 ACTIVE 시즌을 잠금 조회한다. 로컬 `application.yml:104`가 cron을 `*/30 * * * * *`로 덮어써 30초마다 돈다. 대상 API와 무관 |
+| 9 | 0.00096476510067114094 | 46 | 0.0007137608695652174 | 0.032833000000000015 | 3.112339095938235e-05% | 0.00000000000000000000 | - | 트랜잭션 제어 |
+| 10 | 0.000041946308724832214765 | 2 | 0.012708500000000001 | 0.025417000000000002 | 2.4093540889185293e-05% | 0.00000000000000000000 | - | 트랜잭션 제어 |
+
+8번 행의 `행/호출`은 1차 출력에서 `0.00000000000000000000`이다.
+
+**요청당 집계**
+
+| 구분 | 값 |
+|---|---|
+| SQL 문 (1, 2, 3, 5, 6번) | 12.8459941275167785 |
+| SQL 문 + 배경 노이즈(8번) | 12.846140939597315 |
+| 트랜잭션 제어 (`BEGIN READ ONLY` 2 + `BEGIN` 1) | 3.00014681208053691275 |
+| 전체 SQL 실행시간 합 / 요청 수 | 105493.00377599859ms / 47680 = 2.2125210943372...ms |
+
+`BEGIN READ ONLY` 2건은 필터의 `UserRepository.findById`(Spring Data JPA 기본 `readOnly = true`)와
+파사드의 `@Transactional(readOnly = true)`, `BEGIN` 1건은 인터셉터의 UPDATE 트랜잭션이다.
+
+## 쿼리 원문
+
+[1] select count(distinct l1_0.id) from lesson_submission ls1_0 join lesson l1_0 on l1_0.id=ls1_0.lesson_id join unit u1_0 on u1_0.id=l1_0.unit_id where u1_0.chapter_id=$1 and ls1_0.user_id=$2
+
+[2] select count(l1_0.id) from chapter c1_0 join unit u1_0 on u1_0.chapter_id=c1_0.id join lesson l1_0 on l1_0.unit_id=u1_0.id where c1_0.id=$1
+
+[3] select u1_0.id,u1_0.created_at,u1_0.deleted_at,u1_0.email,u1_0.handle,u1_0.is_onboarded,u1_0.last_accessed_at,u1_0.level,u1_0.xp,u1_0.nickname,u1_0.profile_img_number,u1_0.provider_id,u1_0.role,u1_0.status,u1_0.updated_at from users u1_0 where u1_0.id=$1 and (u1_0.deleted_at IS NULL)
+
+[4] BEGIN READ ONLY
+
+[5] select c1_0.id,c1_0.title,c1_0.description from chapter c1_0
+
+[6] update users u1_0 set last_accessed_at=$1 where u1_0.id=$2 and (u1_0.last_accessed_at is null or u1_0.last_accessed_at<$3) and (u1_0.deleted_at IS NULL)
+
+[7] BEGIN
+
+[8] select s1_0.id,s1_0.ends_at,s1_0.season_key,s1_0.starts_at,s1_0.status,s1_0.tz from season s1_0 where s1_0.status=$2 and s1_0.ends_at<=$1 for no key update
+
+[9] COMMIT
+
+[10] ROLLBACK

--- a/.claude/resources/perf/490/chapters/query-stats-summary-1.md
+++ b/.claude/resources/perf/490/chapters/query-stats-summary-1.md
@@ -1,0 +1,68 @@
+# query-stats-summary-1 — chapters
+
+상태: 1 = 사이클 1 적용 후 (단일 집계 쿼리로 N+1 제거)
+측정: VU 50 / ramp-up 30s + 유지 1m + ramp-down 30s (총 2m) / Redis 캐시 cold, DB 캐시 제어하지 않음 / 요청 70715건
+직전 상태 대비: 요청당 SQL 12.8459941275167785 → 4.0 (왕복 15.85 → 7.00), 요청당 DB 실행시간 2.2125210943372ms → 1.3445919ms, `countSolvedLessonByChapterIdAndUserId`(238400회)와 `countTotalLessonByChapterId`(231057회)가 사라지고 `findChapterProgressByUserId`(70715회, 요청당 1회)가 새로 생김
+
+| # | 요청당 | calls | mean_ms | total_ms | 비중 | 행/호출 | 출처 | 하는 일 |
+|---|---|---|---|---|---|---|---|---|
+| 1 | 1.00000000000000000000 | 70715 | 1.1704637619882787 | 82769.34492900038 | 87.04973879038928% | 5.0000000000000000 | `ChapterRepository.findChapterProgressByUserId` | 전체 챕터의 총 레슨 수와 해당 유저가 푼 레슨 수를 챕터별로 한 번에 집계한다. `chapter` → `unit` → `lesson` → `lesson_submission` 3중 LEFT JOIN + `GROUP BY c.id` |
+| 2 | 1.00000000000000000000 | 70715 | 0.05074677653963104 | 3588.5583030000084 | 3.774139606616385% | 1.00000000000000000000 | `UserRepository.findById` (`JwtAuthFilter:81` → `AuthTokenProvider.parseUser:70`) | 토큰의 userId로 유저 엔티티 전체 컬럼을 읽는다 |
+| 3 | 2.0000000000000000 | 141430 | 0.024559445025807813 | 3473.4423099999685 | 3.653070421764848% | 0.000000000000000000000000 | - | 트랜잭션 제어 |
+| 4 | 1.00000000000000000000 | 70715 | 0.03902106241957194 | 2759.3744290000354 | 2.902074717099415% | 0.000000000000000000000000 | `UserRepository.updateLastAccessedAt` (`LastAccessInterceptor:30` → `UserAccessService:25`) | 오늘 첫 접근이면 `last_accessed_at`을 갱신한다 |
+| 5 | 1.00000000000000000000 | 70715 | 0.03405632865728632 | 2408.293280999967 | 2.5328375042901112% | 5.0000000000000000 | `ChapterRepository.findAllChapterSummary` | 전체 챕터의 id, title, description을 읽는다. 조건 없음 |
+| 6 | 1.00008484762780173938 | 70721 | 0.001181764864750203 | 83.57559300000038 | 0.08789768175817536% | 0.000000000000000000000000 | - | 트랜잭션 제어 |
+| 7 | 0.000084847627801739376370 | 6 | 0.03252083333333333 | 0.195125 | 0.00020521583559764736% | 0.00000000000000000000 | `SeasonRepository.findCloseableActiveByNowForUpdate` (`SeasonBatchScheduler.tryQuarterlyRollover` → `SeasonBatchService:48`) | 만료된 ACTIVE 시즌을 잠금 조회한다. 로컬 `application.yml:104`가 cron을 `*/30 * * * * *`로 덮어써 30초마다 돈다. 대상 API와 무관 |
+| 8 | 0.00063635720851304532 | 45 | 0.0007258666666666668 | 0.03266400000000001 | 3.4353209757650513e-05% | 0.00000000000000000000 | - | 트랜잭션 제어 |
+| 9 | 0.000028282542600579792123 | 2 | 0.0008125 | 0.001625 | 1.709036427142483e-06% | 0.00000000000000000000 | - | 트랜잭션 제어 |
+
+7번 행의 `행/호출`은 1차 출력에서 `0.00000000000000000000`이다.
+
+**사라진 쿼리**
+
+| 출처 | 상태 0에서의 값 |
+|---|---|
+| `LessonSubmissionRepository.countSolvedLessonByChapterIdAndUserId` | 요청당 5.0000000000000000회, calls 238400, mean 0.3010765931082263ms, total 71776.65979699792ms (비중 68.03926064083532%) |
+| `LessonRepository.countTotalLessonByChapterId` | 요청당 4.8459941275167785회, calls 231057, mean 0.12106246924351827ms, total 27972.33095600065ms (비중 26.515816172413153%) |
+
+두 메서드 자체는 코드에 남아 있다(`LearningFacade:48`, `UserFacade:118`이 단건으로 호출).
+이 부하 시나리오가 그 경로를 타지 않아 통계에 나타나지 않는다.
+
+**새로 생긴 쿼리**
+
+| 출처 | 값 |
+|---|---|
+| `ChapterRepository.findChapterProgressByUserId` | 요청당 1.00000000000000000000회, calls 70715, mean 1.1704637619882787ms, total 82769.34492900038ms (비중 87.04973879038928%) |
+
+**요청당 집계**
+
+| 구분 | 상태 0 | 상태 1 |
+|---|---|---|
+| SQL 문 | 12.8459941275167785 | 4.0 |
+| SQL 문 + 배경 노이즈 | 12.846140939597315 | 4.000084847627802 |
+| 트랜잭션 제어 (`BEGIN READ ONLY` 2 + `BEGIN` 1) | 3.00014681208053691275 | 3.00008484762780173938 |
+| 왕복 합계 | 15.85 | 7.00 |
+| 전체 SQL 실행시간 합 / 요청 수 | 105493.00377599859 / 47680 = 2.2125210943372ms | 95082.81825900036 / 70715 = 1.3445919ms |
+
+트랜잭션 구성은 변하지 않았다. `BEGIN READ ONLY` 2건은 필터의 `UserRepository.findById`와 파사드의
+`@Transactional(readOnly = true)`, `BEGIN` 1건은 인터셉터의 UPDATE 트랜잭션이다.
+
+## 쿼리 원문
+
+[1] select c1_0.id,count(distinct l1_0.id),count(distinct ls1_0.lesson_id) from chapter c1_0 left join unit u1_0 on u1_0.chapter_id=c1_0.id left join lesson l1_0 on l1_0.unit_id=u1_0.id left join lesson_submission ls1_0 on ls1_0.lesson_id=l1_0.id and ls1_0.user_id=$1 group by c1_0.id
+
+[2] select u1_0.id,u1_0.created_at,u1_0.deleted_at,u1_0.email,u1_0.handle,u1_0.is_onboarded,u1_0.last_accessed_at,u1_0.level,u1_0.xp,u1_0.nickname,u1_0.profile_img_number,u1_0.provider_id,u1_0.role,u1_0.status,u1_0.updated_at from users u1_0 where u1_0.id=$1 and (u1_0.deleted_at IS NULL)
+
+[3] BEGIN READ ONLY
+
+[4] update users u1_0 set last_accessed_at=$1 where u1_0.id=$2 and (u1_0.last_accessed_at is null or u1_0.last_accessed_at<$3) and (u1_0.deleted_at IS NULL)
+
+[5] select c1_0.id,c1_0.title,c1_0.description from chapter c1_0
+
+[6] BEGIN
+
+[7] select s1_0.id,s1_0.ends_at,s1_0.season_key,s1_0.starts_at,s1_0.status,s1_0.tz from season s1_0 where s1_0.status=$2 and s1_0.ends_at<=$1 for no key update
+
+[8] COMMIT
+
+[9] ROLLBACK

--- a/.claude/resources/perf/490/chapters/record.md
+++ b/.claude/resources/perf/490/chapters/record.md
@@ -1,0 +1,385 @@
+# [PERF-490] GET /api/v1/chapters
+
+> 이슈: #490
+> 브랜치: refactor/490-chapter-unit-query-performance
+> 대상 디렉토리: `.claude/resources/perf/490/chapters/`
+
+이 파일은 대상 엔드포인트 하나만 다룬다. 같은 이슈의 다른 엔드포인트는 각자의 디렉토리에 각자의 `record.md`를 가진다.
+
+## 진행 상태
+
+> ⏳ 미완 / ✅ 완료 / ⏭️ 건너뜀
+> 재진입 시 ⏳로 표기된 가장 이른 Phase부터 재개한다.
+
+**준비 (대상당 1회)**
+
+| 1. 대상 | 2. 환경 | 3. 조건 | 4. 기준선 |
+|---|---|---|---|
+| ✅ | ✅ | ✅ | ✅ |
+
+**사이클 (반복)**
+
+| # | 기법 | 5. 설계 | 6. 스냅샷 | 7. 적용 | 8. 검증 |
+|---|---|---|---|---|---|
+| 1 | 단일 집계 쿼리로 N+1 제거 | ✅ | ✅ | ✅ | ✅ |
+
+## 대상
+
+- 엔드포인트: `GET /api/v1/chapters`
+- 실행 경로: `ChapterController.getAllChapter` → `ChapterFacade.getAllChapter` → (`ChapterQueryService`, `LearningProgressRateService`) → (`ChapterRepository`, `LessonSubmissionRepository`, `LessonRepository`)
+- 트랜잭션 경계: `open-in-view: false`. 요청 1회가 트랜잭션 3개로 쪼개진다 - 필터의 SELECT, 인터셉터의 UPDATE, 파사드의 `@Transactional(readOnly = true)`
+- 예상 쿼리 목록 (요청 1회 기준, `n` = 전체 챕터 수, `k` = 그중 제출 이력이 0건인 챕터 수, `0 <= k <= n`)
+
+  **API 밖 (필터, 인터셉터)**
+  1. `UserRepository.findById` - SELECT. `JwtAuthFilter:81` → `AuthTokenProvider.parseUser:70`. 1회
+  2. `UserRepository.updateLastAccessedAt` - `@Modifying` 벌크 UPDATE. `LastAccessInterceptor:30` → `UserAccessService:25`.
+     `WHERE ... lastAccessedAt < :startOfToday` 조건에 걸리지 않아도 쿼리 자체는 나간다. 1회
+
+  **파사드 (`ChapterFacade:21~35`)**
+  3. `ChapterRepository.findAllChapterSummary` - `FROM Chapter c`, 조건 없는 전체 조회. 1회
+  4. `LessonSubmissionRepository.countSolvedLessonByChapterIdAndUserId` - `COUNT(DISTINCT l.id)`, `LessonSubmission` JOIN `Lesson` JOIN `Unit`. 챕터마다 1회, 총 `n`회
+  5. `LessonRepository.countTotalLessonByChapterId` - `COUNT(l.id)`, `Chapter` JOIN `Unit` JOIN `Lesson`. `solvedLessonCount == 0`이면 조기 반환(`LearningProgressRateService:23~25`)이라 건너뛴다. 총 `n - k`회
+
+  **합계: `3 + 2n - k`** (하한 `3 + n`, 상한 `3 + 2n`)
+
+  지연 로딩 지점 없음. 세 파사드 쿼리 모두 record projection 또는 스칼라 카운트라 엔티티를 적재하지 않는다.
+
+## 측정 환경
+
+> 값이 바뀌면 그 사실을 사이클 기록에 남긴다.
+
+| 항목 | 값 |
+|---|---|
+| 프로파일 | perf (`application="gravit-perf"` 확인) |
+| 커넥션 풀 크기 | 60 (`application-perf.yml:17` `maximum-pool-size`) |
+| 데이터 규모 | `users` 1,002 / `chapter` 5 / `unit` 66 / `lesson` 230 / `lesson_submission` 317,300. 현재 규모 유지로 확정, 시드 미사용 |
+| 카디널리티 | `lesson_submission.user_id` 1,000 / `lesson_submission.lesson_id` 148 (`lesson` 230개 중 82개는 제출 이력 없음). `unit.chapter_id` 5 / `lesson.unit_id` 66 (`units` 대상에서 측정, 행 수가 그대로라 유효) |
+| 부하 조건 | VU 50. ramp-up 30s + 유지 1m + ramp-down 30s = 총 2m. 이슈 472, 475, 490-units와 동일 조건 |
+| Redis 캐시 상태 | cold (measure 직전 FLUSHDB) |
+| DB 캐시 상태 | 제어하지 않음. Redis FLUSHDB는 PostgreSQL의 `shared_buffers`와 OS page cache를 비우지 않는다. 둘을 묶어 cold라고 적지 마라 |
+| 캐시 제어 수단 | `redis-cli -h localhost -p 6379` (PONG 확인) |
+| 시드 SQL | 미사용 (현재 규모로 진행) |
+| 시드 모듈과 변수 | - |
+| 유저 범위 | `USER_ID_START=1001`, `USER_COUNT=1000`. `lesson_submission`의 distinct user 1,000과 일치 |
+| chapterId 분산 | 없음. 이 API는 경로 변수 없이 전체 챕터(900001~900005)를 매 요청에 훑는다 |
+
+**챕터별 레슨 수 (편중)**
+
+| chapter_id | lesson_count |
+|---|---|
+| 900001 | 126 |
+| 900002 | 26 |
+| 900003 | 26 |
+| 900004 | 26 |
+| 900005 | 26 |
+
+챕터 하나가 전체 레슨 230개의 55%를 갖는다. `countTotalLessonByChapterId`와
+`countSolvedLessonByChapterIdAndUserId`의 챕터별 비용이 균등하지 않다.
+
+**요청당 쿼리 수 (Phase 1 예측을 실측 분포로 확정)**
+
+`n`(전체 챕터 수) = 5로 고정. `k`(제출 이력 0건인 챕터 수)만 유저마다 다르다.
+
+| 제출 이력 있는 챕터 수 | 유저 수 | `k` | 요청당 쿼리 (`3 + 2n - k`) |
+|---|---|---|---|
+| 4 | 154 | 1 | 12 |
+| 5 | 846 | 0 | 13 |
+
+가중 평균 **12.85**. 유저 1,000명을 균등 순회하므로 이 값이 요청당 기대치다.
+조기 반환(`LearningProgressRateService:23~25`)은 154명에게 챕터 1개씩만 걸려 거의 작동하지 않는다.
+Phase 4의 실측으로 확정한다.
+
+**데이터 규모 판단 (호출자 확정)**
+
+`chapter` 5행을 목표 규모로 확정했다. 운영 실제 콘텐츠 규모이고 `units` 대상과 동일 조건이라 이슈 내 비교가 가능하다.
+증설안(20행)은 N+1 기울기를 4배로 키우지만 `unit`·`lesson`·`lesson_submission` 동반 시드가 필요하고
+`units` 대상과 조건이 어긋나 배제했다.
+
+**Phase 2 게이트 통과 기록**
+
+| 검증 항목 | 관측값 |
+|---|---|
+| perf 프로파일 기동 | `application="gravit-perf"` |
+| actuator health | 200 |
+| 응답시간 히스토그램 버킷 수 | 146 |
+| `pg_stat_statements` | 47행 (살아있음) |
+| Redis 캐시 제어 | PONG |
+
+`units` 대상 Phase 7 적용 후 애플리케이션을 재기동했으므로 Skip 조건이 성립하지 않아 게이트를 다시 통과시켰다.
+관측값은 `units` 때와 동일하다.
+
+## 기준선 (Baseline)
+
+| 지표 | 값 |
+|---|---|
+| p95 | 189.25139999999993 ms |
+| p99 | 463.67911999999995 ms |
+| med | 83.6445 ms |
+| max | 2033.209 ms |
+| RPS | 397.0506729592537 (요청 47,680건) |
+| 에러율 | 0 |
+| check 통과율 | 1 (세 항목 모두 47,680 통과 / 0 실패) |
+| 요청당 쿼리 수 | SQL 12.8459941275167785 + 트랜잭션 제어 3.00014681208053691275 = 왕복 15.85회 |
+| 요청당 DB 실행시간 | 105493.00377599859ms / 47680 = 2.2125 ms |
+
+`waiting_ms` med 83.503 / `duration_ms` med 83.6445. 전송 시간은 무시할 수준이고 전부 서버 대기다.
+
+### 쿼리 통계 (total_exec_time 상위)
+
+> 전체: `query-stats-summary-0.md` / k6 요약: `k6-test-summary-0.json`
+> 여기에는 진단 근거로 쓴 행만 옮긴다. 전체를 복사하지 않는다.
+
+| 요청당 | mean_ms | total_ms | 비중 | 출처 |
+|---|---|---|---|---|
+| 5.0000000000000000 | 0.3010765931082263 | 71776.65979699792 | 68.03926064083532% | `LessonSubmissionRepository.countSolvedLessonByChapterIdAndUserId` |
+| 4.8459941275167785 | 0.12106246924351827 | 27972.33095600065 | 26.515816172413153% | `LessonRepository.countTotalLessonByChapterId` |
+
+상위 2개가 DB 실행시간의 94.55507681324847%를 차지한다. 배경 노이즈는
+`SeasonRepository.findCloseableActiveByNowForUpdate` 7회(비중 0.00028643510866523315%)뿐이다.
+로컬 `application.yml:104`가 시즌 롤오버 cron을 `*/30 * * * * *`로 덮어써 30초마다 도는 것으로, 대상 API와 무관하다.
+
+### 진단
+
+- 병목 성격: **N+1**. 요청당 상호작용 횟수가 비용을 지배한다. 개별 쿼리의 실행시간 문제가 아니다
+- 근거
+  - 상위 2개 쿼리의 mean은 0.3010765931082263ms, 0.12106246924351827ms로 개별 실행은 빠르다.
+    그럼에도 DB 실행시간의 94.56%를 차지하는 이유는 호출 수(238,400회, 231,057회)뿐이다
+  - 요청당 DB 실행시간 2.2125ms 대 med 응답시간 83.6445ms. 격차 81.43ms를 왕복 15.85회로 나누면 왕복당 5.14ms다.
+    loopback RTT(통상 0.05~0.2ms)로 설명되지 않으므로, 순수 네트워크 지연이 아니라
+    왕복마다 붙는 처리비용(JDBC 직렬화, Hibernate 세션, `total_exec_time`에 잡히지 않는 PG 파싱·프로토콜)에
+    50 VU 동시성의 대기가 얹힌 값이다
+  - 동시성 몫 분리 (Little의 법칙, warmup은 JIT 미완이라 참고용 교차검증):
+    5 VU에서 173 RPS → 평균 응답 28.9ms, 왕복당 1.82ms.
+    measure의 평균 동시성 37.5 VU에서 397 RPS → 평균 응답 94.4ms, 왕복당 5.3ms.
+    경합이 거의 없는 5 VU에서도 DB 실행 2.2ms짜리 요청이 28.9ms 걸린다.
+    나머지 26.7ms가 왕복 15.85회에 붙는 고정비고, 동시성이 오르면 약 3배로 증폭된다
+  - 따라서 왕복 횟수를 줄이면 고정비와 증폭분이 함께 줄어든다
+- 예상 쿼리 목록과 어긋난 지점: 없음. Phase 1 예측 `3 + 2n - k`와 Phase 3의 가중 기대치 12.85가
+  실측 12.8459941275167785와 소수 넷째 자리까지 일치한다. `countTotalLessonByChapterId`의
+  예측값 `(846×5 + 154×4)/1000 = 4.846`도 실측 4.8459941275167785와 일치한다
+
+---
+
+## 사이클 1: 단일 집계 쿼리로 N+1 제거
+
+### 설계 결정
+
+> Phase 5-B에서 호출자와 확정한 내용.
+
+| 결정 항목 | 정한 값 | 근거 |
+|---|---|---|
+| 쿼리 분할 | `findAllChapterSummary` 유지 + 집계 쿼리 1개 추가 (1안) | 챕터 메타 조회와 진행도 집계를 분리해 두고 `units` 대상과 같은 모양을 유지한다. 2안(집계 쿼리 하나에 `c.title`, `c.description`까지 담아 `findAllChapterSummary` 제거)보다 왕복이 1회 많다(7 대 6) |
+| 쿼리 배치 | `ChapterRepository.findChapterProgressByUserId` (a안) | 쿼리가 `FROM Chapter c`로 시작하므로 주 엔티티와 리포지토리가 일치한다. `units` 선례(`UnitRepository:59`)와 같은 모양 |
+| 서비스 배치 | `ChapterQueryService.getAllChapterProgress(long userId)`, `@Transactional(readOnly = true)` | 리포지토리와 같은 도메인. `units`는 `UnitQueryService.getAllUnitProgressInChapter` |
+| 내부 DTO | `chapter/dto/internal/ChapterProgressRowDto(chapterId, totalLessons, solvedLessons)` | `UnitProgressRowDto`의 필드 순서를 따른다. 1안이라 `title`은 넣지 않는다 |
+| 조인 방식 | `Chapter` → `Unit` → `Lesson` → `LessonSubmission` 전부 `LEFT JOIN`, `ls.userId = :userId`는 조인 조건에 둔다 | 제출 이력이 없는 챕터도 행을 남겨야 한다. `WHERE`로 내리면 그 챕터가 결과에서 사라진다 |
+| 집계 함수 | 양쪽 다 `COUNT(DISTINCT ...)` | `LessonSubmission`을 조인하면 `l.id`가 제출 건수만큼 중복된다. 기존 `countTotalLessonByChapterId`의 `COUNT(l.id)`를 그대로 쓰면 총 레슨 수가 부풀어 진행률이 틀어진다 |
+| 진행률 계산 | `LearningProgressRateService.calculateProgressRate(solved, total)` 재사용, 누락 시 `NOT_STARTED_PROGRESS_RATE = 0.0` | `units` 사이클 1에서 이미 추가한 순수 계산 메서드 |
+| 기존 메서드 정리 | `getChapterProgress`, `countSolvedLessonByChapterIdAndUserId`, `countTotalLessonByChapterId` **유지** | `LearningFacade:48`, `UserFacade:118`이 `recentSolvedChapterId` 단건으로 호출한다. 그쪽은 N+1이 아니다. `units` 커밋(`fd3482c7`)이 `countSolvedLessonByUnitIdAndUserId`를 지운 것과 다른 지점 |
+
+- 검토했지만 택하지 않은 안
+  - **인덱스 추가·조정**: 상위 2개 쿼리의 mean이 0.3010765931082263ms / 0.12106246924351827ms로 개별 실행이 이미 빠르다.
+    실행시간을 0으로 만들어도 요청당 DB 실행이 2.2125 → 0.31ms, med 83.6445ms 기준 2.3% 미만이고 왕복 15.85회는 그대로다
+  - **챕터 목록 캐싱**: `findAllChapterSummary`는 DB 시간의 1.2682330686505523%뿐이라 단독 효과가 작다
+  - **유저별 챕터 진행도 캐싱**: 효과가 이 기법과 겹치는데 무효화 경로가 넓다.
+    레슨 제출마다 해당 유저의 챕터 진행도를 무효화해야 하고, 놓치면 진행도가 틀린 채 남는다
+- 예상 효과 (호출자는 별도 목표치를 두지 않고 설계를 승인했다. 아래는 기준선 수치에서 도출한 값)
+  - 요청당 왕복 15.85 → **7.00회** (SQL 12.85 → 4, 트랜잭션 제어 3 유지)
+  - `lesson_submission` 검사 행: 유저당 약 317행을 챕터마다 반복해 요청당 약 1,585행 → **약 317행**.
+    `ix_lesson_submission_user_created_at (user_id, created_at) INCLUDE (lesson_id)`가 `WHERE ls.user_id = ?`만으로
+    index-only scan을 지원하므로, 챕터별 반복이 사라지면 그대로 5배가 줄어든다
+  - 응답시간: 왕복 고정비로 환산하면 저동시성(5 VU, 왕복당 1.82ms) 기준 요청당 약 16ms 절감.
+    50 VU에서는 왕복당 환산치가 5.14ms까지 커지므로 절감폭이 더 크다
+  - **DB 실행시간은 목표가 아니다.** 새 쿼리는 4중 LEFT JOIN + GROUP BY라 단건 실행시간이 기존 0.301ms보다 크다.
+    요청당 DB 실행시간(2.2125ms)이 줄지 않거나 늘 수 있다. 판정은 왕복 횟수와 검사 행 수로 한다
+
+### 개선 전 지표
+
+| 지표 | 값 |
+|---|---|
+| p95 / p99 | 189.25139999999993 ms / 463.67911999999995 ms (med 83.6445) |
+| RPS | 397.0506729592537 |
+| 요청당 쿼리 수 | SQL 12.8459941275167785 + 트랜잭션 제어 3.00014681208053691275 = 왕복 15.85회 |
+| 대상 쿼리 calls / mean_ms / total_ms | `countSolvedLessonByChapterIdAndUserId` 238400 / 0.3010765931082263 / 71776.65979699792 (비중 68.04%)<br>`countTotalLessonByChapterId` 231057 / 0.12106246924351827 / 27972.33095600065 (비중 26.52%) |
+| 부하 조건 | VU 50, 총 2m, 커넥션 풀 60, `chapter` 5 / `unit` 66 / `lesson` 230 / `lesson_submission` 317,300 |
+
+**실행계획**
+
+> 원본: `query-plan-0.txt` (개선 후는 `query-plan-1.txt`)
+
+- EXPLAIN 파라미터: chapterId = 900003, userId = 1500 (이후 모든 사이클에서 동일하게 사용)
+  - chapterId는 챕터 5개의 중앙값. 900001은 레슨 126개로 나머지(26개)와 동떨어진 극단값이라 피했다
+  - userId는 `USER_ID_START` 1001 ~ 2000의 중앙. 이 조합의 solved는 26으로 0건이 아니다
+- **절대 시간은 근거로 쓰지 않는다.** psql이 매 실행 새 커넥션을 열어 계획 캐시가 없는 탓에
+  Planning Time이 302.770ms / 109.802ms, 쿼리 1의 Execution Time이 17.879ms로 나왔다.
+  같은 쿼리의 부하 테스트 mean은 0.3010765931082263ms(238,400회)다. 구조만 근거로 쓴다
+- 스캔 방식
+  - 쿼리 1: `lesson_submission`은 `ix_lesson_submission_user_created_at (user_id, created_at) INCLUDE (lesson_id)`로
+    **Index Only Scan, Heap Fetches 0**. `lesson`(230행)과 `unit`(66행)은 Seq Scan 후 Hash Join
+  - 쿼리 2: `chapter`(5행), `unit`(66행), `lesson`(230행) 전부 Seq Scan. Nested Loop + Hash Join
+  - 세 테이블 모두 1~3페이지라 Seq Scan이 올바른 선택이다. 인덱스 부재가 문제인 계획이 아니다
+- actual rows 대 반환 행 수
+  - 쿼리 1: Index Only Scan 317행 → Hash Join 78행 → Aggregate 1행.
+    317행은 user 1500의 **전체 챕터 제출분**이고, 그중 239행은 다른 챕터 것이라 조인에서 버려진다.
+    `chapter_id`가 `unit`에 있어 두 조인 건너에 있으므로 챕터 조건을 인덱스 스캔까지 밀어넣을 수 없다.
+    그래서 챕터마다 같은 317행을 다시 읽는다. 요청당 약 1,585행
+  - 쿼리 2: 26행 → 1행
+- Rows Removed by Filter: 두 계획 모두 `unit` Seq Scan에서 53 (66행 읽어 13행만 사용), 쿼리 2의 `chapter` Seq Scan에서 4
+- shared hit / read: 쿼리 1 최상단 16 / 0 (128KB), 쿼리 2 최상단 6 / 0 (48KB). 두 계획 모두 디스크까지 내려간 적 없음
+- 플래너 추정 대 실측: 315/317, 62/78, 45/26으로 최대 1.7배. 10배 이상 괴리는 없다
+- 위험 신호 판정
+
+  | 지표 | 기준 | 관측 | 신호 |
+  |---|---|---|---|
+  | 검사 행 / 반환 행 | 100:1 초과 | 317 / 1 (집계라 반환은 항상 1), 조인 통과 기준 317 / 78 | 판단 보류 |
+  | 플래너 추정 대 실측 | 10배 이상 | 최대 1.7배 | 없음 |
+  | 단일 쿼리 total_exec_time 점유율 | 30% 이상 | 68.03926064083532% | **있음** |
+  | OLTP 경로의 Seq Scan | 1만 행 이상 테이블 | `lesson` 230, `unit` 66, `chapter` 5 | 없음 |
+  | 동일 쿼리의 요청당 호출 횟수 | 1회 초과 | 5.0회 / 4.8459941275167785회 | **있음** |
+
+  신호가 켜진 두 항목이 모두 호출 횟수에서 나온다. 노드 단위로 비싼 곳은 없다.
+  계획이 드러내는 것은 노드 하나의 비용이 아니라 챕터마다 같은 317행을 다시 읽는 반복이다
+
+**로직 개선 기법의 추가 캡처 — 변경 전 요청당 쿼리 수와 호출 스택**
+
+```
+ChapterController.getAllChapter (ChapterController:24)
+└ ChapterFacade.getAllChapter (ChapterFacade:21)  @Transactional(readOnly = true)
+    ├ ChapterQueryService.getAllChapter (ChapterQueryService:22)
+    │   └ ChapterRepository.findAllChapterSummary          ... 1회
+    └ chapters.stream().map(...)  — 챕터 n=5개를 순차 순회
+        └ LearningProgressRateService.getChapterProgress (LearningProgressRateService:17)
+            ├ LessonSubmissionRepository.countSolvedLessonByChapterIdAndUserId  ... 챕터마다 1회, 총 5회
+            └ LessonRepository.countTotalLessonByChapterId ... solvedCount>0인 챕터만, 총 4.85회
+                (solvedLessonCount == 0이면 LearningProgressRateService:23~25에서 조기 반환)
+```
+
+`stream().map`은 순차 실행이므로 9.85회의 왕복이 직렬로 쌓인다.
+
+### 적용 내용
+
+| 파일 | 변경 |
+|---|---|
+| `chapter/dto/internal/ChapterProgressRowDto.java` | 신규. `(chapterId, totalLessons, solvedLessons)`. 같은 패키지의 `ChapterSolvedStatDto` 형식을 따랐다 |
+| `chapter/repository/ChapterRepository.java` | `findChapterProgressByUserId(userId)` 추가. `FROM Chapter c` + `Unit`, `Lesson`, `LessonSubmission` 3중 LEFT JOIN + `GROUP BY c.id` |
+| `chapter/service/ChapterQueryService.java` | `getAllChapterProgress(userId)` 추가, `@Transactional(readOnly = true)` |
+| `chapter/facade/ChapterFacade.java` | 챕터별 `getChapterProgress` 루프 제거. 집계 결과를 `Map<Long, Double>`로 만들고 `calculateProgressRate(solved, total)` 재사용. 누락 시 `NOT_STARTED_PROGRESS_RATE = 0.0` |
+| `test/.../ChapterFacadeUnitTest.java` | 새 협력 객체 경로로 수정. `집계에_없는_챕터는_진행도가_0이다` 케이스 추가 |
+| `test/.../ChapterQueryServiceUnitTest.java` | `GetAllChapterProgress` 중첩 클래스 추가 |
+
+**손대지 않은 것** — `LearningProgressRateService.getChapterProgress`,
+`LessonSubmissionRepository.countSolvedLessonByChapterIdAndUserId`, `LessonRepository.countTotalLessonByChapterId`.
+`LearningFacade:48`, `UserFacade:118`이 `recentSolvedChapterId` 단건으로 호출하며 그쪽은 N+1이 아니다.
+
+**쿼리 설계상 주의점 (구현 근거)**
+
+- `COUNT(DISTINCT l.id)` — `LessonSubmission`을 조인하면 같은 레슨이 제출 건수만큼 중복된다.
+  `COUNT(l.id)`를 쓰면 총 레슨 수가 줄 수만큼 부풀어 진행률이 낮게 나온다.
+  기존 `countTotalLessonByChapterId`가 `COUNT(l.id)`여도 문제없던 건 제출 테이블을 조인하지 않아서다
+- `ls.userId = :userId`를 `ON`에 둔다 — `WHERE`로 내리면 제출이 없어 `ls`가 null인 행이 걸러져
+  해당 챕터가 결과에서 통째로 사라진다
+- `COUNT`는 null을 세지 않으므로 제출 이력이 없는 챕터는 별도 분기 없이 `solvedLessons = 0`이 된다.
+  기존의 `solvedLessonCount == 0` 조기 반환이 하던 역할을 집계가 대신한다
+
+- 테스트: `./gradlew test` 통과
+
+### 개선 후 지표
+
+| 구분 | 지표 | 개선 전 | 개선 후 | 변화 |
+|---|---|---|---|---|
+| 하드웨어 의존 | p95 | 189.25139999999993 ms | 125.61419999999995 ms | −33.6% |
+| | p99 | 463.67911999999995 ms | 328.7562199999998 ms | −29.1% |
+| | med | 83.6445 ms | 52.239 ms | −37.5% |
+| | RPS | 397.0506729592537 | 589.2846296260478 | +48.4% |
+| | 처리 요청 수 | 47,680 | 70,715 | +48.3% |
+| | 에러율 / check 통과율 | 0 / 1 | 0 / 1 | 동일 |
+| 하드웨어 독립 | 요청당 SQL | 12.8459941275167785 | 4.0 | −68.9% |
+| | 요청당 왕복 (SQL + 트랜잭션 제어) | 15.85 | 7.00 | −55.8% |
+| | 요청당 DB 실행시간 | 2.2125210943372 ms | 1.3445919 ms | −39.2% |
+| | 진행도 집계 부분의 요청당 실행시간 | 2.09206 ms (9.85개 쿼리) | 1.1704637619882787 ms (1개 쿼리) | −44.1% |
+| | 대상 쿼리 total_ms | `countSolved` 71776.65979699792 + `countTotal` 27972.33095600065 | `findChapterProgressByUserId` 82769.34492900038 | 요청 수가 달라 total 직접 비교는 무의미. 요청당 값으로 본다 |
+| | 검사 행 / 반환 행 | `lesson_submission` 약 1,585행 (317 × 5회) → 5행 | **317행 (317 × 1회) → 5행** | 검사 행 −80% |
+| | 만진 버퍼 / 요청 | 약 109.1페이지 (872.6 KB) | **17페이지 (136 KB)** | −84.4% |
+| | 스캔 방식 | `lesson_submission` Index Only Scan(Heap Fetches 0) + `lesson`·`unit` Seq Scan + Hash Join, 요청당 9.85회 반복 | 동일한 스캔 방식이되 Hash Right Join 3단 + Sort + GroupAggregate, **loops 전부 1** | 스캔 종류는 그대로, 반복이 사라짐 |
+| | Rows Removed by Filter | `unit` Seq Scan에서 53 (두 쿼리 모두) | **0 (Filter 노드 자체가 없음)** | 해소 |
+| | 캐시 hit / miss, 적중률 | - | - | 캐싱 사이클 아님 |
+
+**실행계획 변화 (`query-plan-1.txt`, userId 1500)**
+
+- EXPLAIN 파라미터: userId = 1500 (Phase 6과 동일). **chapterId = 900003은 이번 쿼리에 존재하지 않는다.**
+  챕터별 필터를 없앤 것이 이 기법의 핵심이므로 파라미터가 하나 사라진 것이고, 값을 바꾼 것이 아니다
+- 계획 구조: GroupAggregate ← Sort(quicksort, Memory 51kB, Batches 1 — 디스크 스필 없음) ← Hash Right Join 3단
+  ← Index Only Scan `ix_lesson_submission_user_created_at`(실측 317행, Heap Fetches 0) + `lesson`(230) · `unit`(66) · `chapter`(5) Seq Scan
+- 조인 결과 430행은 제출 317건이 레슨과 곱해져 부푼 값이고, `COUNT(DISTINCT)`가 여기서 중복을 걷어낸다
+- 플래너 추정 대 실측: 316/317, 316/430(1.36배), 5/5. 10배 이상 괴리 없음
+- Planning Time 302.770ms → **3.518ms**. Phase 6에서 "302ms는 psql 콜드 커넥션 노이즈"라고 본 판단이 이 값으로 확인된다.
+  Execution Time 1.653ms도 부하 테스트의 mean 1.1704637619882787ms와 같은 자릿수로 맞는다
+
+**Phase 5 예상과 실측 대조**
+
+| 예상 | 실측 | 판정 |
+|---|---|---|
+| 요청당 왕복 15.85 → 7.00회 | 15.85 → 7.00 | 일치 |
+| `lesson_submission` 검사 행 약 1,585 → 약 317 (5배 감소) | 317 × 1회 | 일치 |
+| DB 실행시간은 목표가 아니며 줄지 않거나 늘 수 있다 | 2.2125 → 1.3446 ms (−39.2%) | **빗나감. 예상보다 좋다** |
+
+마지막 항목의 어긋난 가정: 집계 쿼리의 **단건** 실행시간이 커진다는 예측은 맞았다(0.3010765931082263 → 1.1704637619882787ms, 3.9배).
+틀린 것은 그 증가가 상쇄되지 않으리라 본 부분이다. 9.85건을 1건으로 줄인 효과가 단건 증가를 덮고도 남았다.
+같은 317행을 챕터마다 다시 읽던 낭비가 사라진 만큼이 실행시간으로 돌아왔다.
+
+### 판정
+
+- 개선 여부 (하드웨어 독립 증거 기준): **있음**
+  - 요청당 SQL 12.8459941275167785 → 4.0, 왕복 15.85 → 7.00. Phase 5의 예측값과 소수점까지 일치한다.
+    이 수치는 코드 경로에서 결정되므로 부하 상황에 따라 달라지지 않는다. 측정 편차로 설명할 수 없다
+  - 실행계획의 `loops`가 전부 1이 되었고 `Rows Removed by Filter`가 0이 되었다
+  - 만진 버퍼가 요청당 109.1페이지 → 17페이지
+  - 하드웨어 의존 지표(p95 −33.6%, RPS +48.4%)는 같은 방향을 가리키지만,
+    로컬 한 대에서 k6·JVM·PostgreSQL이 CPU를 공유한 결과이므로 방향으로만 읽는다. 운영 개선폭의 예측치가 아니다
+- 남은 위험 신호
+  - **단일 쿼리 total_exec_time 점유율 87.04973879038928% (기준 30% 초과)**.
+    다만 성격이 바뀌었다. 개선 전에는 같은 일을 9.85번 나눠 하며 68.04%였고, 지금은 한 번에 하며 87.05%다.
+    분모인 요청당 DB 실행시간이 2.2125 → 1.3446ms로 줄어든 상태에서의 점유율이다
+  - 해소된 신호: 동일 쿼리의 요청당 호출 횟수(5.0 / 4.85 → 전부 1.0), `Rows Removed by Filter`(53 → 0)
+- 다음 사이클 진행 여부: **종료.** 남은 왕복 7회 중 집계 쿼리는 실행계획상 더 깎을 데가 없고
+  (Filter 0, Index Only Scan Heap Fetches 0, 소형 테이블 Seq Scan이 최적, Sort는 51kB 인메모리),
+  필터·인터셉터 2회는 전체 API 공통 경로라 이 대상만의 문제가 아니다.
+  검토한 사이클 2 후보와 배제 근거는 아래와 같다
+
+  | 후보 | 효과 | 배제 근거 |
+  |---|---|---|
+  | 챕터 목록 캐싱 | 왕복 7.00 → 6.00 (−14.3%), DB 시간 −2.53% | 캐시 계층과 어드민 변경 시 무효화를 추가하는 비용에 비해 효과가 작다 |
+  | 유저별 진행도 캐싱 | DB 시간 −87.05% (캐시 히트 시) | 레슨 제출 경로 전반에 무효화를 심어야 하고, 놓치면 진행도가 틀린 채 남는다 |
+  | 집계 쿼리 튜닝 (인덱스) | — | 실행계획에 낭비가 없다. `Rows Removed by Filter` 0, 추정 대 실측 최대 1.36배 |
+
+---
+
+## 최종 요약
+
+> 하드웨어 의존 증거와 독립 증거를 모두 남긴다.
+
+| 구분 | 지표 | 최초 (상태 0) | 최종 (상태 1) | 변화 |
+|---|---|---|---|---|
+| 하드웨어 의존 | p95 | 189.25139999999993 ms | 125.61419999999995 ms | −33.6% |
+| | p99 | 463.67911999999995 ms | 328.7562199999998 ms | −29.1% |
+| | med | 83.6445 ms | 52.239 ms | −37.5% |
+| | RPS | 397.0506729592537 | 589.2846296260478 | +48.4% |
+| | 에러율 / check 통과율 | 0 / 1 | 0 / 1 | 동일 |
+| 하드웨어 독립 | 요청당 SQL | 12.8459941275167785 | 4.0 | −68.9% |
+| | 요청당 왕복 (SQL + 트랜잭션 제어) | 15.85 | 7.00 | −55.8% |
+| | 요청당 DB 실행시간 | 2.2125210943372 ms | 1.3445919 ms | −39.2% |
+| | 검사 행 / 반환 행 | `lesson_submission` 약 1,585행 (317 × 5회) → 5행 | 317행 (317 × 1회) → 5행 | 검사 행 −80% |
+| | 만진 버퍼 / 요청 | 약 109.1페이지 (872.6 KB) | 17페이지 (136 KB) | −84.4% |
+| | 스캔 방식 | `lesson_submission` Index Only Scan(Heap Fetches 0) + `lesson`·`unit` Seq Scan + Hash Join을 요청당 9.85회 반복 | 같은 스캔 방식으로 Hash Right Join 3단 + Sort + GroupAggregate, loops 전부 1 | 스캔 종류는 그대로, 반복이 사라짐 |
+| | Rows Removed by Filter | `unit` Seq Scan에서 53 (두 쿼리 모두) | 0 (Filter 노드 없음) | 해소 |
+| | 캐시 hit / miss, 적중률 | - | - | 캐싱 사이클 없음 |
+
+적용한 기법: 사이클 1 — 단일 집계 쿼리로 N+1 제거 (`ChapterRepository.findChapterProgressByUserId`)
+
+측정 조건: perf 프로파일, VU 50, ramp-up 30s + 유지 1m + ramp-down 30s (총 2m), 커넥션 풀 60,
+Redis 캐시 cold(측정 직전 FLUSHDB), DB 캐시 제어하지 않음, 시드 미사용
+(`chapter` 5 / `unit` 66 / `lesson` 230 / `lesson_submission` 317,300 / `users` 1,002).
+상태 0과 상태 1의 조건은 동일하다.
+
+하드웨어 의존 지표는 로컬 한 대에서 k6·JVM·PostgreSQL이 CPU를 공유한 결과이므로 방향으로만 읽는다.
+운영 환경의 개선폭 예측치가 아니다.

--- a/.claude/resources/perf/490/chapters/test-script.js
+++ b/.claude/resources/perf/490/chapters/test-script.js
@@ -1,0 +1,158 @@
+// 부하 테스트 스크립트. 대상: GET /api/v1/chapters (이슈 #490)
+//
+// 실행: 토큰 발급, warmup, measure를 각각 따로 돌린다. 통계 리셋은 토큰 발급이 끝난 뒤에 한다.
+//
+//   (토큰 발급 - Phase 4, 8의 명령 블록 참조. $PERF_DIR/tokens.json 생성)
+//   k6 run -e PHASE=warmup $TARGET_DIR/test-script.js
+//   psql ... -c "SELECT pg_stat_statements_reset();"
+//   k6 run -e PHASE=measure -e SUMMARY_OUT=$TARGET_DIR/k6-test-summary-{n}.json \
+//     $TARGET_DIR/test-script.js
+//
+// {n}은 상태 번호다. 0 = 아무것도 적용하지 않은 원본(Phase 4), n = 사이클 n 적용 후(Phase 8).
+
+import http from 'k6/http';
+import exec from 'k6/execution';
+import { check } from 'k6';
+
+const BASE_URL = __ENV.BASE_URL || 'http://localhost:8080';
+const USER_ID_START = Number(__ENV.USER_ID_START || 1001);
+const USER_COUNT = Number(__ENV.USER_COUNT || 1000);
+const PHASE = __ENV.PHASE || 'measure';
+
+// 이 API는 전체 챕터를 훑으므로 경로 변수가 없다. 챕터는 5개(900001~900005) 전부가 매 요청에 걸린다.
+const CHAPTER_COUNT = 5;
+
+// 이 측정이 무엇이었는지 요약 파일만 보고 알 수 있게 한다.
+const TARGET = 'chapters';
+const ENDPOINT = 'GET /api/v1/chapters';
+const CONDITION = {
+    vus: 50,
+    steady_state_duration: '1m',
+    ramp_up: '30s',
+    ramp_down: '30s',
+    total_duration: '2m',
+    redis_cache: 'cold',
+    db_cache: '제어하지 않음',
+    user_id_start: USER_ID_START,
+    user_count: USER_COUNT,
+    chapter_count: CHAPTER_COUNT,
+};
+
+// tokens.json은 이슈 디렉토리에 있다(대상 간 공유).
+const tokens = JSON.parse(open('../tokens.json'));
+
+if (tokens.length !== USER_COUNT) {
+    throw new Error(
+        `토큰 ${tokens.length}건 / 필요 ${USER_COUNT}건. 로그인에 실패한 userId가 있다. ` +
+        'tokens.json을 다시 만들고 userId 범위와 perf 프로파일 기동 상태를 확인하라.'
+    );
+}
+
+const scenarios = {
+    warmup: {
+        executor: 'constant-vus',
+        vus: 5,
+        duration: '30s',
+    },
+    measure: {
+        executor: 'ramping-vus',
+        startVUs: 0,
+        stages: [
+            { duration: '30s', target: 50 },
+            { duration: '1m', target: 50 },
+            { duration: '30s', target: 0 },
+        ],
+    },
+};
+
+export const options = {
+    scenarios: { [PHASE]: scenarios[PHASE] },
+    summaryTrendStats: ['avg', 'min', 'med', 'p(90)', 'p(95)', 'p(99)', 'max'],
+    thresholds: {
+        http_req_failed: ['rate<0.01'],
+        checks: ['rate>0.99'],
+    },
+};
+
+// 비JSON 응답에서 예외를 던지지 않는다. 파싱 실패는 null로 떨어뜨려 check 실패로 드러낸다.
+function parseBody(res) {
+    if (res.status !== 200 || res.body === null || res.body.length <= 2) {
+        return null;
+    }
+    try {
+        return res.json();
+    } catch (e) {
+        return null;
+    }
+}
+
+export default function () {
+    // 시나리오 전체의 반복 번호로 고른다. VU 수와 무관하게 토큰 USER_COUNT개를 균등하게 돈다.
+    const iteration = exec.scenario.iterationInTest;
+
+    const token = tokens[iteration % tokens.length];
+    const params = { headers: { Authorization: `Bearer ${token}` } };
+
+    const res = http.get(`${BASE_URL}/api/v1/chapters`, params);
+
+    check(res, {
+        'status is 200': (r) => r.status === 200,
+        'body is not empty': (r) => r.body !== null && r.body.length > 2,
+        'chapterSummaryResponse가 실린 배열이다': (r) => {
+            const body = parseBody(r);
+            return body !== null
+                && Array.isArray(body)
+                && body.length > 0
+                && body[0].chapterSummaryResponse !== undefined;
+        },
+    });
+}
+
+export function handleSummary(data) {
+    const m = data.metrics || {};
+    const val = (name, key) => (m[name] && m[name].values[key] !== undefined ? m[name].values[key] : null);
+    const trend = (name) => ({
+        med: val(name, 'med'),
+        p95: val(name, 'p(95)'),
+        p99: val(name, 'p(99)'),
+        max: val(name, 'max'),
+    });
+
+    const summary = {
+        phase: PHASE,
+        target: TARGET,
+        endpoint: ENDPOINT,
+        condition: CONDITION,
+        requests: val('http_reqs', 'count'),
+        rps: val('http_reqs', 'rate'),
+        failed_rate: val('http_req_failed', 'rate'),
+        checks_rate: val('checks', 'rate'),
+        checks: ((data.root_group || {}).checks || []).map((c) => ({
+            name: c.name,
+            passes: c.passes,
+            fails: c.fails,
+        })),
+        duration_ms: trend('http_req_duration'),
+        waiting_ms: trend('http_req_waiting'),
+        bytes_received: val('data_received', 'count'),
+    };
+
+    // 아래 반올림은 터미널 한 줄 출력에만 쓴다. summary 객체의 값은 손대지 않는다.
+    const num = (x, d) => (typeof x === 'number' ? x.toFixed(d) : '-');
+    const line = [
+        `[${PHASE}] ${TARGET}`,
+        `요청 ${summary.requests}건`,
+        `p95 ${num(summary.duration_ms.p95, 1)}ms`,
+        `p99 ${num(summary.duration_ms.p99, 1)}ms`,
+        `실패율 ${num(summary.failed_rate * 100, 2)}%`,
+        `check ${num(summary.checks_rate * 100, 2)}%`,
+    ].join(' / ');
+
+    const out = { stdout: `\n${line}\n\n` };
+
+    if (__ENV.SUMMARY_OUT) {
+        out[__ENV.SUMMARY_OUT] = JSON.stringify(summary, null, 2);
+    }
+
+    return out;
+}

--- a/.claude/resources/perf/490/units/k6-test-summary-0.json
+++ b/.claude/resources/perf/490/units/k6-test-summary-0.json
@@ -1,0 +1,52 @@
+{
+  "phase": "measure",
+  "target": "units",
+  "endpoint": "GET /api/v1/units/{chapterId}",
+  "condition": {
+    "vus": 50,
+    "steady_state_duration": "1m",
+    "ramp_up": "30s",
+    "ramp_down": "30s",
+    "total_duration": "2m",
+    "redis_cache": "cold",
+    "db_cache": "제어하지 않음",
+    "user_id_start": 1001,
+    "user_count": 1000,
+    "chapter_id_start": 900001,
+    "chapter_count": 5
+  },
+  "requests": 33647,
+  "rps": 280.3764562439154,
+  "failed_rate": 0,
+  "checks_rate": 1,
+  "checks": [
+    {
+      "name": "status is 200",
+      "passes": 33647,
+      "fails": 0
+    },
+    {
+      "name": "body is not empty",
+      "passes": 33647,
+      "fails": 0
+    },
+    {
+      "name": "unitDetailResponses가 실려 있다",
+      "passes": 33647,
+      "fails": 0
+    }
+  ],
+  "duration_ms": {
+    "med": 128.171,
+    "p95": 251.16699999999997,
+    "p99": 502.76631999999995,
+    "max": 1101.469
+  },
+  "waiting_ms": {
+    "med": 128.033,
+    "p95": 250.94999999999996,
+    "p99": 502.6034599999999,
+    "max": 1101.394
+  },
+  "bytes_received": 68074144
+}

--- a/.claude/resources/perf/490/units/k6-test-summary-1.json
+++ b/.claude/resources/perf/490/units/k6-test-summary-1.json
@@ -1,0 +1,65 @@
+{
+  "phase": "measure",
+  "target": "units",
+  "endpoint": "GET /api/v1/units/{chapterId}",
+  "condition": {
+    "vus": 50,
+    "steady_state_duration": "1m",
+    "ramp_up": "30s",
+    "ramp_down": "30s",
+    "total_duration": "2m",
+    "redis_cache": "cold",
+    "db_cache": "제어하지 않음",
+    "user_id_start": 1001,
+    "user_count": 1000,
+    "chapter_id_start": 900001,
+    "chapter_count": 5
+  },
+  "requests": 82328,
+  "rps": 686.0507502892599,
+  "failed_rate": 0,
+  "checks_rate": 1,
+  "checks": [
+    {
+      "name": "status is 200",
+      "passes": 82328,
+      "fails": 0
+    },
+    {
+      "name": "body is not empty",
+      "passes": 82328,
+      "fails": 0
+    },
+    {
+      "name": "unitDetailResponses가 실려 있다",
+      "passes": 82328,
+      "fails": 0
+    }
+  ],
+  "duration_ms": {
+    "med": 46.713499999999996,
+    "p95": 116.05729999999984,
+    "p99": 254.81243999999998,
+    "max": 1538.989
+  },
+  "waiting_ms": {
+    "med": 46.56,
+    "p95": 115.75189999999998,
+    "p99": 254.49304999999993,
+    "max": 1538.485
+  },
+  "bytes_received": 166565306,
+  "delta_vs_prev": {
+    "from": "k6-test-summary-0.json",
+    "requests": { "before": 33647, "after": 82328 },
+    "rps": { "before": 280.3764562439154, "after": 686.0507502892599 },
+    "duration_med_ms": { "before": 128.171, "after": 46.713499999999996 },
+    "duration_p95_ms": { "before": 251.16699999999997, "after": 116.05729999999984 },
+    "duration_p99_ms": { "before": 502.76631999999995, "after": 254.81243999999998 },
+    "duration_max_ms": { "before": 1101.469, "after": 1538.989 },
+    "queries_per_request": { "before": 27.5032543763188397, "after": 5.0 },
+    "db_time_per_request_ms": { "before": 2.7876, "after": 0.5757 },
+    "failed_rate": { "before": 0, "after": 0 },
+    "checks_rate": { "before": 1, "after": 1 }
+  }
+}

--- a/.claude/resources/perf/490/units/query-plan-0.txt
+++ b/.claude/resources/perf/490/units/query-plan-0.txt
@@ -1,0 +1,81 @@
+BEGIN
+                                                                                        QUERY PLAN                                                                                         
+-------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
+ Aggregate  (cost=27.71..27.72 rows=1 width=8) (actual time=2.423..2.427 rows=1 loops=1)
+   Output: count(DISTINCT l1_0.id)
+   Buffers: shared hit=14
+   ->  Hash Join  (cost=6.32..27.70 rows=4 width=8) (actual time=1.523..1.615 rows=6 loops=1)
+         Output: l1_0.id
+         Inner Unique: true
+         Hash Cond: (ls1_0.lesson_id = l1_0.id)
+         Buffers: shared hit=11
+         ->  Index Only Scan using ix_lesson_submission_user_created_at on public.lesson_submission ls1_0  (cost=0.42..20.56 rows=465 width=8) (actual time=0.985..1.064 rows=317 loops=1)
+               Output: ls1_0.user_id, ls1_0.created_at, ls1_0.lesson_id
+               Index Cond: (ls1_0.user_id = 1500)
+               Heap Fetches: 0
+               Buffers: shared hit=8
+         ->  Hash  (cost=5.88..5.88 rows=2 width=8) (actual time=0.149..0.150 rows=2 loops=1)
+               Output: l1_0.id
+               Buckets: 1024  Batches: 1  Memory Usage: 9kB
+               Buffers: shared hit=3
+               ->  Seq Scan on public.lesson l1_0  (cost=0.00..5.88 rows=2 width=8) (actual time=0.080..0.083 rows=2 loops=1)
+                     Output: l1_0.id
+                     Filter: (l1_0.unit_id = 900033)
+                     Rows Removed by Filter: 228
+                     Buffers: shared hit=3
+ Query Identifier: 8221422339103481763
+ Planning:
+   Buffers: shared hit=151
+ Planning Time: 4.455 ms
+ Execution Time: 2.734 ms
+(27 rows)
+
+                                                                                           QUERY PLAN                                                                                            
+-------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
+ GroupAggregate  (cost=35.66..36.70 rows=13 width=36) (actual time=0.689..0.721 rows=13 loops=1)
+   Output: u1_0.id, u1_0.title, count(DISTINCT l1_0.id), count(DISTINCT ls1_0.lesson_id)
+   Group Key: u1_0.id
+   Buffers: shared hit=10
+   ->  Sort  (cost=35.66..35.89 rows=91 width=36) (actual time=0.389..0.398 rows=78 loops=1)
+         Output: u1_0.id, u1_0.title, l1_0.id, ls1_0.lesson_id
+         Sort Key: u1_0.id
+         Sort Method: quicksort  Memory: 31kB
+         Buffers: shared hit=10
+         ->  Hash Right Join  (cost=9.91..32.70 rows=91 width=36) (actual time=0.254..0.338 rows=78 loops=1)
+               Output: u1_0.id, u1_0.title, l1_0.id, ls1_0.lesson_id
+               Hash Cond: (ls1_0.lesson_id = l1_0.id)
+               Buffers: shared hit=10
+               ->  Index Only Scan using ix_lesson_submission_user_created_at on public.lesson_submission ls1_0  (cost=0.42..20.56 rows=465 width=8) (actual time=0.047..0.089 rows=317 loops=1)
+                     Output: ls1_0.user_id, ls1_0.created_at, ls1_0.lesson_id
+                     Index Cond: (ls1_0.user_id = 1500)
+                     Heap Fetches: 0
+                     Buffers: shared hit=5
+               ->  Hash  (cost=8.92..8.92 rows=45 width=28) (actual time=0.202..0.203 rows=26 loops=1)
+                     Output: u1_0.id, u1_0.title, l1_0.id
+                     Buckets: 1024  Batches: 1  Memory Usage: 10kB
+                     Buffers: shared hit=5
+                     ->  Hash Right Join  (cost=2.99..8.92 rows=45 width=28) (actual time=0.157..0.191 rows=26 loops=1)
+                           Output: u1_0.id, u1_0.title, l1_0.id
+                           Inner Unique: true
+                           Hash Cond: (l1_0.unit_id = u1_0.id)
+                           Buffers: shared hit=5
+                           ->  Seq Scan on public.lesson l1_0  (cost=0.00..5.30 rows=230 width=16) (actual time=0.002..0.034 rows=230 loops=1)
+                                 Output: l1_0.id, l1_0.title, l1_0.unit_id
+                                 Buffers: shared hit=3
+                           ->  Hash  (cost=2.83..2.83 rows=13 width=20) (actual time=0.033..0.034 rows=13 loops=1)
+                                 Output: u1_0.id, u1_0.title
+                                 Buckets: 1024  Batches: 1  Memory Usage: 9kB
+                                 Buffers: shared hit=2
+                                 ->  Seq Scan on public.unit u1_0  (cost=0.00..2.83 rows=13 width=20) (actual time=0.021..0.024 rows=13 loops=1)
+                                       Output: u1_0.id, u1_0.title
+                                       Filter: (u1_0.chapter_id = 900003)
+                                       Rows Removed by Filter: 53
+                                       Buffers: shared hit=2
+ Query Identifier: 581384667906442718
+ Planning:
+   Buffers: shared hit=60
+ Planning Time: 1.103 ms
+ Execution Time: 0.822 ms
+(44 rows)
+
+ROLLBACK

--- a/.claude/resources/perf/490/units/query-plan-1.txt
+++ b/.claude/resources/perf/490/units/query-plan-1.txt
@@ -1,0 +1,50 @@
+BEGIN
+                                                                                           QUERY PLAN                                                                                            
+-------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
+ GroupAggregate  (cost=27.07..27.82 rows=13 width=36) (actual time=0.795..0.859 rows=13 loops=1)
+   Output: u1_0.id, u1_0.title, count(DISTINCT l1_0.id), count(DISTINCT ls1_0.lesson_id)
+   Group Key: u1_0.id
+   Buffers: shared hit=16
+   ->  Sort  (cost=27.07..27.22 rows=62 width=36) (actual time=0.726..0.739 rows=78 loops=1)
+         Output: u1_0.id, u1_0.title, l1_0.id, ls1_0.lesson_id
+         Sort Key: u1_0.id
+         Sort Method: quicksort  Memory: 31kB
+         Buffers: shared hit=16
+         ->  Hash Right Join  (cost=9.91..25.22 rows=62 width=36) (actual time=0.522..0.667 rows=78 loops=1)
+               Output: u1_0.id, u1_0.title, l1_0.id, ls1_0.lesson_id
+               Hash Cond: (ls1_0.lesson_id = l1_0.id)
+               Buffers: shared hit=13
+               ->  Index Only Scan using ix_lesson_submission_user_created_at on public.lesson_submission ls1_0  (cost=0.42..13.94 rows=315 width=8) (actual time=0.369..0.425 rows=317 loops=1)
+                     Output: ls1_0.user_id, ls1_0.created_at, ls1_0.lesson_id
+                     Index Cond: (ls1_0.user_id = 1500)
+                     Heap Fetches: 0
+                     Buffers: shared hit=8
+               ->  Hash  (cost=8.92..8.92 rows=45 width=28) (actual time=0.137..0.141 rows=26 loops=1)
+                     Output: u1_0.id, u1_0.title, l1_0.id
+                     Buckets: 1024  Batches: 1  Memory Usage: 10kB
+                     Buffers: shared hit=5
+                     ->  Hash Right Join  (cost=2.99..8.92 rows=45 width=28) (actual time=0.101..0.132 rows=26 loops=1)
+                           Output: u1_0.id, u1_0.title, l1_0.id
+                           Inner Unique: true
+                           Hash Cond: (l1_0.unit_id = u1_0.id)
+                           Buffers: shared hit=5
+                           ->  Seq Scan on public.lesson l1_0  (cost=0.00..5.30 rows=230 width=16) (actual time=0.003..0.028 rows=230 loops=1)
+                                 Output: l1_0.id, l1_0.title, l1_0.unit_id
+                                 Buffers: shared hit=3
+                           ->  Hash  (cost=2.83..2.83 rows=13 width=20) (actual time=0.032..0.033 rows=13 loops=1)
+                                 Output: u1_0.id, u1_0.title
+                                 Buckets: 1024  Batches: 1  Memory Usage: 9kB
+                                 Buffers: shared hit=2
+                                 ->  Seq Scan on public.unit u1_0  (cost=0.00..2.83 rows=13 width=20) (actual time=0.012..0.018 rows=13 loops=1)
+                                       Output: u1_0.id, u1_0.title
+                                       Filter: (u1_0.chapter_id = 900003)
+                                       Rows Removed by Filter: 53
+                                       Buffers: shared hit=2
+ Query Identifier: 581384667906442718
+ Planning:
+   Buffers: shared hit=209
+ Planning Time: 2.571 ms
+ Execution Time: 0.982 ms
+(44 rows)
+
+ROLLBACK

--- a/.claude/resources/perf/490/units/query-stats-summary-0.md
+++ b/.claude/resources/perf/490/units/query-stats-summary-0.md
@@ -1,0 +1,46 @@
+# query-stats-summary-0 — units
+
+상태: 0 = 원본 (아무것도 적용하지 않음)
+측정: VU 50 / ramp-up 30s + 유지 1m + ramp-down 30s (총 2m) / Redis cold, DB 캐시 제어하지 않음 / 요청 33647건
+직전 상태 대비: -
+
+| # | 요청당 | calls | mean_ms | total_ms | 비중 | 행/호출 | 출처 | 하는 일 |
+|---|---|---|---|---|---|---|---|---|
+| 1 | 13.2000178321990073 | 444141 | 0.15408816826638075 | 68436.87314199883 | 72.96558285477879% | 1.00000000000000000000 | `LessonSubmissionRepository.countSolvedLessonByUnitIdAndUserId` | 유닛 하나에서 해당 유저가 제출한 서로 다른 레슨 수를 센다 |
+| 2 | 10.3032365441198324 | 346673 | 0.06126250718977414 | 21238.057155000402 | 22.6434544401578% | 1.00000000000000000000 | `LessonRepository.countTotalLessonByUnitId` | 유닛 하나에 속한 전체 레슨 수를 센다 |
+| 3 | 1.00000000000000000000 | 33647 | 0.03226445582072698 | 1085.602144999997 | 1.1574402748349957% | 1.00000000000000000000 | `AuthTokenProvider.parseUser` (`JwtAuthFilter` 경유) | 토큰의 subject로 유저 엔티티 전체 컬럼을 읽는다 |
+| 4 | 1.00000000000000000000 | 33647 | 0.03094173117959992 | 1041.0964290000004 | 1.1099894583493994% | 13.2000178321990073 | `UnitRepository.findAllUnitSummaryByChapterId` | 챕터에 속한 유닛의 id, title, description을 읽는다 |
+| 5 | 2.0000000000000000 | 67294 | 0.011670944467560293 | 785.384536999999 | 0.8373562069154138% | 0.000000000000000000000000 | - | 트랜잭션 제어 |
+| 6 | 1.00000000000000000000 | 33647 | 0.01871428739560719 | 629.6796280000033 | 0.6713477539143252% | 0.000000000000000000000000 | `UserRepository.updateLastAccessedAt` (`LastAccessInterceptor` 경유) | 유저의 last_accessed_at을 갱신한다 |
+| 7 | 1.00000000000000000000 | 33647 | 0.016008778613249366 | 538.6473740000002 | 0.5742915740109473% | 1.00000000000000000000 | `ChapterRepository.findChapterSummaryByChapterId` | 챕터 단건의 id, title, description을 읽는다 |
+| 8 | 1.00011888132671560615 | 33651 | 0.0011243999286796838 | 37.83718199999443 | 0.04034100202800854% | 0.000000000000000000000000 | - | 트랜잭션 제어 |
+| 9 | 0.00020804232175231076 | 7 | 0.011482285714285714 | 0.080376 | 8.56947639230557e-05% | 0.00000000000000000000 | - | JDBC 드라이버의 application_name 설정 |
+| 10 | 0.00011888132671560615 | 4 | 0.014270999999999999 | 0.057083999999999996 | 6.086144998237919e-05% | 0.00000000000000000000 | `SeasonRepository.findCloseableActiveByNowForUpdate` | 마감 시각이 지난 ACTIVE 시즌을 잠금 조회한다 |
+| 11 | 0.00166433857401848605 | 56 | 0.0007959999999999999 | 0.04457600000000002 | 4.75257514262234e-05% | 0.00000000000000000000 | - | 트랜잭션 제어 |
+| 12 | 0.000089160995036704609623 | 3 | 0.0007356666666666666 | 0.0022069999999999998 | 2.3530449882823715e-06% | 0.00000000000000000000 | - | 트랜잭션 제어 |
+
+## 쿼리 원문
+
+[1] select count(distinct l1_0.id) from lesson_submission ls1_0 join lesson l1_0 on l1_0.id=ls1_0.lesson_id where l1_0.unit_id=$1 and ls1_0.user_id=$2
+
+[2] select count(l1_0.id) from unit u1_0 join lesson l1_0 on l1_0.unit_id=u1_0.id where u1_0.id=$1
+
+[3] select u1_0.id,u1_0.created_at,u1_0.deleted_at,u1_0.email,u1_0.handle,u1_0.is_onboarded,u1_0.last_accessed_at,u1_0.level,u1_0.xp,u1_0.nickname,u1_0.profile_img_number,u1_0.provider_id,u1_0.role,u1_0.status,u1_0.updated_at from users u1_0 where u1_0.id=$1 and (u1_0.deleted_at IS NULL)
+
+[4] select u1_0.id,u1_0.title,u1_0.description from unit u1_0 where u1_0.chapter_id=$1
+
+[5] BEGIN READ ONLY
+
+[6] update users u1_0 set last_accessed_at=$1 where u1_0.id=$2 and (u1_0.last_accessed_at is null or u1_0.last_accessed_at<$3) and (u1_0.deleted_at IS NULL)
+
+[7] select c1_0.id,c1_0.title,c1_0.description from chapter c1_0 where c1_0.id=$1
+
+[8] BEGIN
+
+[9] SET application_name = 'PostgreSQL JDBC Driver'
+
+[10] select s1_0.id,s1_0.ends_at,s1_0.season_key,s1_0.starts_at,s1_0.status,s1_0.tz from season s1_0 where s1_0.status=$2 and s1_0.ends_at<=$1 for no key update
+
+[11] COMMIT
+
+[12] ROLLBACK

--- a/.claude/resources/perf/490/units/query-stats-summary-1.md
+++ b/.claude/resources/perf/490/units/query-stats-summary-1.md
@@ -1,0 +1,55 @@
+# query-stats-summary-1 — units
+
+상태: 1 = 사이클 1 적용 후 (단일 집계 쿼리로 N+1 제거)
+측정: VU 50 / ramp-up 30s + 유지 1m + ramp-down 30s (총 2m) / Redis cold, DB 캐시 제어하지 않음 / 요청 82328건
+직전 상태 대비: 요청당 쿼리 수 27.5033 → 5.0000, 요청당 DB 시간 2.7876 ms → 0.5757 ms, 총 DB 시간 93793.362 ms → 47396.173 ms. `countSolvedLessonByUnitIdAndUserId`(요청당 13.2000178321990073회)와 `countTotalLessonByUnitId`(요청당 10.3032365441198324회)가 사라지고 `findUnitProgressByChapterIdAndUserId`(요청당 1회)가 새로 생겼다. 나머지 5개 쿼리는 요청당 호출 수가 그대로다.
+
+| # | 요청당 | calls | mean_ms | total_ms | 비중 | 행/호출 | 출처 | 하는 일 |
+|---|---|---|---|---|---|---|---|---|
+| 1 | 1.00000000000000000000 | 82328 | 0.425866908852397 | 35060.77087199996 | 73.97384293539044% | 13.2000048586143232 | `UnitRepository.findUnitProgressByChapterIdAndUserId` | 챕터의 유닛별로 전체 레슨 수와 해당 유저가 제출한 레슨 수를 한 번에 집계한다 |
+| 2 | 1.00000000000000000000 | 82328 | 0.038811200454280305 | 3195.2485110000384 | 6.741574860267018% | 13.2000048586143232 | `UnitRepository.findAllUnitSummaryByChapterId` | 챕터에 속한 유닛의 id, title, description을 읽는다 |
+| 3 | 1.00000000000000000000 | 82328 | 0.032994515717617544 | 2716.372489999964 | 5.731206329229537% | 1.00000000000000000000 | `AuthTokenProvider.parseUser` (`JwtAuthFilter` 경유) | 토큰의 subject로 유저 엔티티 전체 컬럼을 읽는다 |
+| 4 | 2.0000000000000000 | 164656 | 0.014914430776892775 | 2455.750513999979 | 5.181326545110739% | 0.000000000000000000000000 | - | 트랜잭션 제어 |
+| 5 | 1.00000000000000000000 | 82328 | 0.026223036427460857 | 2158.8901429999996 | 4.554988278383361% | 0.000000000000000000000000 | `UserRepository.updateLastAccessedAt` (`LastAccessInterceptor` 경유) | 유저의 last_accessed_at을 갱신한다 |
+| 6 | 1.00000000000000000000 | 82328 | 0.020225839325623964 | 1665.152899999996 | 3.513264427006115% | 1.00000000000000000000 | `ChapterRepository.findChapterSummaryByChapterId` | 챕터 단건의 id, title, description을 읽는다 |
+| 7 | 1.00006073267903993781 | 82333 | 0.0017461307738087905 | 143.7641850000186 | 0.3033244556929833% | 0.000000000000000000000000 | - | 트랜잭션 제어 |
+| 8 | 0.000060732679039937809737 | 5 | 0.0373414 | 0.186707 | 0.0003939284262562508% | 0.00000000000000000000 | `SeasonRepository.findCloseableActiveByNowForUpdate` | 마감 시각이 지난 ACTIVE 시즌을 잠금 조회한다 |
+| 9 | 0.00054659411135944029 | 45 | 0.0007898000000000001 | 0.03554100000000002 | 7.49870663530206e-05% | 0.00000000000000000000 | - | 트랜잭션 제어 |
+| 10 | 0.000036439607423962685842 | 3 | 0.000514 | 0.001542 | 3.2534272056598776e-06% | 0.00000000000000000000 | - | 트랜잭션 제어 |
+
+사라진 쿼리 (상태 0에 있었으나 상태 1에 없음)
+
+| 쿼리 | 상태 0의 요청당 | 상태 0의 비중 |
+|---|---|---|
+| `LessonSubmissionRepository.countSolvedLessonByUnitIdAndUserId` | 13.2000178321990073 | 72.96558285477879% |
+| `LessonRepository.countTotalLessonByUnitId` | 10.3032365441198324 | 22.6434544401578% |
+
+새로 생긴 쿼리 (상태 1에만 있음)
+
+| 쿼리 | 상태 1의 요청당 | 상태 1의 비중 |
+|---|---|---|
+| `UnitRepository.findUnitProgressByChapterIdAndUserId` | 1.00000000000000000000 | 73.97384293539044% |
+
+상태 0에 있던 `SET application_name = 'PostgreSQL JDBC Driver'`(7회)는 상태 1의 상위 20행에 나타나지 않았다.
+
+## 쿼리 원문
+
+[1] select u1_0.id,u1_0.title,count(distinct l1_0.id),count(distinct ls1_0.lesson_id) from unit u1_0 left join lesson l1_0 on l1_0.unit_id=u1_0.id left join lesson_submission ls1_0 on ls1_0.lesson_id=l1_0.id and ls1_0.user_id=$1 where u1_0.chapter_id=$2 group by u1_0.id,u1_0.title order by u1_0.id
+
+[2] select u1_0.id,u1_0.title,u1_0.description from unit u1_0 where u1_0.chapter_id=$1
+
+[3] select u1_0.id,u1_0.created_at,u1_0.deleted_at,u1_0.email,u1_0.handle,u1_0.is_onboarded,u1_0.last_accessed_at,u1_0.level,u1_0.xp,u1_0.nickname,u1_0.profile_img_number,u1_0.provider_id,u1_0.role,u1_0.status,u1_0.updated_at from users u1_0 where u1_0.id=$1 and (u1_0.deleted_at IS NULL)
+
+[4] BEGIN READ ONLY
+
+[5] update users u1_0 set last_accessed_at=$1 where u1_0.id=$2 and (u1_0.last_accessed_at is null or u1_0.last_accessed_at<$3) and (u1_0.deleted_at IS NULL)
+
+[6] select c1_0.id,c1_0.title,c1_0.description from chapter c1_0 where c1_0.id=$1
+
+[7] BEGIN
+
+[8] select s1_0.id,s1_0.ends_at,s1_0.season_key,s1_0.starts_at,s1_0.status,s1_0.tz from season s1_0 where s1_0.status=$2 and s1_0.ends_at<=$1 for no key update
+
+[9] COMMIT
+
+[10] ROLLBACK

--- a/.claude/resources/perf/490/units/record.md
+++ b/.claude/resources/perf/490/units/record.md
@@ -1,0 +1,430 @@
+# [PERF-490] GET /api/v1/units/{chapterId}
+
+> 이슈: #490
+> 브랜치: refactor/490-chapter-unit-query-performance
+> 대상 디렉토리: `.claude/resources/perf/490/units/`
+
+이 파일은 대상 엔드포인트 하나만 다룬다. 같은 이슈의 다른 엔드포인트는 각자의 디렉토리에 각자의 `record.md`를 가진다.
+
+## 진행 상태
+
+> ⏳ 미완 / ✅ 완료 / ⏭️ 건너뜀
+> 재진입 시 ⏳로 표기된 가장 이른 Phase부터 재개한다.
+
+**준비 (대상당 1회)**
+
+| 1. 대상 | 2. 환경 | 3. 조건 | 4. 기준선 |
+|---|---|---|---|
+| ✅ | ✅ | ✅ | ✅ |
+
+**사이클 (반복)**
+
+| # | 기법 | 5. 설계 | 6. 스냅샷 | 7. 적용 | 8. 검증 |
+|---|---|---|---|---|---|
+| 1 | 단일 집계 쿼리로 N+1 제거 | ✅ | ✅ | ✅ | ✅ |
+
+## 대상
+
+- 엔드포인트: `GET /api/v1/units/{chapterId}`
+- 실행 경로: `UnitController.getAllUnitInChapter` → `UnitFacade.getAllUnitInChapter` → (`ChapterQueryService`, `UnitQueryService`, `LearningProgressRateService`) → (`ChapterRepository`, `UnitRepository`, `LessonSubmissionRepository`, `LessonRepository`)
+- 트랜잭션 경계: `open-in-view: false`. 요청 1회가 트랜잭션 3개로 쪼개진다 - 필터의 SELECT, 인터셉터의 UPDATE, 파사드의 `@Transactional(readOnly = true)`
+- 예상 쿼리 목록 (요청 1회 기준, `n` = 챕터의 유닛 수, `k` = 그중 제출 이력이 1건 이상인 유닛 수, `0 <= k <= n`)
+
+  **API 밖 (필터, 인터셉터)**
+  1. `UserRepository.findById` - SELECT. `JwtAuthFilter:81` → `AuthTokenProvider.parseUser:67`. 1회
+  2. `UserRepository.updateLastAccessedAt` - UPDATE. `LastAccessInterceptor:30` → `UserAccessService.updateLastAccessed`. 1회
+
+  **파사드 (`UnitFacade:30~44`)**
+  3. `ChapterRepository.findChapterSummaryByChapterId` - 챕터 단건 요약. 1회
+  4. `UnitRepository.findAllUnitSummaryByChapterId` - `WHERE u.chapterId = :chapterId`. 1회
+  5. `LessonSubmissionRepository.countSolvedLessonByUnitIdAndUserId` - `COUNT(DISTINCT l.id)`, `LessonSubmission` JOIN `Lesson`. 유닛마다 1회, 총 `n`회
+  6. `LessonRepository.countTotalLessonByUnitId` - `COUNT(l.id)`, `Unit` JOIN `Lesson`. `solvedLessonCount == 0`이면 조기 반환(`LearningProgressRateService:41`)이라 건너뛴다. 총 `k`회
+
+  **합계: `4 + n + k`** (하한 `4 + n`, 상한 `4 + 2n`)
+
+- 지연 로딩 추가 쿼리 후보: 없음. 4~6은 전부 JPQL 생성자 표현식과 `COUNT` 스칼라 반환이라 엔티티 프록시를 만들지 않는다
+- 참고: `UnitRepository.findUnitProgressByChapterIdAndUserId`(`UnitRepository:59`)가 챕터 단위 유닛별 진행 집계를 단일 쿼리로 이미 제공하지만 이 API는 사용하지 않는다
+
+## 측정 환경
+
+> 값이 바뀌면 그 사실을 사이클 기록에 남긴다.
+
+| 항목 | 값 |
+|---|---|
+| 프로파일 | perf (`application="gravit-perf"` 확인) |
+| 커넥션 풀 크기 | 60 (`application-perf.yml:17` `maximum-pool-size`) |
+| 데이터 규모 | `users` 1,002 / `chapter` 5 / `unit` 66 / `lesson` 230 / `lesson_submission` 317,300. 현재 규모 유지로 확정, 시드 미사용 |
+| 카디널리티 | `unit.chapter_id` 5 / `lesson.unit_id` 66 / `lesson_submission.user_id` 1,000 / `lesson_submission.lesson_id` 148 (`lesson` 230개 중 82개는 제출 이력 없음) |
+| 부하 조건 | VU 50. ramp-up 30s + 유지 1m + ramp-down 30s = 총 2m. 이슈 472, 475와 동일 조건 |
+| Redis 캐시 상태 | cold (measure 직전 FLUSHDB) |
+| DB 캐시 상태 | 제어하지 않음. Redis FLUSHDB는 PostgreSQL의 `shared_buffers`와 OS page cache를 비우지 않는다. 둘을 묶어 cold라고 적지 마라 |
+| 캐시 제어 수단 | `redis-cli -h localhost -p 6379` (PONG 확인) |
+| 시드 SQL | 미사용 (현재 규모로 진행) |
+| 시드 모듈과 변수 | - |
+| 유저 범위 | `USER_ID_START=1001`, `USER_COUNT=1000`. `users` id는 1~2000, 총 1,002행 |
+| chapterId 분산 | `900001 + (iterationInTest % 5)`. 챕터 900001은 유닛 14개, 900002~900005는 13개 |
+
+**요청당 쿼리 수 (Phase 1 예측을 실측 데이터로 확정)**
+
+`n`(챕터당 유닛 수) = 13~14. 챕터 900001 상위 유저의 `k`(제출 이력이 있는 유닛 수) = 14 = `n`이라
+`solvedLessonCount == 0` 조기 반환이 걸리지 않는다. 즉 상한이 그대로 실측치가 된다.
+
+| 챕터 | n | k | 요청당 쿼리 (`4 + n + k`) |
+|---|---|---|---|
+| 900001 | 14 | 14 | 32 |
+| 900002~900005 | 13 | 13 (예상) | 30 |
+
+`chapterId`를 5개 순회하므로 요청당 평균은 30~32 사이다. Phase 4의 실측으로 확정한다.
+
+토큰 인덱스(`iterationInTest % 1000`)와 chapterId(`iterationInTest % 5`)가 같은 카운터에서 나오고
+1000이 5의 배수라, 한 유저는 항상 같은 챕터만 조회한다. 챕터별로 서로 다른 유저 200명이 균등하게 붙으므로
+커버리지 문제는 없고, 사이클 간 재현성이 확보된다.
+
+**Phase 2 게이트 통과 기록**
+
+| 검증 항목 | 관측값 |
+|---|---|
+| perf 프로파일 기동 | `application="gravit-perf"` |
+| 응답시간 히스토그램 버킷 수 | 146 |
+| `pg_stat_statements` 행 수 | 51 |
+| Redis 응답 | PONG |
+| psql 접속 | `-h localhost -p 5433 -U postgres -d mydb`, 비밀번호 `postgres` (`PGPASSWORD` 사용) |
+
+기동 전 `build/`에 Finder식 사본(`V1__init_tables 2.sql` 등 27개)이 남아 Flyway가 `Found more than one migration with version 1`로 실패했다. `rm -rf build out` 후 정상 기동. 소스 트리(`src/main/resources/db/migration/`)에는 사본이 없었다.
+
+## 기준선 (Baseline)
+
+| 지표 | 값 |
+|---|---|
+| p95 | 251.16699999999997 ms |
+| p99 | 502.76631999999995 ms |
+| med | 128.171 ms |
+| max | 1101.469 ms |
+| RPS | 280.3764562439154 |
+| 에러율 | 0 |
+| check 통과율 | 1 (33,647/33,647, 3개 항목 전부) |
+| 요청당 쿼리 수 | **27.5033** (트랜잭션 제어문 3.0001 별도) |
+
+**커넥션 풀 (부하 종료 후 프로메테우스 누적값, warmup과 토큰 발급 포함)**
+
+| 지표 | 값 |
+|---|---|
+| `hikaricp_connections_pending` | 0 |
+| 획득 횟수 / 시간 총합 / 평균 | 115,405회 / 1.077초 / 9.33 µs |
+| 커넥션 점유 시간 총합 | 4,588.165초 |
+| 서버측 응답시간 총합 | 4,620.531154398초 (38,103건) |
+| 점유 / 응답 비율 | **99.30%** |
+| 요청당 체크아웃 | 3.029회 (115,405 ÷ 38,103) |
+| 평균 동시 점유 커넥션 | 약 37개 / 풀 60 = 61.7% |
+
+**measure 구간 추정치** (warmup 4,456건을 5 VU ÷ 30초로 분리한 값)
+
+| 구분 | 요청당 | 비율 |
+|---|---|---|
+| 커넥션 점유 | 131.93 ms | 100% |
+| 그중 실제 SQL 실행 | 2.7876 ms | 2.11% |
+| 그 외 (왕복, Hibernate 처리, 스레드 스케줄링) | 129.14 ms | 97.89% |
+| 서버측 평균 응답 | 132.87 ms | - |
+| k6 클라이언트측 평균 응답 (Little's Law, 50 VU ÷ 280.376 RPS) | 178.33 ms | - |
+
+### 쿼리 통계 (total_exec_time 상위)
+
+> 전체: `query-stats-summary-0.md` / k6 요약: `k6-test-summary-0.json`
+> 여기에는 진단 근거로 쓴 행만 옮긴다. 전체를 복사하지 않는다.
+
+| 요청당 | mean_ms | total_ms | 비중 | 출처 |
+|---|---|---|---|---|
+| 13.2000178321990073 | 0.15408816826638075 | 68436.87314199883 | 72.96558285477879% | `LessonSubmissionRepository.countSolvedLessonByUnitIdAndUserId` |
+| 10.3032365441198324 | 0.06126250718977414 | 21238.057155000402 | 22.6434544401578% | `LessonRepository.countTotalLessonByUnitId` |
+| 1.00000000000000000000 | 0.03226445582072698 | 1085.602144999997 | 1.1574402748349957% | `AuthTokenProvider.parseUser` (`JwtAuthFilter` 경유) |
+| 1.00000000000000000000 | 0.03094173117959992 | 1041.0964290000004 | 1.1099894583493994% | `UnitRepository.findAllUnitSummaryByChapterId` |
+| 1.00000000000000000000 | 0.01871428739560719 | 629.6796280000033 | 0.6713477539143252% | `UserRepository.updateLastAccessedAt` (`LastAccessInterceptor` 경유) |
+| 1.00000000000000000000 | 0.016008778613249366 | 538.6473740000002 | 0.5742915740109473% | `ChapterRepository.findChapterSummaryByChapterId` |
+
+상위 2건 합계: 요청당 23.5033회(전체 호출의 85.5%), DB 시간 비중 95.609%.
+
+### 진단
+
+- **병목 성격: N+1.** 느린 쿼리 하나가 아니라, 빠른 쿼리를 챕터의 유닛 수만큼 순차 반복하면서 왕복 비용이 누적된다.
+- 근거
+  - 개별 쿼리는 빠르다. `countSolvedLessonByUnitIdAndUserId` 0.15408816826638075 ms, `countTotalLessonByUnitId` 0.06126250718977414 ms.
+  - 호출 수가 유닛 수에 비례한다. 요청당 각각 13.2000178321990073회, 10.3032365441198324회로 두 건이 전체 호출 27.5033회 중 23.5033회(85.5%), DB 시간의 95.609%를 차지한다.
+  - 시간이 실행이 아니라 왕복에 있다. 커넥션 점유 131.93 ms 중 실제 SQL 실행은 2.7876 ms(2.11%)뿐이다. 왕복 1회당 131.93 ÷ 27.5 = 약 4.80 ms인데 그중 서버 실행은 0.10 ms다.
+  - 커넥션 대기는 아니다. `pending`이 0이고 획득 시간 총합이 115,405회에 1.077초(평균 9.33 µs)다. 평균 동시 점유 약 37개로 풀 60에 미달해 대기열이 생기지 않았다.
+  - localhost 왕복 자체는 0.1 ms 안팎이므로 4.80 ms 전부가 통신 시간은 아니다. 한 머신에서 k6 50 VU, 톰캣 스레드, 활성 PostgreSQL 백엔드 37개가 CPU를 나눠 쓰는 스케줄링 지연이 섞여 있다. 다만 두 성분 모두 왕복 횟수에 비례하므로 호출 수를 줄이면 함께 준다.
+- 예상 쿼리 목록과 어긋난 지점
+  - `k`(제출 이력이 있는 유닛 수)를 Phase 3에서 `n`과 같은 13.2로 예측했으나 실측은 10.3032365441198324였다. 요청당 2.8968개 유닛에서 `solvedLessonCount == 0` 조기 반환이 걸렸다.
+  - 원인은 Phase 3의 확인 쿼리가 `ORDER BY units_with_submission DESC LIMIT 5`로 상위 5명만 본 편향 표본이었다는 점이다. 1,000명 전체 평균은 10.30이다.
+  - `n`은 예측과 정확히 일치했다. `findAllUnitSummaryByChapterId`의 행/호출이 13.2000178321990073으로 `(14+13+13+13+13)/5 = 13.2`와 맞는다.
+  - 그 외 쿼리는 전부 예상 목록과 일치했다. 목록에 없던 것은 시즌 마감 스케줄러(`SeasonRepository.findCloseableActiveByNowForUpdate`, 요청당 0.00011888132671560615회)뿐으로 무시 가능한 수준이다.
+
+### 인덱스 현황 (Phase 5-B 재료)
+
+| 테이블 | 인덱스 | 정의 | 크기 |
+|---|---|---|---|
+| `lesson` | `lesson_pkey` | `btree (id)` UNIQUE | 16 kB |
+| `lesson_submission` | `lesson_submission_pkey` | `btree (id)` UNIQUE | 13 MB |
+| `lesson_submission` | `ix_lesson_submission_user_created_at` | `btree (user_id, created_at) INCLUDE (lesson_id)` | 12 MB |
+
+`lesson`에 `unit_id` 인덱스가 없고, `lesson_submission`에 `lesson_id` 선두 인덱스가 없다.
+
+**부하 중 스캔 통계**
+
+| 테이블 | seq_scan | seq_tup_read | idx_scan | 행 수 | 테이블 크기 |
+|---|---|---|---|---|---|
+| `lesson` | 895,559 | 205,978,570 | 624 | 230 | 24 kB |
+| `lesson_submission` | 6 | 1,269,200 | 502,961 | 317,300 | 48 MB |
+| `unit` | 430,702 | 28,426,332 | 2 | 66 | 16 kB |
+| `chapter` | 38,104 | 190,520 | 0 | 5 | 8,192 bytes |
+
+- `lesson` seq_scan 895,559 ≈ 요청당 23.5회 × 38,103건. 두 count 쿼리가 매번 230행을 전체 스캔한다.
+- `lesson_submission`만 인덱스를 탄다. `idx_tup_read` 159,593,077 ÷ `idx_scan` 502,961 = 호출당 317.3행을 읽어 `idx_tup_fetch` 기준 약 2.03행을 쓴다. 요청당 13.2회 반복되어 4,188행을 훑는다.
+- `lesson`과 `unit`의 Seq Scan은 테이블이 24 kB, 16 kB로 작아 플래너가 고른 것이다. 인덱스를 추가해도 채택되지 않을 공산이 크다.
+
+**카디널리티 (pg_stats)**
+
+| 테이블 | 컬럼 | n_distinct | correlation |
+|---|---|---|---|
+| `lesson` | `unit_id` | -0.28695652 (230 × 0.287 = 66) | -0.46198505 |
+| `lesson_submission` | `user_id` | 1000 | -0.006640228 |
+| `lesson_submission` | `lesson_id` | 148 | -0.14780127 |
+
+---
+
+## 사이클 1: 단일 집계 쿼리로 N+1 제거
+
+### 설계 결정
+
+> Phase 5-B에서 호출자와 확정한 내용.
+
+| 결정 항목 | 정한 값 | 근거 |
+|---|---|---|
+| 기법 | 로직 개선 - 유닛별 반복 호출을 챕터 단위 집계 쿼리 1회로 대체 | 요청당 23.5033회 호출이 DB 시간 95.609%를 차지하고, 시간이 실행(2.11%)이 아니라 왕복에 있다 |
+| 집계 쿼리 | 기존 `UnitRepository.findUnitProgressByChapterIdAndUserId`(`UnitRepository.java:59`)를 **수정 없이** 재사용 | 유닛별 `totalLessons`, `solvedLessons`를 이미 한 쿼리로 준다. 수정하지 않으면 이 쿼리를 공유하는 `LearningFacade:45`, `UserFacade:114`에 영향이 없다 |
+| description 공급 | `UnitRepository.findAllUnitSummaryByChapterId` 유지 | 이 쿼리가 이미 `(id, title, description)`을 준다. 집계 쿼리에는 `description`이 없어 추가하려면 `GROUP BY` 확장과 `UnitProgressRowDto` 시그니처 변경이 따르고, 공유 호출부 2곳에 파급된다 |
+| 두 목록의 정합 | `unitId`로 결합. `WHERE u.chapterId = :chapterId`가 동일하고 집계는 `Unit` 기준 `LEFT JOIN`이라 유닛 집합이 같다. 같은 `readOnly` 트랜잭션 안에서 동일 스냅샷을 본다 | 레슨이 0개인 유닛도 `totalLessons=0, solvedLessons=0` 행으로 나온다 |
+| 진행률 계산 위치 | `LearningProgressRateService.calculateProgressRate(solvedLessons, totalLessons)` 신규. DB를 타지 않으므로 트랜잭션 어노테이션을 붙이지 않는다 | 진행률 규칙을 learning 도메인에 남겨 `getChapterProgress`, `getPlanetConquestRate`와 위치를 일관되게 둔다. Service가 다른 도메인 Service를 호출하지 않는 컨벤션상, 조합은 `UnitFacade`가 맡는다 |
+| 0으로 나누기 | `solvedLessons == 0`을 먼저 걸러 `0.0` 반환 | 레슨이 0개면 제출도 0건이라 반드시 이 분기에 걸린다. 현재 `getUnitProgress:39`와 같은 구조 |
+| 미사용 메서드 처리 | `LearningProgressRateService.getUnitProgress`와 `LessonSubmissionRepository.countSolvedLessonByUnitIdAndUserId` **제거** | 변경 후 호출부가 0개다. `LessonRepository.countTotalLessonByUnitId`는 `AdminUnitService:31`이 계속 쓰므로 남긴다 |
+
+**변경 대상**
+
+| 클래스.메서드 | 작업 |
+|---|---|
+| `UnitQueryService.getAllUnitProgressInChapter(chapterId, userId)` | 신규. `unitRepository.findUnitProgressByChapterIdAndUserId`를 그대로 호출해 `List<UnitProgressRowDto>` 반환 |
+| `LearningProgressRateService.calculateProgressRate(solvedLessons, totalLessons)` | 신규. 순수 계산 |
+| `UnitFacade.getAllUnitInChapter` | `stream().map()` 안의 유닛별 `getUnitProgress` 호출 제거. 집계 1회 + `unitId → progressRate` 맵으로 결합 |
+| `LearningProgressRateService.getUnitProgress` | 제거 |
+| `LessonSubmissionRepository.countSolvedLessonByUnitIdAndUserId` | 제거 |
+
+**영향 테스트**: `UnitFacadeUnitTest`, `UnitFacadeIntegrationTest`, `UnitQueryServiceUnitTest`, `UnitQueryServiceIntegrationTest`, `LearningProgressRateServiceUnitTest`, `LearningProgressRateServiceIntegrationTest`
+
+- 검토했지만 택하지 않은 안
+  - **인덱스 추가**(`lesson(unit_id)`, `lesson_submission(user_id, lesson_id)`) - 호출 수 23.5033회는 그대로 남고, 실행시간은 커넥션 점유 131.93 ms의 2.11%(2.7876 ms)뿐이라 개선 상한이 낮다. `lesson`은 24 kB라 인덱스가 채택되지 않을 공산도 크다
+  - **콘텐츠 캐싱**(Redis) - 요청당 27.50 → 14.20으로 줄지만 유저별 진행률 13.20회가 남는다. 무효화 설계 비용이 셋 중 가장 크다. 이번 사이클 이후 추가 사이클로 검토 가능
+  - **집계 쿼리에 description 통합**(옵션 2) - 요청당 4.0으로 1회 더 줄지만(기준선 대비 3.6%p), 공유 쿼리를 수정해 `LearningFacade`, `UserFacade` 2곳에 파급된다. 본체 효과(23.5 → 1)에 비해 이득이 작다
+- 호출자가 예상한 효과: 요청당 쿼리 수 27.5033 → 5.0
+
+### 개선 전 지표
+
+| 지표 | 값 |
+|---|---|
+| p95 / p99 | 251.16699999999997 ms / 502.76631999999995 ms |
+| RPS | 280.3764562439154 |
+| 요청당 쿼리 수 | 27.5033 |
+| `countSolvedLessonByUnitIdAndUserId` calls / mean_ms / total_ms | 444141 / 0.15408816826638075 / 68436.87314199883 (비중 72.96558285477879%) |
+| `countTotalLessonByUnitId` calls / mean_ms / total_ms | 346673 / 0.06126250718977414 / 21238.057155000402 (비중 22.6434544401578%) |
+
+**실행계획**
+
+> 원본: `query-plan-0.txt` (개선 후는 `query-plan-1.txt`)
+
+- EXPLAIN 파라미터: `chapterId = 900003`, `unitId = 900033`, `userId = 1500` (이후 모든 사이클에서 동일하게 사용)
+  - 전부 분포의 중앙값이다. 챕터 900001~900005의 중앙이 900003, 그 챕터의 유닛 900027~900039의 중앙이 900033, 유저 1001~2000의 중앙이 1500(제출 317건 / 서로 다른 레슨 117개).
+- 캡처한 쿼리 2개
+  - 계획 A: `countSolvedLessonByUnitIdAndUserId` - 개선 전 지배 쿼리(요청당 13.20회, 72.97%)
+  - 계획 B: `findUnitProgressByChapterIdAndUserId` - 개선 후 대체 쿼리. 기준선 부하에서 실행된 적이 없어 `pg_stat_statements`에 Hibernate 생성 원문이 없다. JPQL(`UnitRepository.java:59`)을 손으로 SQL로 옮겨 캡처했으므로 Phase 8에서 실제 생성 SQL로 재확인한다.
+
+| 항목 | 계획 A | 계획 B |
+|---|---|---|
+| 스캔 방식 | `Index Only Scan` (`ix_lesson_submission_user_created_at`) + `lesson` Seq Scan, Hash Join | 동일 `Index Only Scan` + `lesson`, `unit` Seq Scan, Hash Right Join 2단, Sort, GroupAggregate |
+| actual rows 대 반환 행 수 | 317 → 조인 후 6 → 집계 1 (**317:1**) | 317 + 230 + 66 → 78 → 13 (**47:1**) |
+| Rows Removed by Filter | `lesson` Seq Scan 228 (230행 중 2행 남김) | `unit` Seq Scan 53 (66행 중 13행 남김). `lesson` Seq Scan은 필터 없음 |
+| shared hit / read | 최상단 hit=14 / read=0 (114.7 KB) | 최상단 hit=10 / read=0 (81.9 KB) |
+| 플래너 추정 대 실측 | Index Only Scan 465 / 317 = 1.47배 | 동일 1.47배 |
+| Heap Fetches | 0 | 0 |
+| Planning / Execution Time | 4.455 ms / 2.734 ms | 1.103 ms / 0.822 ms |
+
+**요청 단위 환산**
+
+| 항목 | 개선 전 (A × 13.20 + `countTotalLessonByUnitId` × 10.30) | 개선 후 (B × 1) | 변화 |
+|---|---|---|---|
+| 만진 버퍼 | 184.8 페이지 (1.44 MB) | 10 페이지 (0.078 MB) | -94.6% |
+| 인덱스에서 읽은 행 | 4,184.4 | 317 | -92.4% |
+| `lesson` 스캔 행 | 5,405.7 | 230 | -95.7% |
+
+**해석**
+
+- 노드 단위 비율은 두 계획이 같다. `Index Only Scan`은 양쪽 모두 317행을 읽고 추정/실측 1.47배, `Heap Fetches: 0`까지 동일하다. 이번 변경은 노드의 비효율을 고치지 않고, **그 노드를 도는 횟수를 13.20회에서 1회로 줄인다.**
+- `lesson` Seq Scan도 같다. 계획 A는 230행을 훑어 228행을 버리기를 13.20회 반복하고, 계획 B는 230행을 한 번 훑되 필터가 없다. 걸러내는 일이 `unit`(66행 중 53행 제거)으로 옮겨간다.
+- 위험 신호 대조: 검사/반환 비율 317:1 → 47:1, 동일 쿼리 요청당 호출 13.20회 → 1회, 단일 쿼리 시간 점유율 72.97% → 해당 쿼리 소멸. 플래너 추정 괴리 1.47배는 기준(10배) 안이라 신호가 아니다.
+- 노드 자체의 317:1을 줄이려면 `lesson_submission(user_id, lesson_id)` 인덱스로 플래너가 `lesson` 26행을 먼저 잡고 탐침하도록 유도하는 방향이 있으나, 사이클 2 후보이며 이번 범위가 아니다.
+- `EXPLAIN ANALYZE`의 절대 시간(2.734 ms, 0.822 ms)은 계측 오버헤드와 미캐시 Planning Time을 포함하므로 `pg_stat_statements` 평균(0.154 ms)과 직접 비교하지 않는다. 비교는 노드 구조와 행 수로 한다.
+
+**로직 개선 기법의 추가 캡처 - 변경 전 요청당 쿼리 수와 호출 스택**
+
+| 쿼리 | 요청당 | 호출 스택 |
+|---|---|---|
+| `countSolvedLessonByUnitIdAndUserId` | 13.2000178321990073 | `UnitFacade:38` → `LearningProgressRateService.getUnitProgress:38` → `LessonSubmissionRepository` |
+| `countTotalLessonByUnitId` | 10.3032365441198324 | `UnitFacade:38` → `LearningProgressRateService.getUnitProgress:44` → `LessonRepository` |
+
+두 호출 모두 `UnitFacade.getAllUnitInChapter`의 `unitSummaries.stream().map(...)`(`UnitFacade.java:34~44`) 안에 있어 유닛 수만큼 반복된다.
+
+### 적용 내용
+
+**메인 코드**
+
+| 파일 | 변경 |
+|---|---|
+| `unit/facade/UnitFacade.java` | `unitSummaries.stream().map(...)` 안의 유닛별 `learningProgressRateService.getUnitProgress` 호출 제거. `unitQueryService.getAllUnitProgressInChapter`를 1회 호출해 `unitId → progressRate` 맵을 만들고 유닛 목록과 결합. `NOT_STARTED_PROGRESS_RATE = 0.0` 상수 추가 |
+| `unit/service/UnitQueryService.java` | `getAllUnitProgressInChapter(chapterId, userId)` 신규. `unitRepository.findUnitProgressByChapterIdAndUserId`를 그대로 위임해 `List<UnitProgressRowDto>` 반환 |
+| `learning/service/LearningProgressRateService.java` | `getUnitProgress(unitId, userId)` 제거. `calculateProgressRate(solvedLessonCount, totalLessonCount)` 신규 - DB를 타지 않는 순수 계산이라 트랜잭션 어노테이션을 붙이지 않았다 |
+| `lesson/repository/LessonSubmissionRepository.java` | `countSolvedLessonByUnitIdAndUserId` 제거 |
+
+설계대로 `UnitRepository.findUnitProgressByChapterIdAndUserId`와 `findAllUnitSummaryByChapterId`는 수정하지 않았다. 두 쿼리를 공유하는 `LearningFacade:45`, `UserFacade:114`는 무영향이다.
+`LessonRepository.countTotalLessonByUnitId`는 `AdminUnitService:31`이 계속 쓰므로 남겼다.
+
+**테스트**
+
+| 파일 | 변경 |
+|---|---|
+| `UnitFacadeUnitTest` | `getUnitProgress` 스텁을 `getAllUnitProgressInChapter` + `calculateProgressRate` 스텁으로 교체. 유닛이 없는 케이스에도 빈 목록 스텁 추가 |
+| `LearningProgressRateServiceUnitTest` | `GetUnitProgress` 중첩 클래스를 `CalculateProgressRate`로 교체. `totalLessonCount = 0` 케이스를 추가해 0으로 나누기 방어선을 검증 |
+| `LearningProgressRateServiceIntegrationTest` | `GetUnitProgress` 중첩 클래스 제거(대상 메서드 소멸). 커버리지는 순수 계산(`LearningProgressRateServiceUnitTest`), 집계 쿼리(`UnitQueryServiceIntegrationTest`), 종단 결합(`UnitFacadeIntegrationTest`, progressRate 50.0과 0.0 검증)으로 유지 |
+
+- 테스트: `./gradlew test` 통과
+- 컴파일 경고는 기존 `UserFacade.getMainPage` deprecation뿐으로 이번 변경과 무관하다
+
+### 개선 후 지표
+
+| 구분 | 지표 | 개선 전 | 개선 후 | 변화 |
+|---|---|---|---|---|
+| 하드웨어 의존 | p95 | 251.16699999999997 ms | 116.05729999999984 ms | -53.8% |
+| | p99 | 502.76631999999995 ms | 254.81243999999998 ms | -49.3% |
+| | med | 128.171 ms | 46.713499999999996 ms | -63.6% |
+| | max | 1101.469 ms | 1538.989 ms | +39.7% (단일 표본, 아래 참조) |
+| | RPS | 280.3764562439154 | 686.0507502892599 | +144.7% |
+| | 요청 수 (2m) | 33647 | 82328 | +144.7% |
+| | 서버측 평균 응답 | 121.26 ms | 48.89 ms | -59.7% |
+| 하드웨어 독립 | 요청당 쿼리 수 | 27.5033 | 5.0000 | **-81.8%** |
+| | 요청당 DB 시간 | 2.7876 ms | 0.5757 ms | -79.3% |
+| | 총 DB 시간 | 93793.362 ms | 47396.173 ms | -49.5% |
+| | 대체된 작업의 요청당 DB 시간 | 2.6652 ms (쿼리 2종) | 0.4259 ms (집계 1회) | -84.0% |
+| | 검사 행 / 반환 행 | 317:1 | 47:1 | 해소 |
+| | 스캔 방식 | `Index Only Scan` + `lesson` Seq Scan을 요청당 13.20회 반복 | 동일 노드를 요청당 1회 | 반복 소멸 |
+| | 플래너 추정 / 실측 | 465 / 317 = 1.47배 | 315 / 317 = 1.006배 | `VACUUM ANALYZE`로 통계 갱신됨 |
+| | 캐시 hit / miss, 적중률 | - | - | - |
+
+**쿼리 구성 변화**
+
+| 쿼리 | 전 (요청당) | 후 (요청당) |
+|---|---|---|
+| `countSolvedLessonByUnitIdAndUserId` | 13.2000178321990073 | 소멸 |
+| `countTotalLessonByUnitId` | 10.3032365441198324 | 소멸 |
+| `findUnitProgressByChapterIdAndUserId` | 없음 | 1.00000000000000000000 |
+| `findAllUnitSummaryByChapterId` | 1.0 | 1.0 |
+| `AuthTokenProvider.parseUser` | 1.0 | 1.0 |
+| `updateLastAccessedAt` | 1.0 | 1.0 |
+| `findChapterSummaryByChapterId` | 1.0 | 1.0 |
+| `BEGIN READ ONLY` / `BEGIN` | 2.0 / 1.0001 | 2.0 / 1.0001 |
+
+**max 1538.989 ms의 정체 - 단일 외톨이**
+
+서버측 히스토그램(앱 재기동으로 이번 측정만 담김)으로 꼬리 분포를 대조했다.
+
+| 구간 | 개선 전 건수 / 비율 | 개선 후 건수 / 비율 |
+|---|---|---|
+| > 0.5s | 346 / 38103 = 0.908% | 264 / 92121 = 0.287% |
+| > 0.715827881s | 99 = 0.260% | 84 = 0.091% |
+| > 1.0s | 24 = 0.063% | 47 = 0.051% |
+| > 1.431655765s | 0 = 0.000% | **1 = 0.0011%** |
+| > 2.147483647s | - | 0 = 0% |
+
+- `1.431655765s`를 넘긴 요청이 92,121건 중 **1건**이고 그 위로는 없다. k6의 `max` 1538.989 ms가 그 한 건이다.
+- 비율로 보면 꼬리는 모든 구간에서 얇아졌다. 0.5초 초과 0.908% → 0.287%(-68.4%), 1.0초 초과 0.063% → 0.051%(-19.0%).
+- 1.0초 초과 절대 건수가 24 → 47로 는 것은 표본이 38,103 → 92,121건으로 2.42배 커진 결과다.
+- `max / med` 비율이 8.60배 → 32.94배로 나빠진 것은 분모(med)가 63.6% 줄어 생긴 착시다. 단일 표본을 중앙값으로 나눈 값은 분포 두께를 대표하지 못한다.
+
+**실행계획 (개선 후, `query-plan-1.txt`)**
+
+파라미터는 Phase 6과 동일(`chapterId = 900003`, `userId = 1500`).
+
+| 노드 | 스캔 방식 / 인덱스 | actual time | 추정 rows | 실측 rows | loops | Rows Removed by Filter | shared hit / read |
+|---|---|---|---|---|---|---|---|
+| GroupAggregate | Group Key: `u1_0.id` | 0.795..0.859 | 13 | 13 | 1 | - | hit=16 / read=0 |
+| Sort | quicksort, Memory 31kB | 0.726..0.739 | 62 | 78 | 1 | - | hit=16 / read=0 |
+| Hash Right Join | `ls.lesson_id = l.id` | 0.522..0.667 | 62 | 78 | 1 | - | hit=13 / read=0 |
+| Index Only Scan | `ix_lesson_submission_user_created_at` | 0.369..0.425 | 315 | 317 | 1 | - | hit=8 / read=0 |
+| Hash | - | 0.137..0.141 | 45 | 26 | 1 | - | hit=5 / read=0 |
+| Hash Right Join | `l.unit_id = u.id` | 0.101..0.132 | 45 | 26 | 1 | - | hit=5 / read=0 |
+| Seq Scan on `lesson` | 필터 없음 | 0.003..0.028 | 230 | 230 | 1 | - | hit=3 / read=0 |
+| Hash | - | 0.032..0.033 | 13 | 13 | 1 | - | hit=2 / read=0 |
+| Seq Scan on `unit` | Filter: `chapter_id = 900003` | 0.012..0.018 | 13 | 13 | 1 | 53 | hit=2 / read=0 |
+
+Planning Time 2.571 ms / Execution Time 0.982 ms / Heap Fetches 0
+
+**Phase 6의 손 번역 SQL 검증**
+
+Phase 6에서 집계 쿼리를 JPQL에서 손으로 SQL로 옮겨 캡처했고, Phase 8에서 확인하기로 했다.
+`query-stats-summary-1.md` 1행의 Hibernate 생성 원문과 대조한 결과 공백과 `$1/$2` 대 리터럴을 빼면 토큰 단위로 동일하다.
+조인 순서, 조인 종류(`left join` 2개), 조인 조건 위치(`and ls1_0.user_id`가 `ON` 절), `GROUP BY` 키, `ORDER BY`가 모두 같다.
+
+`query-plan-0.txt`의 계획 B와 `query-plan-1.txt`의 `Query Identifier`가 581384667906442718로 같은 것은 **같은 SQL 텍스트를 두 번 EXPLAIN했기 때문**이며 손 번역의 검증 근거가 아니다.
+개선 전 지배 쿼리(`query-plan-0.txt` 계획 A)의 identifier는 8221422339103481763으로 다르다.
+
+### 판정
+
+- **개선 여부 (하드웨어 독립 증거 기준): 있음.**
+  - 요청당 쿼리 수 27.5033 → 5.0000(-81.8%). 코드 구조로 결정되는 값이라 측정 편차로 흔들리지 않는다.
+  - 요청당 DB 시간 2.7876 ms → 0.5757 ms(-79.3%).
+  - 대체된 작업만 떼어 보면 요청당 2.6652 ms(쿼리 13.20회 + 10.30회) → 0.4259 ms(집계 1회)로 -84.0%.
+  - 검사 행/반환 행 317:1 → 47:1.
+  - 하드웨어 의존 지표도 같은 방향이다. p95 -53.8%, p99 -49.3%, RPS +144.7%.
+- 호출자가 예상한 효과와의 대조: Phase 5-B에서 요청당 쿼리 27.5033 → 5.0을 예상했고 실측이 **정확히 5.0**이다. 근거였던 "요청당 23.5033회 호출이 DB 시간 95.609%를 차지하고 시간이 실행이 아니라 왕복에 있다"는 진단이 맞았다.
+- 남은 위험 신호
+  - **단일 쿼리 시간 점유율 73.97%** (기준 30% 이상). `findUnitProgressByChapterIdAndUserId`가 요청당 0.4259 ms로 DB 시간의 73.97%를 차지한다. 다만 절대 시간은 개선 전 같은 작업의 2.6652 ms보다 84.0% 작고, 다른 쿼리들도 함께 줄어 비율이 유지된 것이다.
+  - `Index Only Scan`이 여전히 호출당 317행을 읽어 13행을 만든다(47:1). 노드 자체의 비효율은 이번 사이클이 건드리지 않았다. `lesson_submission(user_id, lesson_id)` 인덱스로 플래너가 `lesson` 26행을 먼저 잡고 탐침하도록 유도하는 방향이 사이클 2 후보다.
+  - 콘텐츠 캐싱(Phase 5-A의 3번)도 미적용 상태다. 남은 5개 쿼리 중 `findAllUnitSummaryByChapterId`, `findChapterSummaryByChapterId`가 유저와 무관한 콘텐츠 조회다.
+- 다음 사이클 진행 여부: 진행하지 않음. 호출자가 사이클 1에서 종료를 선택했다. 요청당 DB 시간이 응답시간의 0.79%(사이클 1 전 1.563%)로 DB가 더 이상 응답시간을 지배하지 않아, 추가 사이클의 체감 이득이 작다고 판단했다.
+
+---
+
+## 최종 요약
+
+> 하드웨어 의존 증거와 독립 증거를 모두 남긴다.
+
+| 구분 | 지표 | 최초 | 최종 | 변화 |
+|---|---|---|---|---|
+| 하드웨어 의존 | p95 | 251.16699999999997 ms | 116.05729999999984 ms | -53.8% |
+| | p99 | 502.76631999999995 ms | 254.81243999999998 ms | -49.3% |
+| | med | 128.171 ms | 46.713499999999996 ms | -63.6% |
+| | RPS | 280.3764562439154 | 686.0507502892599 | +144.7% |
+| | 2분간 처리 요청 수 | 33647 | 82328 | +144.7% |
+| | 서버측 평균 응답 | 121.26 ms | 48.89 ms | -59.7% |
+| 하드웨어 독립 | 요청당 쿼리 수 | 27.5033 | 5.0000 | **-81.8%** |
+| | 요청당 DB 시간 | 2.7876 ms | 0.5757 ms | -79.3% |
+| | 총 DB 시간 | 93793.362 ms | 47396.173 ms | -49.5% |
+| | 검사 행 / 반환 행 | 317:1 | 47:1 | 해소 |
+| | 스캔 방식 | `Index Only Scan` + `lesson` Seq Scan을 요청당 13.20회 반복 | 동일 노드를 요청당 1회 | 반복 소멸 |
+| | 요청당 만진 버퍼 | 184.8 페이지 (1.44 MB) | 10 페이지 (0.078 MB) | -94.6% |
+| | 캐시 hit / miss, 적중률 | - | - | - |
+
+적용한 기법: 사이클 1 - 단일 집계 쿼리로 N+1 제거
+
+측정 조건은 두 측정이 동일하다. VU 50 / ramp-up 30s + 유지 1m + ramp-down 30s(총 2m) / Redis cold / DB 캐시 미제어 / `USER_ID_START=1001`, `USER_COUNT=1000` / `chapterId = 900001 + (iterationInTest % 5)` / 데이터 규모 변경 없음(시드 미사용) / 커넥션 풀 60. 양쪽 모두 실패율 0, check 통과율 1이다.
+
+남은 개선 여지 (다음 사이클 후보)
+
+- `lesson_submission(user_id, lesson_id)` 인덱스로 집계 쿼리의 호출당 317행 스캔을 줄이는 방향. 요청당 쿼리 수는 5.0 그대로고 실행시간만 준다.
+- 콘텐츠 캐싱(Redis)으로 `findAllUnitSummaryByChapterId`, `findChapterSummaryByChapterId`를 걷어내는 방향. 요청당 쿼리 5.0 → 3.0. 무효화 설계 필요.
+- 두 방향 모두 DB 시간이 이미 응답시간의 0.79%라 체감 이득은 사이클 1보다 작다.

--- a/.claude/resources/perf/490/units/test-script.js
+++ b/.claude/resources/perf/490/units/test-script.js
@@ -1,0 +1,161 @@
+// 부하 테스트 스크립트. 대상: GET /api/v1/units/{chapterId} (이슈 #490)
+//
+// 실행: 토큰 발급, warmup, measure를 각각 따로 돌린다. 통계 리셋은 토큰 발급이 끝난 뒤에 한다.
+//
+//   (토큰 발급 - Phase 4, 8의 명령 블록 참조. $PERF_DIR/tokens.json 생성)
+//   k6 run -e PHASE=warmup $TARGET_DIR/test-script.js
+//   psql ... -c "SELECT pg_stat_statements_reset();"
+//   k6 run -e PHASE=measure -e SUMMARY_OUT=$TARGET_DIR/k6-test-summary-{n}.json \
+//     $TARGET_DIR/test-script.js
+//
+// {n}은 상태 번호다. 0 = 아무것도 적용하지 않은 원본(Phase 4), n = 사이클 n 적용 후(Phase 8).
+
+import http from 'k6/http';
+import exec from 'k6/execution';
+import { check } from 'k6';
+
+const BASE_URL = __ENV.BASE_URL || 'http://localhost:8080';
+const USER_ID_START = Number(__ENV.USER_ID_START || 1001);
+const USER_COUNT = Number(__ENV.USER_COUNT || 1000);
+const PHASE = __ENV.PHASE || 'measure';
+
+// 챕터는 900001~900005 5개. 900001만 유닛 14개, 나머지는 13개다.
+const CHAPTER_ID_START = 900001;
+const CHAPTER_COUNT = 5;
+
+// 이 측정이 무엇이었는지 요약 파일만 보고 알 수 있게 한다.
+const TARGET = 'units';
+const ENDPOINT = 'GET /api/v1/units/{chapterId}';
+const CONDITION = {
+    vus: 50,
+    steady_state_duration: '1m',
+    ramp_up: '30s',
+    ramp_down: '30s',
+    total_duration: '2m',
+    redis_cache: 'cold',
+    db_cache: '제어하지 않음',
+    user_id_start: USER_ID_START,
+    user_count: USER_COUNT,
+    chapter_id_start: CHAPTER_ID_START,
+    chapter_count: CHAPTER_COUNT,
+};
+
+// tokens.json은 이슈 디렉토리에 있다(대상 간 공유).
+const tokens = JSON.parse(open('../tokens.json'));
+
+if (tokens.length !== USER_COUNT) {
+    throw new Error(
+        `토큰 ${tokens.length}건 / 필요 ${USER_COUNT}건. 로그인에 실패한 userId가 있다. ` +
+        'tokens.json을 다시 만들고 userId 범위와 perf 프로파일 기동 상태를 확인하라.'
+    );
+}
+
+const scenarios = {
+    warmup: {
+        executor: 'constant-vus',
+        vus: 5,
+        duration: '30s',
+    },
+    measure: {
+        executor: 'ramping-vus',
+        startVUs: 0,
+        stages: [
+            { duration: '30s', target: 50 },
+            { duration: '1m', target: 50 },
+            { duration: '30s', target: 0 },
+        ],
+    },
+};
+
+export const options = {
+    scenarios: { [PHASE]: scenarios[PHASE] },
+    summaryTrendStats: ['avg', 'min', 'med', 'p(90)', 'p(95)', 'p(99)', 'max'],
+    thresholds: {
+        http_req_failed: ['rate<0.01'],
+        checks: ['rate>0.99'],
+    },
+};
+
+// 비JSON 응답에서 예외를 던지지 않는다. 파싱 실패는 null로 떨어뜨려 check 실패로 드러낸다.
+function parseBody(res) {
+    if (res.status !== 200 || res.body === null || res.body.length <= 2) {
+        return null;
+    }
+    try {
+        return res.json();
+    } catch (e) {
+        return null;
+    }
+}
+
+export default function () {
+    // 시나리오 전체의 반복 번호로 고른다. VU 수와 무관하게 토큰 USER_COUNT개를 균등하게 돈다.
+    const iteration = exec.scenario.iterationInTest;
+
+    const token = tokens[iteration % tokens.length];
+    const params = { headers: { Authorization: `Bearer ${token}` } };
+
+    const chapterId = CHAPTER_ID_START + (iteration % CHAPTER_COUNT);
+
+    const res = http.get(`${BASE_URL}/api/v1/units/${chapterId}`, params);
+
+    check(res, {
+        'status is 200': (r) => r.status === 200,
+        'body is not empty': (r) => r.body !== null && r.body.length > 2,
+        'unitDetailResponses가 실려 있다': (r) => {
+            const body = parseBody(r);
+            return body !== null
+                && Array.isArray(body.unitDetailResponses)
+                && body.unitDetailResponses.length > 0;
+        },
+    });
+}
+
+export function handleSummary(data) {
+    const m = data.metrics || {};
+    const val = (name, key) => (m[name] && m[name].values[key] !== undefined ? m[name].values[key] : null);
+    const trend = (name) => ({
+        med: val(name, 'med'),
+        p95: val(name, 'p(95)'),
+        p99: val(name, 'p(99)'),
+        max: val(name, 'max'),
+    });
+
+    const summary = {
+        phase: PHASE,
+        target: TARGET,
+        endpoint: ENDPOINT,
+        condition: CONDITION,
+        requests: val('http_reqs', 'count'),
+        rps: val('http_reqs', 'rate'),
+        failed_rate: val('http_req_failed', 'rate'),
+        checks_rate: val('checks', 'rate'),
+        checks: ((data.root_group || {}).checks || []).map((c) => ({
+            name: c.name,
+            passes: c.passes,
+            fails: c.fails,
+        })),
+        duration_ms: trend('http_req_duration'),
+        waiting_ms: trend('http_req_waiting'),
+        bytes_received: val('data_received', 'count'),
+    };
+
+    // 아래 반올림은 터미널 한 줄 출력에만 쓴다. summary 객체의 값은 손대지 않는다.
+    const num = (x, d) => (typeof x === 'number' ? x.toFixed(d) : '-');
+    const line = [
+        `[${PHASE}] ${TARGET}`,
+        `요청 ${summary.requests}건`,
+        `p95 ${num(summary.duration_ms.p95, 1)}ms`,
+        `p99 ${num(summary.duration_ms.p99, 1)}ms`,
+        `실패율 ${num(summary.failed_rate * 100, 2)}%`,
+        `check ${num(summary.checks_rate * 100, 2)}%`,
+    ].join(' / ');
+
+    const out = { stdout: `\n${line}\n\n` };
+
+    if (__ENV.SUMMARY_OUT) {
+        out[__ENV.SUMMARY_OUT] = JSON.stringify(summary, null, 2);
+    }
+
+    return out;
+}

--- a/src/main/java/gravit/code/chapter/dto/internal/ChapterProgressRowDto.java
+++ b/src/main/java/gravit/code/chapter/dto/internal/ChapterProgressRowDto.java
@@ -1,0 +1,8 @@
+package gravit.code.chapter.dto.internal;
+
+public record ChapterProgressRowDto(
+        long chapterId,
+        long totalLessons,
+        long solvedLessons
+) {
+}

--- a/src/main/java/gravit/code/chapter/facade/ChapterFacade.java
+++ b/src/main/java/gravit/code/chapter/facade/ChapterFacade.java
@@ -1,5 +1,6 @@
 package gravit.code.chapter.facade;
 
+import gravit.code.chapter.dto.internal.ChapterProgressRowDto;
 import gravit.code.chapter.dto.response.ChapterDetailResponse;
 import gravit.code.chapter.dto.response.ChapterSummaryResponse;
 import gravit.code.chapter.service.ChapterQueryService;
@@ -9,10 +10,14 @@ import lombok.RequiredArgsConstructor;
 import org.springframework.transaction.annotation.Transactional;
 
 import java.util.List;
+import java.util.Map;
+import java.util.stream.Collectors;
 
 @Facade
 @RequiredArgsConstructor
 public class ChapterFacade {
+
+    private static final double NOT_STARTED_PROGRESS_RATE = 0.0;
 
     private final ChapterQueryService chapterQueryService;
     private final LearningProgressRateService learningProgressRateService;
@@ -21,16 +26,17 @@ public class ChapterFacade {
     public List<ChapterDetailResponse> getAllChapter(long userId){
         List<ChapterSummaryResponse> chapters = chapterQueryService.getAllChapter();
 
+        Map<Long, Double> progressRates = chapterQueryService.getAllChapterProgress(userId)
+                .stream()
+                .collect(Collectors.toMap(
+                        ChapterProgressRowDto::chapterId,
+                        row -> learningProgressRateService.calculateProgressRate(row.solvedLessons(), row.totalLessons())
+                ));
+
         return chapters.stream()
-                .map(chapter -> {
-                    long chapterId = chapter.chapterId();
-
-                    double chapterProgressRate = learningProgressRateService.getChapterProgress(chapterId, userId);
-
-                    return ChapterDetailResponse.create(
-                            chapter,
-                            chapterProgressRate
-                    );
-                }).toList();
+                .map(chapter -> ChapterDetailResponse.create(
+                        chapter,
+                        progressRates.getOrDefault(chapter.chapterId(), NOT_STARTED_PROGRESS_RATE)
+                )).toList();
     }
 }

--- a/src/main/java/gravit/code/chapter/repository/ChapterRepository.java
+++ b/src/main/java/gravit/code/chapter/repository/ChapterRepository.java
@@ -1,6 +1,7 @@
 package gravit.code.chapter.repository;
 
 import gravit.code.chapter.domain.Chapter;
+import gravit.code.chapter.dto.internal.ChapterProgressRowDto;
 import gravit.code.chapter.dto.response.ChapterBriefResponse;
 import gravit.code.chapter.dto.response.ChapterSummaryResponse;
 import org.springframework.data.jpa.repository.JpaRepository;
@@ -34,4 +35,16 @@ public interface ChapterRepository extends JpaRepository<Chapter, Long> {
         WHERE u.id = :unitId
     """)
     Optional<ChapterBriefResponse> findChapterBriefByUnitId(@Param("unitId") long unitId);
+
+    @Query("""
+        SELECT new gravit.code.chapter.dto.internal.ChapterProgressRowDto(
+            c.id, COUNT(DISTINCT l.id), COUNT(DISTINCT ls.lessonId)
+        )
+        FROM Chapter c
+        LEFT JOIN Unit u ON u.chapterId = c.id
+        LEFT JOIN Lesson l ON l.unitId = u.id
+        LEFT JOIN LessonSubmission ls ON ls.lessonId = l.id AND ls.userId = :userId
+        GROUP BY c.id
+    """)
+    List<ChapterProgressRowDto> findChapterProgressByUserId(@Param("userId") long userId);
 }

--- a/src/main/java/gravit/code/chapter/service/ChapterQueryService.java
+++ b/src/main/java/gravit/code/chapter/service/ChapterQueryService.java
@@ -1,6 +1,7 @@
 package gravit.code.chapter.service;
 
 import gravit.code.chapter.domain.Chapter;
+import gravit.code.chapter.dto.internal.ChapterProgressRowDto;
 import gravit.code.chapter.dto.response.ChapterBriefResponse;
 import gravit.code.chapter.dto.response.ChapterSummaryResponse;
 import gravit.code.chapter.repository.ChapterRepository;
@@ -21,6 +22,11 @@ public class ChapterQueryService {
     @Transactional(readOnly = true)
     public List<ChapterSummaryResponse> getAllChapter(){
         return chapterRepository.findAllChapterSummary();
+    }
+
+    @Transactional(readOnly = true)
+    public List<ChapterProgressRowDto> getAllChapterProgress(long userId){
+        return chapterRepository.findChapterProgressByUserId(userId);
     }
 
     @Transactional(readOnly = true)

--- a/src/main/java/gravit/code/learning/service/LearningProgressRateService.java
+++ b/src/main/java/gravit/code/learning/service/LearningProgressRateService.java
@@ -30,18 +30,13 @@ public class LearningProgressRateService {
         return Math.floor(progressRate);
     }
 
-    @Transactional(readOnly = true)
-    public double getUnitProgress(
-            long unitId,
-            long userId
+    public double calculateProgressRate(
+            long solvedLessonCount,
+            long totalLessonCount
     ) {
-        int solvedLessonCount = lessonSubmissionRepository.countSolvedLessonByUnitIdAndUserId(unitId, userId);
-
         if(solvedLessonCount == 0) {
             return 0.0;
         }
-
-        int totalLessonCount = lessonRepository.countTotalLessonByUnitId(unitId);
 
         double progressRate = ((double) solvedLessonCount / totalLessonCount) * 100;
         return Math.floor(progressRate);

--- a/src/main/java/gravit/code/lesson/repository/LessonSubmissionRepository.java
+++ b/src/main/java/gravit/code/lesson/repository/LessonSubmissionRepository.java
@@ -33,17 +33,6 @@ public interface LessonSubmissionRepository extends JpaRepository<LessonSubmissi
     );
 
     @Query("""
-        SELECT COUNT(DISTINCT l.id)
-        FROM LessonSubmission ls
-        JOIN Lesson l ON l.id = ls.lessonId
-        WHERE l.unitId = :unitId AND ls.userId = :userId
-    """)
-    int countSolvedLessonByUnitIdAndUserId(
-            @Param("unitId") long unitId,
-            @Param("userId") long userId
-    );
-
-    @Query("""
         SELECT COUNT(ls.id)
         FROM LessonSubmission ls
         WHERE ls.lessonId = :lessonId AND ls.userId = :userId

--- a/src/main/java/gravit/code/unit/facade/UnitFacade.java
+++ b/src/main/java/gravit/code/unit/facade/UnitFacade.java
@@ -4,6 +4,7 @@ import gravit.code.chapter.dto.response.ChapterSummaryResponse;
 import gravit.code.chapter.service.ChapterQueryService;
 import gravit.code.global.annotation.Facade;
 import gravit.code.learning.service.LearningProgressRateService;
+import gravit.code.unit.dto.internal.UnitProgressRowDto;
 import gravit.code.unit.dto.response.UnitDetailResponse;
 import gravit.code.unit.dto.response.UnitPageResponse;
 import gravit.code.unit.dto.response.UnitSummaryResponse;
@@ -12,10 +13,14 @@ import lombok.RequiredArgsConstructor;
 import org.springframework.transaction.annotation.Transactional;
 
 import java.util.List;
+import java.util.Map;
+import java.util.stream.Collectors;
 
 @Facade
 @RequiredArgsConstructor
 public class UnitFacade {
+
+    private static final double NOT_STARTED_PROGRESS_RATE = 0.0;
 
     private final UnitQueryService unitQueryService;
 
@@ -31,17 +36,18 @@ public class UnitFacade {
 
         List<UnitSummaryResponse> unitSummaries = unitQueryService.getAllUnitSummaryByChapterId(chapterId);
 
+        Map<Long, Double> progressRates = unitQueryService.getAllUnitProgressInChapter(chapterId, userId)
+                .stream()
+                .collect(Collectors.toMap(
+                        UnitProgressRowDto::unitId,
+                        row -> learningProgressRateService.calculateProgressRate(row.solvedLessons(), row.totalLessons())
+                ));
+
         List<UnitDetailResponse> unitDetailResponses = unitSummaries.stream()
-                .map(unitSummary -> {
-                    long unitId = unitSummary.unitId();
-
-                    double unitProgressRate = learningProgressRateService.getUnitProgress(unitId, userId);
-
-                    return UnitDetailResponse.create(
-                            unitSummary,
-                            unitProgressRate
-                    );
-                }).toList();
+                .map(unitSummary -> UnitDetailResponse.create(
+                        unitSummary,
+                        progressRates.getOrDefault(unitSummary.unitId(), NOT_STARTED_PROGRESS_RATE)
+                )).toList();
 
         return UnitPageResponse.create(
                 chapterSummaryResponse,

--- a/src/main/java/gravit/code/unit/service/UnitQueryService.java
+++ b/src/main/java/gravit/code/unit/service/UnitQueryService.java
@@ -47,6 +47,13 @@ public class UnitQueryService {
                 .toList();
     }
 
+    public List<UnitProgressRowDto> getAllUnitProgressInChapter(
+            long chapterId,
+            long userId
+    ){
+        return unitRepository.findUnitProgressByChapterIdAndUserId(chapterId, userId);
+    }
+
     public List<RecommendedUnitResponse> getRecommendedUnits(long userId) {
         List<Long> allUnitIds = unitRepository.findAllUnitIdsOrderById();
 

--- a/src/test/java/gravit/code/chapter/facade/ChapterFacadeUnitTest.java
+++ b/src/test/java/gravit/code/chapter/facade/ChapterFacadeUnitTest.java
@@ -1,5 +1,6 @@
 package gravit.code.chapter.facade;
 
+import gravit.code.chapter.dto.internal.ChapterProgressRowDto;
 import gravit.code.chapter.dto.response.ChapterDetailResponse;
 import gravit.code.chapter.dto.response.ChapterSummaryResponse;
 import gravit.code.chapter.service.ChapterQueryService;
@@ -43,8 +44,12 @@ class ChapterFacadeUnitTest {
                     new ChapterSummaryResponse(2L, "네트워크", "네트워크 기초 개념")
             );
             when(chapterQueryService.getAllChapter()).thenReturn(chapters);
-            when(learningProgressRateService.getChapterProgress(1L, userId)).thenReturn(50.0);
-            when(learningProgressRateService.getChapterProgress(2L, userId)).thenReturn(30.0);
+            when(chapterQueryService.getAllChapterProgress(userId)).thenReturn(List.of(
+                    new ChapterProgressRowDto(1L, 10L, 5L),
+                    new ChapterProgressRowDto(2L, 10L, 3L)
+            ));
+            when(learningProgressRateService.calculateProgressRate(5L, 10L)).thenReturn(50.0);
+            when(learningProgressRateService.calculateProgressRate(3L, 10L)).thenReturn(30.0);
 
             // when
             List<ChapterDetailResponse> result = chapterFacade.getAllChapter(userId);
@@ -60,10 +65,36 @@ class ChapterFacadeUnitTest {
         }
 
         @Test
+        void 집계에_없는_챕터는_진행도가_0이다() {
+            // given
+            long userId = 1L;
+            List<ChapterSummaryResponse> chapters = List.of(
+                    new ChapterSummaryResponse(1L, "운영체제", "운영체제 기초 개념"),
+                    new ChapterSummaryResponse(2L, "네트워크", "네트워크 기초 개념")
+            );
+            when(chapterQueryService.getAllChapter()).thenReturn(chapters);
+            when(chapterQueryService.getAllChapterProgress(userId)).thenReturn(List.of(
+                    new ChapterProgressRowDto(1L, 10L, 5L)
+            ));
+            when(learningProgressRateService.calculateProgressRate(5L, 10L)).thenReturn(50.0);
+
+            // when
+            List<ChapterDetailResponse> result = chapterFacade.getAllChapter(userId);
+
+            // then
+            assertSoftly(softly -> {
+                softly.assertThat(result).hasSize(2);
+                softly.assertThat(result.get(0).chapterProgressRate()).isEqualTo(50.0);
+                softly.assertThat(result.get(1).chapterProgressRate()).isEqualTo(0.0);
+            });
+        }
+
+        @Test
         void 챕터가_없으면_빈_리스트를_반환한다() {
             // given
             long userId = 1L;
             when(chapterQueryService.getAllChapter()).thenReturn(List.of());
+            when(chapterQueryService.getAllChapterProgress(userId)).thenReturn(List.of());
 
             // when
             List<ChapterDetailResponse> result = chapterFacade.getAllChapter(userId);

--- a/src/test/java/gravit/code/chapter/service/ChapterQueryServiceUnitTest.java
+++ b/src/test/java/gravit/code/chapter/service/ChapterQueryServiceUnitTest.java
@@ -1,5 +1,6 @@
 package gravit.code.chapter.service;
 
+import gravit.code.chapter.dto.internal.ChapterProgressRowDto;
 import gravit.code.chapter.dto.response.ChapterSummaryResponse;
 import gravit.code.chapter.repository.ChapterRepository;
 import gravit.code.global.exception.domain.RestApiException;
@@ -59,6 +60,28 @@ class ChapterQueryServiceTest {
 
             // then
             assertThat(result).isEmpty();
+        }
+    }
+
+    @Nested
+    @DisplayName("전체 챕터의 진행도를 조회할 때")
+    class GetAllChapterProgress {
+
+        @Test
+        void 성공한다() {
+            // given
+            long userId = 1L;
+            List<ChapterProgressRowDto> expected = List.of(
+                    new ChapterProgressRowDto(1L, 10L, 5L),
+                    new ChapterProgressRowDto(2L, 10L, 0L)
+            );
+            when(chapterRepository.findChapterProgressByUserId(userId)).thenReturn(expected);
+
+            // when
+            List<ChapterProgressRowDto> result = chapterQueryService.getAllChapterProgress(userId);
+
+            // then
+            assertThat(result).isEqualTo(expected);
         }
     }
 

--- a/src/test/java/gravit/code/learning/service/LearningProgressRateServiceIntegrationTest.java
+++ b/src/test/java/gravit/code/learning/service/LearningProgressRateServiceIntegrationTest.java
@@ -99,62 +99,6 @@ class LearningProgressRateServiceIntegrationTest {
     }
 
     @Nested
-    @DisplayName("유닛 진행률을 조회할 때")
-    class GetUnitProgress {
-
-        @Test
-        void 풀이한_레슨이_없으면_0을_반환한다() {
-            // given
-            long userId = 1L;
-            Chapter chapter = chapterRepository.save(Chapter.create("자료구조", "자료구조 기초"));
-            Unit unit = unitRepository.save(Unit.create("연결리스트", "배열과 연결리스트", chapter.getId()));
-            lessonRepository.save(Lesson.create("레슨1", unit.getId()));
-
-            // when
-            double result = learningProgressRateService.getUnitProgress(unit.getId(), userId);
-
-            // then
-            assertThat(result).isEqualTo(0.0);
-        }
-
-        @Test
-        void 일부_레슨을_풀었으면_진행률을_반환한다() {
-            // given
-            long userId = 1L;
-            Chapter chapter = chapterRepository.save(Chapter.create("자료구조", "자료구조 기초"));
-            Unit unit = unitRepository.save(Unit.create("연결리스트", "배열과 연결리스트", chapter.getId()));
-            Lesson lesson1 = lessonRepository.save(Lesson.create("레슨1", unit.getId()));
-            lessonRepository.save(Lesson.create("레슨2", unit.getId()));
-            lessonRepository.save(Lesson.create("레슨3", unit.getId()));
-            lessonSubmissionRepository.save(LessonSubmission.create(120, 100, lesson1.getId(), userId));
-
-            // when
-            double result = learningProgressRateService.getUnitProgress(unit.getId(), userId);
-
-            // then
-            assertThat(result).isEqualTo(33.0); // floor(1/3 * 100)
-        }
-
-        @Test
-        void 모든_레슨을_풀었으면_100을_반환한다() {
-            // given
-            long userId = 1L;
-            Chapter chapter = chapterRepository.save(Chapter.create("자료구조", "자료구조 기초"));
-            Unit unit = unitRepository.save(Unit.create("연결리스트", "배열과 연결리스트", chapter.getId()));
-            Lesson lesson1 = lessonRepository.save(Lesson.create("레슨1", unit.getId()));
-            Lesson lesson2 = lessonRepository.save(Lesson.create("레슨2", unit.getId()));
-            lessonSubmissionRepository.save(LessonSubmission.create(120, 100, lesson1.getId(), userId));
-            lessonSubmissionRepository.save(LessonSubmission.create(90, 100, lesson2.getId(), userId));
-
-            // when
-            double result = learningProgressRateService.getUnitProgress(unit.getId(), userId);
-
-            // then
-            assertThat(result).isEqualTo(100.0);
-        }
-    }
-
-    @Nested
     @DisplayName("행성 정복률을 조회할 때")
     class GetPlanetConquestRate {
 

--- a/src/test/java/gravit/code/learning/service/LearningProgressRateServiceUnitTest.java
+++ b/src/test/java/gravit/code/learning/service/LearningProgressRateServiceUnitTest.java
@@ -78,19 +78,30 @@ class LearningProgressRateServiceUnitTest {
     }
 
     @Nested
-    @DisplayName("유닛 진행률을 조회할 때")
-    class GetUnitProgress {
+    @DisplayName("진행률을 계산할 때")
+    class CalculateProgressRate {
 
         @Test
         void 풀이한_레슨이_없으면_0을_반환한다() {
             // given
-            long unitId = 1L;
-            long userId = 1L;
-
-            when(lessonSubmissionRepository.countSolvedLessonByUnitIdAndUserId(unitId, userId)).thenReturn(0);
+            long solvedLessonCount = 0L;
+            long totalLessonCount = 3L;
 
             // when
-            double result = learningProgressRateService.getUnitProgress(unitId, userId);
+            double result = learningProgressRateService.calculateProgressRate(solvedLessonCount, totalLessonCount);
+
+            // then
+            assertThat(result).isEqualTo(0.0);
+        }
+
+        @Test
+        void 레슨이_없는_유닛이면_0을_반환한다() {
+            // given
+            long solvedLessonCount = 0L;
+            long totalLessonCount = 0L;
+
+            // when
+            double result = learningProgressRateService.calculateProgressRate(solvedLessonCount, totalLessonCount);
 
             // then
             assertThat(result).isEqualTo(0.0);
@@ -99,14 +110,11 @@ class LearningProgressRateServiceUnitTest {
         @Test
         void 일부_레슨을_풀었으면_진행률을_반환한다() {
             // given
-            long unitId = 1L;
-            long userId = 1L;
-
-            when(lessonSubmissionRepository.countSolvedLessonByUnitIdAndUserId(unitId, userId)).thenReturn(2);
-            when(lessonRepository.countTotalLessonByUnitId(unitId)).thenReturn(3);
+            long solvedLessonCount = 2L;
+            long totalLessonCount = 3L;
 
             // when
-            double result = learningProgressRateService.getUnitProgress(unitId, userId);
+            double result = learningProgressRateService.calculateProgressRate(solvedLessonCount, totalLessonCount);
 
             // then
             assertThat(result).isEqualTo(66.0); // floor(66.66...)
@@ -115,14 +123,11 @@ class LearningProgressRateServiceUnitTest {
         @Test
         void 모든_레슨을_풀었으면_100을_반환한다() {
             // given
-            long unitId = 1L;
-            long userId = 1L;
-
-            when(lessonSubmissionRepository.countSolvedLessonByUnitIdAndUserId(unitId, userId)).thenReturn(3);
-            when(lessonRepository.countTotalLessonByUnitId(unitId)).thenReturn(3);
+            long solvedLessonCount = 3L;
+            long totalLessonCount = 3L;
 
             // when
-            double result = learningProgressRateService.getUnitProgress(unitId, userId);
+            double result = learningProgressRateService.calculateProgressRate(solvedLessonCount, totalLessonCount);
 
             // then
             assertThat(result).isEqualTo(100.0);

--- a/src/test/java/gravit/code/unit/facade/UnitFacadeUnitTest.java
+++ b/src/test/java/gravit/code/unit/facade/UnitFacadeUnitTest.java
@@ -3,6 +3,7 @@ package gravit.code.unit.facade;
 import gravit.code.chapter.dto.response.ChapterSummaryResponse;
 import gravit.code.chapter.service.ChapterQueryService;
 import gravit.code.learning.service.LearningProgressRateService;
+import gravit.code.unit.dto.internal.UnitProgressRowDto;
 import gravit.code.unit.dto.response.UnitPageResponse;
 import gravit.code.unit.dto.response.UnitSummaryResponse;
 import gravit.code.unit.service.UnitQueryService;
@@ -49,10 +50,16 @@ class UnitFacadeUnitTest {
                     new UnitSummaryResponse(2L, "스레드", "스레드 개념")
             );
 
+            List<UnitProgressRowDto> progressRows = List.of(
+                    new UnitProgressRowDto(1L, "프로세스", 5L, 4L),
+                    new UnitProgressRowDto(2L, "스레드", 3L, 0L)
+            );
+
             when(chapterQueryService.getChapterSummary(chapterId)).thenReturn(chapterSummaryResponse);
             when(unitQueryService.getAllUnitSummaryByChapterId(chapterId)).thenReturn(unitSummaries);
-            when(learningProgressRateService.getUnitProgress(1L, userId)).thenReturn(80.0);
-            when(learningProgressRateService.getUnitProgress(2L, userId)).thenReturn(0.0);
+            when(unitQueryService.getAllUnitProgressInChapter(chapterId, userId)).thenReturn(progressRows);
+            when(learningProgressRateService.calculateProgressRate(4L, 5L)).thenReturn(80.0);
+            when(learningProgressRateService.calculateProgressRate(0L, 3L)).thenReturn(0.0);
 
             // when
             UnitPageResponse result = unitFacade.getAllUnitInChapter(userId, chapterId);
@@ -76,6 +83,7 @@ class UnitFacadeUnitTest {
 
             when(chapterQueryService.getChapterSummary(chapterId)).thenReturn(chapterSummaryResponse);
             when(unitQueryService.getAllUnitSummaryByChapterId(chapterId)).thenReturn(List.of());
+            when(unitQueryService.getAllUnitProgressInChapter(chapterId, userId)).thenReturn(List.of());
 
             // when
             UnitPageResponse result = unitFacade.getAllUnitInChapter(userId, chapterId);


### PR DESCRIPTION
## PR Summary

챕터 목록과 유닛 목록 조회에서 진행률을 대상 하나씩 계산하느라 발생하던 N+1 쿼리를 단일 집계 쿼리로 대체했습니다. 요청당 쿼리 수가 유닛 조회는 27.50 -> 5.00, 챕터 조회는 12.85 -> 4.00으로 줄었습니다.

<br>

## Problem

**문제 1 - 유닛 목록 조회의 진행률 계산 반복** (`GET /api/v1/units/{chapterId}`, 챕터당 유닛 13~14개 기준)

유닛 목록을 가져온 뒤 유닛마다 "푼 레슨 수"와 "전체 레슨 수"를 세는 쿼리를 각각 날리고 있었습니다. 요청 하나가 27.50개의 쿼리를 만들었고 그중 23.50개가 이 두 종류의 반복이었으며, 두 쿼리가 DB 실행시간의 95.609%를 차지했습니다.

개별 쿼리가 느린 것이 아니었습니다. 같은 유저의 제출 이력 317행을 유닛마다 다시 읽는 것이 문제였습니다. 스캔 행과 반환 행의 비가 317:1이었고 요청 하나가 만지는 buffers가 184.8페이지(1.44 MB)에 달했습니다.

<br>

**문제 2 - 챕터 목록 조회의 진행률 계산 반복** (`GET /api/v1/chapters`, 챕터 5개 기준)

같은 구조가 챕터 조회에도 있었습니다. 챕터마다 진행률 계산 쿼리 두 개가 나가 요청당 SQL 12.85개 중 9.85개가 반복분이었고, 두 쿼리가 DB 실행시간의 94.56%를 차지했습니다.

원인도 같습니다. 유저의 제출 317행을 챕터마다 다시 읽어 요청당 약 1,585행을 스캔했습니다. 챕터를 거르는 조건이 `unit` 테이블에 있어 조인 두 단계 건너에 놓이는 탓에, WHERE 조건을 인덱스 스캔까지 내릴 수 없는 구조였습니다.

측정에서 드러난 사실 하나를 덧붙입니다. 챕터 조회의 요청당 DB 실행시간은 2.21 ms인데 응답시간 중앙값은 83.64 ms였습니다. 시간은 쿼리 실행이 아니라 요청당 15.85회의 왕복과 거기에 얹히는 동시성 대기에 있었습니다. 왕복 횟수를 줄이는 것이 유효한 방향이라고 판단한 근거입니다.

<br>

## Solution

**해결 1 - 유닛 진행률을 단일 집계 쿼리로 대체**

유닛마다 반복하던 두 쿼리를 `UnitRepository.findUnitProgressByChapterIdAndUserId` 하나로 합쳤습니다. `Unit`을 기준으로 `Lesson`과 `LessonSubmission`을 LEFT JOIN해 유닛별 전체 레슨 수와 푼 레슨 수를 한 번에 집계하고, 파사드는 그 결과를 `Map`으로 받아 조립합니다.

**유닛 조회 - 실행 계획**

| 항목 | Before | After | 변화 |
|---|---|---|---|
| 스캔 방식 | `Index Only Scan` + `lesson` Seq Scan을 요청당 13.20회 반복 | 동일 노드를 요청당 1회 | 반복 소멸 |
| 스캔 행 / 반환 행 | 317:1 | 47:1 | 해소 |
| 요청당 buffers | 184.8페이지 (1.44 MB) | 10페이지 (0.078 MB) | -94.6% |

**유닛 조회 - 부하 지표**

| 항목 | Before | After | 변화 |
|---|---|---|---|
| 요청당 쿼리 수 | 27.5033 | 5.0000 | -81.8% |
| 요청당 DB 실행시간 | 2.7876 ms | 0.5757 ms | -79.3% |
| 진행률 계산 부분의 요청당 실행시간 | 2.6652 ms | 0.4259 ms | -84.0% |
| p95 | 251.16699999999997 ms | 116.05729999999984 ms | -53.8% |
| p99 | 502.76631999999995 ms | 254.81243999999998 ms | -49.3% |
| med | 128.171 ms | 46.713499999999996 ms | -63.6% |
| 처리량(RPS) | 280.3764562439154 | 686.0507502892599 | 2.45배 |

<br>

**해결 2 - 챕터 진행률을 단일 집계 쿼리로 대체**

같은 방식을 챕터에 적용해 `ChapterRepository.findChapterProgressByUserId`를 추가했습니다. `Chapter`를 기준으로 `Unit`, `Lesson`, `LessonSubmission`을 LEFT JOIN하고 `GROUP BY c.id`로 챕터별 전체 레슨 수와 푼 레슨 수를 한 번에 집계합니다.

집계 함수는 양쪽 모두 `COUNT(DISTINCT ...)`를 씁니다. 제출 이력을 조인하면 같은 레슨이 제출 건수만큼 중복되기 때문에, 기존의 `COUNT(l.id)`를 그대로 두면 전체 레슨 수가 부풀어 진행률이 낮게 나옵니다. 유저 조건은 WHERE가 아니라 조인 조건에 뒀습니다. WHERE로 내리면 제출이 없어 NULL인 행이 걸러져 해당 챕터가 결과에서 통째로 사라집니다.

진행률 계산 자체는 `LearningProgressRateService.calculateProgressRate`를 재사용했습니다. 기존 `getChapterProgress`와 그것이 쓰는 두 카운트 쿼리는 지우지 않았습니다. 최근 학습 챕터를 단건으로 조회하는 다른 두 경로가 이 메서드를 쓰고 있고, 그쪽은 호출이 한 번뿐이라 N+1이 아니기 때문입니다.

**챕터 조회 - 실행 계획**

| 항목 | Before | After | 변화 |
|---|---|---|---|
| 스캔 방식 | `Index Only Scan`(Heap Fetches 0) + `lesson`, `unit` Seq Scan + Hash Join을 요청당 9.85회 반복 | 같은 스캔 방식을 Hash Right Join 3단 + Sort + GroupAggregate로 묶어 loops 전부 1회 | 반복 소멸 |
| `lesson_submission` 스캔 행 | 약 1,585행 (317행 x 5회) | 317행 (317행 x 1회) | -80% |
| 스캔 행 / 반환 행 | 317:1 | 63.4:1 | 개선 |
| 필터로 버린 행 | `unit` Seq Scan에서 53행 (두 쿼리 모두) | 0행 (Filter 노드 없음) | 해소 |
| 요청당 buffers | 109.1페이지 (872.6 KB) | 17페이지 (136 KB) | -84.4% |
| 옵티마이저 추정 대 실측 | 최대 1.7배 | 최대 1.36배 | 괴리 없음 |

**챕터 조회 - 부하 지표**

| 항목 | Before | After | 변화 |
|---|---|---|---|
| 요청당 SQL | 12.8459941275167785 | 4.0 | -68.9% |
| 요청당 왕복 (SQL + 트랜잭션 제어) | 15.85 | 7.00 | -55.8% |
| 요청당 DB 실행시간 | 2.2125210943372 ms | 1.3445919 ms | -39.2% |
| 진행률 계산 부분의 요청당 실행시간 | 2.09206 ms | 1.1704637619882787 ms | -44.1% |
| 쿼리 평균 실행시간 | 0.3010765931082263 ms, 0.12106246924351827 ms (쿼리 2개) | 1.1704637619882787 ms (쿼리 1개) | 단건은 증가, 요청당 합계는 감소 |
| p95 | 189.25139999999993 ms | 125.61419999999995 ms | -33.6% |
| p99 | 463.67911999999995 ms | 328.7562199999998 ms | -29.1% |
| med | 83.6445 ms | 52.239 ms | -37.5% |
| 처리량(RPS) | 397.0506729592537 | 589.2846296260478 | 1.48배 |

<br>

**측정하고 적용하지 않은 것**

챕터 목록 캐싱은 요청당 왕복을 7.00에서 6.00으로(-14.3%) 줄이지만 DB 실행시간 기준 효과가 2.53%에 그쳐, 캐시 계층과 무효화를 더하는 비용에 비해 이득이 작다고 보고 넣지 않았습니다. 유저별 진행률 캐싱은 캐시 적중 시 DB 실행시간의 87.05%를 없앨 수 있지만 레슨 제출 경로 전반에 무효화를 심어야 하고 한 곳이라도 놓치면 진행률이 틀린 채 남습니다.

집계 쿼리에 인덱스를 더하는 방향도 검토했습니다. 개선 후 실행 계획에는 필터로 버린 행이 0이고 옵티마이저 추정과 실측의 괴리도 최대 1.36배라 깎을 여지가 보이지 않았습니다. 유닛 조회 쪽은 `lesson_submission(user_id, lesson_id)` 인덱스로 호출당 317행 스캔을 줄이는 후보가 남아 있으나, 요청당 DB 실행시간이 이미 응답시간의 0.79%라 체감 이득이 작다고 판단했습니다.

남은 왕복 7회 중 2회는 JWT 필터의 유저 조회와 최종 접근시각 갱신 인터셉터입니다. 이 두 쿼리는 인증이 걸린 모든 API에 공통으로 붙으므로 이 이슈에서는 다루지 않았습니다.

<br>

**측정 조건**

두 대상 모두 perf 프로파일에서 VU 50, ramp-up 30s + 유지 1m + ramp-down 30s(총 2m), 커넥션 풀 60, Redis 캐시는 측정 직전 FLUSHDB로 비우고 DB 캐시는 제어하지 않았습니다. 데이터는 시드 없이 기존 규모(`chapter` 5, `unit` 66, `lesson` 230, `lesson_submission` 317,300, `users` 1,002)를 그대로 썼고, 개선 전후의 조건은 동일합니다. 양쪽 모두 실패율 0, check 통과율 1입니다.

처리량과 응답시간은 로컬 한 대에서 k6와 애플리케이션, PostgreSQL이 CPU를 공유한 결과라 하드웨어에 의존합니다. 개선 판정은 요청당 쿼리 수, 스캔 행, buffers, 실행 계획의 loops처럼 코드 구조로 결정되는 값으로 했고, 응답시간과 처리량은 방향 확인용으로만 봤습니다. 커넥션 풀 점유율은 유닛 조회의 기준선에서만 측정했습니다(평균 동시 점유 약 37개 / 풀 60, 점유 시간이 서버측 응답시간의 99.30%). 개선 후와 챕터 조회에서는 측정하지 않았습니다.

측정 산출물은 `.claude/resources/perf/490/units/`와 `.claude/resources/perf/490/chapters/`에 있습니다. 각 디렉토리의 `record.md`에 단계별 관측값과 판정 근거가, `k6-test-summary-{0,1}.json`, `query-stats-summary-{0,1}.md`, `query-plan-{0,1}.txt`에 원 측정값이 들어 있습니다.

<br>

## Related Issue
- close #490


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **개선 사항**
  - 챕터 및 유닛 조회 시 학습 진도 정보를 효율적으로 집계하도록 개선했습니다.
  - 불필요한 반복 조회를 줄여 요청당 데이터베이스 쿼리와 왕복 횟수를 감소시켰습니다.
  - 진도 데이터가 없는 항목은 진행률 0%로 안정적으로 표시됩니다.
  - 부하 테스트 기준 유닛 조회 처리량이 향상되고 응답 지연 시간이 감소했습니다.

- **테스트**
  - 챕터·유닛 진도 계산과 예외 상황에 대한 검증을 보강했습니다.

- **문서**
  - API 성능 측정 결과와 데이터베이스 실행 계획을 추가했습니다.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->