### PR TITLE
refactor: 북마크, 오답노트 조회 성능 개선(#492)

### DIFF
--- a/.claude/resources/perf/492/bookmarks/k6-test-summary-0.json
+++ b/.claude/resources/perf/492/bookmarks/k6-test-summary-0.json
@@ -1,0 +1,52 @@
+{
+  "phase": "measure",
+  "target": "bookmarks",
+  "endpoint": "GET /api/v1/bookmarks/{unitId}",
+  "condition": {
+    "vus": 50,
+    "steady_state_duration": "1m",
+    "ramp_up": "30s",
+    "ramp_down": "30s",
+    "total_duration": "2m",
+    "redis_cache": "cold (measure 직전 FLUSHDB)",
+    "db_cache": "제어하지 않음. FLUSHDB는 PostgreSQL shared_buffers와 OS page cache를 비우지 않는다",
+    "target_unit_id": 900002,
+    "expected_problems_per_request": 30,
+    "user_id_start": 1001,
+    "user_count": 1000
+  },
+  "requests": 19941,
+  "rps": 166.1613138464495,
+  "failed_rate": 0,
+  "checks_rate": 1,
+  "checks": [
+    {
+      "name": "status is 200",
+      "passes": 19941,
+      "fails": 0
+    },
+    {
+      "name": "body is not empty",
+      "passes": 19941,
+      "fails": 0
+    },
+    {
+      "name": "problems 30건이 실려 있다",
+      "passes": 19941,
+      "fails": 0
+    }
+  ],
+  "duration_ms": {
+    "med": 219.35,
+    "p95": 473.056,
+    "p99": 719.1027999999997,
+    "max": 1784.57
+  },
+  "waiting_ms": {
+    "med": 219.156,
+    "p95": 472.879,
+    "p99": 718.9229999999997,
+    "max": 1784.335
+  },
+  "bytes_received": 289985385
+}

--- a/.claude/resources/perf/492/bookmarks/k6-test-summary-1.json
+++ b/.claude/resources/perf/492/bookmarks/k6-test-summary-1.json
@@ -1,0 +1,63 @@
+{
+  "phase": "measure",
+  "target": "bookmarks",
+  "endpoint": "GET /api/v1/bookmarks/{unitId}",
+  "condition": {
+    "vus": 50,
+    "steady_state_duration": "1m",
+    "ramp_up": "30s",
+    "ramp_down": "30s",
+    "total_duration": "2m",
+    "redis_cache": "cold (measure 직전 FLUSHDB)",
+    "db_cache": "제어하지 않음. FLUSHDB는 PostgreSQL shared_buffers와 OS page cache를 비우지 않는다",
+    "target_unit_id": 900002,
+    "expected_problems_per_request": 30,
+    "user_id_start": 1001,
+    "user_count": 1000
+  },
+  "requests": 26551,
+  "rps": 221.21615110025436,
+  "failed_rate": 0,
+  "checks_rate": 1,
+  "checks": [
+    {
+      "name": "status is 200",
+      "passes": 26551,
+      "fails": 0
+    },
+    {
+      "name": "body is not empty",
+      "passes": 26551,
+      "fails": 0
+    },
+    {
+      "name": "problems 30건이 실려 있다",
+      "passes": 26551,
+      "fails": 0
+    }
+  ],
+  "duration_ms": {
+    "med": 125.126,
+    "p95": 442.3124999999996,
+    "p99": 968.1165,
+    "max": 1898.165
+  },
+  "waiting_ms": {
+    "med": 124.938,
+    "p95": 441.9599999999998,
+    "p99": 967.9425,
+    "max": 1897.965
+  },
+  "bytes_received": 386109259,
+  "delta_vs_prev": {
+    "from": "k6-test-summary-0.json",
+    "requests": { "before": 19941, "after": 26551 },
+    "rps": { "before": 166.1613138464495, "after": 221.21615110025436 },
+    "duration_med_ms": { "before": 219.35, "after": 125.126 },
+    "duration_p95_ms": { "before": 473.056, "after": 442.3124999999996 },
+    "duration_p99_ms": { "before": 719.1027999999997, "after": 968.1165 },
+    "duration_max_ms": { "before": 1784.57, "after": 1898.165 },
+    "failed_rate": { "before": 0, "after": 0 },
+    "checks_rate": { "before": 1, "after": 1 }
+  }
+}

--- a/.claude/resources/perf/492/bookmarks/query-plan-0.txt
+++ b/.claude/resources/perf/492/bookmarks/query-plan-0.txt
@@ -1,0 +1,54 @@
+BEGIN
+                                                                     QUERY PLAN                                                                     
+----------------------------------------------------------------------------------------------------------------------------------------------------
+ Sort  (cost=3287.53..3287.54 rows=1 width=72) (actual time=14.467..14.476 rows=30 loops=1)
+   Output: p1_0.id, p1_0.problem_type, p1_0.instruction, p1_0.content, true, b1_0.created_at
+   Sort Key: b1_0.created_at
+   Sort Method: quicksort  Memory: 28kB
+   Buffers: shared hit=1306
+   ->  Nested Loop  (cost=186.10..3287.52 rows=1 width=72) (actual time=9.140..14.437 rows=30 loops=1)
+         Output: p1_0.id, p1_0.problem_type, p1_0.instruction, p1_0.content, true, b1_0.created_at
+         Buffers: shared hit=1303
+         ->  Hash Join  (cost=186.10..3284.69 rows=1 width=79) (actual time=9.127..14.316 rows=30 loops=1)
+               Output: b1_0.created_at, p1_0.id, p1_0.problem_type, p1_0.instruction, p1_0.content, l1_0.unit_id
+               Hash Cond: (b1_0.problem_id = p1_0.id)
+               Buffers: shared hit=1243
+               ->  Seq Scan on public.bookmark b1_0  (cost=0.00..3098.00 rows=155 width=16) (actual time=7.089..12.258 rows=156 loops=1)
+                     Output: b1_0.id, b1_0.created_at, b1_0.problem_id, b1_0.user_id
+                     Filter: (b1_0.user_id = 1500)
+                     Rows Removed by Filter: 155844
+                     Buffers: shared hit=1148
+               ->  Hash  (cost=185.35..185.35 rows=60 width=71) (actual time=2.022..2.024 rows=60 loops=1)
+                     Output: p1_0.id, p1_0.problem_type, p1_0.instruction, p1_0.content, l1_0.unit_id
+                     Buckets: 1024  Batches: 1  Memory Usage: 15kB
+                     Buffers: shared hit=95
+                     ->  Hash Join  (cost=5.90..185.35 rows=60 width=71) (actual time=0.852..1.992 rows=60 loops=1)
+                           Output: p1_0.id, p1_0.problem_type, p1_0.instruction, p1_0.content, l1_0.unit_id
+                           Inner Unique: true
+                           Hash Cond: (p1_0.lesson_id = l1_0.id)
+                           Buffers: shared hit=95
+                           ->  Seq Scan on public.problem p1_0  (cost=0.00..161.00 rows=6900 width=71) (actual time=0.009..0.889 rows=6900 loops=1)
+                                 Output: p1_0.id, p1_0.content, p1_0.instruction, p1_0.lesson_id, p1_0.problem_type
+                                 Buffers: shared hit=92
+                           ->  Hash  (cost=5.88..5.88 rows=2 width=16) (actual time=0.033..0.034 rows=2 loops=1)
+                                 Output: l1_0.id, l1_0.unit_id
+                                 Buckets: 1024  Batches: 1  Memory Usage: 9kB
+                                 Buffers: shared hit=3
+                                 ->  Seq Scan on public.lesson l1_0  (cost=0.00..5.88 rows=2 width=16) (actual time=0.018..0.028 rows=2 loops=1)
+                                       Output: l1_0.id, l1_0.unit_id
+                                       Filter: (l1_0.unit_id = 900002)
+                                       Rows Removed by Filter: 228
+                                       Buffers: shared hit=3
+         ->  Seq Scan on public.unit u1_0  (cost=0.00..2.83 rows=1 width=8) (actual time=0.001..0.003 rows=1 loops=30)
+               Output: u1_0.id, u1_0.chapter_id, u1_0.description, u1_0.title
+               Filter: (u1_0.id = 900002)
+               Rows Removed by Filter: 65
+               Buffers: shared hit=60
+ Query Identifier: -2721271575161825793
+ Planning:
+   Buffers: shared hit=275
+ Planning Time: 3.020 ms
+ Execution Time: 14.585 ms
+(48 rows)
+
+ROLLBACK

--- a/.claude/resources/perf/492/bookmarks/query-plan-1.txt
+++ b/.claude/resources/perf/492/bookmarks/query-plan-1.txt
@@ -1,0 +1,49 @@
+BEGIN
+                                                                            QUERY PLAN                                                                             
+-------------------------------------------------------------------------------------------------------------------------------------------------------------------
+ Sort  (cost=275.51..275.51 rows=1 width=72) (actual time=1.747..1.754 rows=30 loops=1)
+   Output: p1_0.id, p1_0.problem_type, p1_0.instruction, p1_0.content, true, b1_0.created_at
+   Sort Key: b1_0.created_at
+   Sort Method: quicksort  Memory: 28kB
+   Buffers: shared hit=371
+   ->  Nested Loop  (cost=6.32..275.50 rows=1 width=72) (actual time=0.608..1.704 rows=30 loops=1)
+         Output: p1_0.id, p1_0.problem_type, p1_0.instruction, p1_0.content, true, b1_0.created_at
+         Buffers: shared hit=368
+         ->  Nested Loop  (cost=6.32..272.66 rows=1 width=79) (actual time=0.602..1.543 rows=30 loops=1)
+               Output: b1_0.created_at, p1_0.id, p1_0.problem_type, p1_0.instruction, p1_0.content, l1_0.unit_id
+               Inner Unique: true
+               Buffers: shared hit=308
+               ->  Hash Join  (cost=5.90..185.35 rows=60 width=71) (actual time=0.554..1.378 rows=60 loops=1)
+                     Output: p1_0.id, p1_0.problem_type, p1_0.instruction, p1_0.content, l1_0.unit_id
+                     Inner Unique: true
+                     Hash Cond: (p1_0.lesson_id = l1_0.id)
+                     Buffers: shared hit=95
+                     ->  Seq Scan on public.problem p1_0  (cost=0.00..161.00 rows=6900 width=71) (actual time=0.008..0.540 rows=6900 loops=1)
+                           Output: p1_0.id, p1_0.content, p1_0.instruction, p1_0.lesson_id, p1_0.problem_type
+                           Buffers: shared hit=92
+                     ->  Hash  (cost=5.88..5.88 rows=2 width=16) (actual time=0.029..0.030 rows=2 loops=1)
+                           Output: l1_0.id, l1_0.unit_id
+                           Buckets: 1024  Batches: 1  Memory Usage: 9kB
+                           Buffers: shared hit=3
+                           ->  Seq Scan on public.lesson l1_0  (cost=0.00..5.88 rows=2 width=16) (actual time=0.016..0.026 rows=2 loops=1)
+                                 Output: l1_0.id, l1_0.unit_id
+                                 Filter: (l1_0.unit_id = 900002)
+                                 Rows Removed by Filter: 228
+                                 Buffers: shared hit=3
+               ->  Index Scan using ix_bookmark_user_problem on public.bookmark b1_0  (cost=0.42..1.46 rows=1 width=16) (actual time=0.002..0.002 rows=0 loops=60)
+                     Output: b1_0.id, b1_0.created_at, b1_0.problem_id, b1_0.user_id
+                     Index Cond: ((b1_0.user_id = 1500) AND (b1_0.problem_id = p1_0.id))
+                     Buffers: shared hit=213
+         ->  Seq Scan on public.unit u1_0  (cost=0.00..2.83 rows=1 width=8) (actual time=0.001..0.005 rows=1 loops=30)
+               Output: u1_0.id, u1_0.chapter_id, u1_0.description, u1_0.title
+               Filter: (u1_0.id = 900002)
+               Rows Removed by Filter: 65
+               Buffers: shared hit=60
+ Query Identifier: -2721271575161825793
+ Planning:
+   Buffers: shared hit=292
+ Planning Time: 2.543 ms
+ Execution Time: 1.875 ms
+(43 rows)
+
+ROLLBACK

--- a/.claude/resources/perf/492/bookmarks/query-stats-summary-0.md
+++ b/.claude/resources/perf/492/bookmarks/query-stats-summary-0.md
@@ -1,0 +1,45 @@
+# query-stats-summary-0 — bookmarks
+
+상태: 0 = 아무것도 적용하지 않은 원본
+측정: VU 50 / ramp-up 30s + 유지 1m + ramp-down 30s / Redis cold, DB 캐시 제어하지 않음 / 요청 19941건
+
+| # | 요청당 | calls | mean_ms | total_ms | 비중 | 행/호출 | 출처 | 하는 일 |
+|---|---|---|---|---|---|---|---|---|
+| 1 | 1.00000000000000000000 | 19941 | 101.58188398951914 | 2025644.3486349937 | 91.2000115838526% | 30.0000000000000000 | `BookmarkRepository.findBookmarkedProblemDetailByUnitIdAndUserId` | `bookmark`를 `problem`, `lesson`, `unit`과 조인해 특정 유저, 특정 유닛의 북마크 문제 상세를 `created_at` 순으로 읽는다 |
+| 2 | 1.00000000000000000000 | 19941 | 7.867449813650273 | 156884.8167340002 | 7.063380653722835% | 60.0000000000000000 | `OptionRepository.findAllByProblemIdIn` | OBJECTIVE 문제 15건의 선택지를 `problem_id IN`으로 읽는다 |
+| 3 | 1.00000000000000000000 | 19941 | 1.5959442353944158 | 31824.723998000096 | 1.432835531679759% | 15.0000000000000000 | `AnswerRepository.findByProblemIdIn` | SUBJECTIVE 문제 15건의 정답을 `problem_id IN`으로 읽는다 |
+| 4 | 1.00000000000000000000 | 19941 | 0.09943197743342828 | 1982.7730620000016 | 0.08926982979238429% | 1.00000000000000000000 | `UnitRepository.findUnitSummaryById` | `unit`을 PK로 단건 읽는다 |
+| 5 | 1.00000000000000000000 | 19941 | 0.09042022275713398 | 1803.0696620000022 | 0.08117909452945349% | 1.00000000000000000000 | `AuthTokenProvider.parseUser` (`UserRepository.findById`, JwtAuthFilter 경유) | `users`를 PK로 단건 읽는다 |
+| 6 | 2.0000000000000000 | 39882 | 0.040689615415475784 | 1622.7832420000389 | 0.07306211012225104% | 0.000000000000000000000000 | - | 트랜잭션 제어 |
+| 7 | 1.00000000000000000000 | 19941 | 0.06380370457850669 | 1272.3096730000098 | 0.057282837924653475% | 0.000000000000000000000000 | `LastAccessInterceptor.preHandle` → `UserAccessService.updateLastAccessed` (`UserRepository`) | `users.last_accessed_at`을 오늘 첫 접근일 때만 갱신한다 |
+| 8 | 1.0046136101499423 | 20033 | 0.0030089006639045625 | 60.277306999999645 | 0.0027138481147235085% | 0.000000000000000000000000 | - | 트랜잭션 제어 |
+| 9 | 0.00461361014994232987 | 92 | 0.03950953260869564 | 3.6348769999999986 | 0.00016365203730322417% | 0.00000000000000000000 | 미상 | `season`에서 종료 시각이 지난 시즌을 잠금 조회한다 |
+| 10 | 0.00601775236948999549 | 120 | 0.01809335833333333 | 2.171203 | 9.775345750320365e-05% | 0.00000000000000000000 | 미상 (JDBC 드라이버) | 커넥션 초기화 |
+| 11 | 0.00090266285542349932 | 18 | 0.002094944444444445 | 0.037709 | 1.6977616229289967e-06% | 0.00000000000000000000 | - | 트랜잭션 제어 |
+| 12 | 0.00245724888420841482 | 49 | 0.0006377755102040816 | 0.031251000000000015 | 1.407004918670718e-06% | 0.00000000000000000000 | - | 트랜잭션 제어 |
+
+## 쿼리 원문
+
+[1] select p1_0.id,p1_0.problem_type,p1_0.instruction,p1_0.content,true from bookmark b1_0 join problem p1_0 on p1_0.id=b1_0.problem_id join lesson l1_0 on l1_0.id=p1_0.lesson_id join unit u1_0 on u1_0.id=l1_0.unit_id where u1_0.id=$1 and b1_0.user_id=$2 order by b1_0.created_at
+
+[2] select o1_0.id,o1_0.content,o1_0.explanation,o1_0.is_answer,o1_0.problem_id from option o1_0 where o1_0.problem_id in ($1,$2,$3,$4,$5,$6,$7,$8,$9,$10,$11,$12,$13,$14,$15) order by o1_0.problem_id
+
+[3] select a1_0.id,a1_0.content,a1_0.explanation,a1_0.problem_id from answer a1_0 where a1_0.problem_id in ($1,$2,$3,$4,$5,$6,$7,$8,$9,$10,$11,$12,$13,$14,$15) order by a1_0.problem_id
+
+[4] select u1_0.id,u1_0.title,u1_0.description from unit u1_0 where u1_0.id=$1
+
+[5] select u1_0.id,u1_0.created_at,u1_0.deleted_at,u1_0.email,u1_0.handle,u1_0.is_onboarded,u1_0.last_accessed_at,u1_0.level,u1_0.xp,u1_0.nickname,u1_0.profile_img_number,u1_0.provider_id,u1_0.role,u1_0.status,u1_0.updated_at from users u1_0 where u1_0.id=$1 and (u1_0.deleted_at IS NULL)
+
+[6] BEGIN READ ONLY
+
+[7] update users u1_0 set last_accessed_at=$1 where u1_0.id=$2 and (u1_0.last_accessed_at is null or u1_0.last_accessed_at<$3) and (u1_0.deleted_at IS NULL)
+
+[8] BEGIN
+
+[9] select s1_0.id,s1_0.ends_at,s1_0.season_key,s1_0.starts_at,s1_0.status,s1_0.tz from season s1_0 where s1_0.status=$2 and s1_0.ends_at<=$1 for no key update
+
+[10] SET application_name = 'PostgreSQL JDBC Driver'
+
+[11] ROLLBACK
+
+[12] COMMIT

--- a/.claude/resources/perf/492/bookmarks/query-stats-summary-1.md
+++ b/.claude/resources/perf/492/bookmarks/query-stats-summary-1.md
@@ -1,0 +1,45 @@
+# query-stats-summary-1 — bookmarks
+
+상태: 1 = 사이클 1 적용 후: `bookmark (user_id, problem_id)` UNIQUE 인덱스 추가
+측정: VU 50 / ramp-up 30s + 유지 1m + ramp-down 30s / Redis cold, DB 캐시 제어하지 않음 / 요청 26551건
+직전 상태 대비: 요청당 쿼리 수 6 → 6 (변화 없음), 대상 쿼리 mean_ms 101.58188398951914 → 7.549862536326318, total_ms 2025644.3486349937 → 200456.40020199993, 비중 91.2000115838526% → 32.318545126437755%. 대상 쿼리가 1위에서 2위로 내려가고 `option` 조회가 1위가 됐다. 요청 수가 19941 → 26551로 늘어 total_ms는 직접 비교 대상이 아니다
+
+| # | 요청당 | calls | mean_ms | total_ms | 비중 | 행/호출 | 출처 | 하는 일 |
+|---|---|---|---|---|---|---|---|---|
+| 1 | 1.00000000000000000000 | 26551 | 12.100271866295044 | 321274.3183219986 | 51.79739107452778% | 60.0000000000000000 | `OptionRepository.findAllByProblemIdIn` | OBJECTIVE 문제 15건의 선택지를 `problem_id IN`으로 읽는다 |
+| 2 | 1.00000000000000000000 | 26551 | 7.549862536326318 | 200456.40020199993 | 32.318545126437755% | 30.0000000000000000 | `BookmarkRepository.findBookmarkedProblemDetailByUnitIdAndUserId` | `bookmark`를 `problem`, `lesson`, `unit`과 조인해 특정 유저, 특정 유닛의 북마크 문제 상세를 `created_at` 순으로 읽는다 |
+| 3 | 1.00000000000000000000 | 26551 | 2.9878205807690725 | 79329.62423999973 | 12.789903631314452% | 15.0000000000000000 | `AnswerRepository.findByProblemIdIn` | SUBJECTIVE 문제 15건의 정답을 `problem_id IN`으로 읽는다 |
+| 4 | 1.00000000000000000000 | 26551 | 0.23537510093781805 | 6249.444304999989 | 1.0075654735033326% | 1.00000000000000000000 | `AuthTokenProvider.parseUser` (`UserRepository.findById`, JwtAuthFilter 경유) | `users`를 PK로 단건 읽는다 |
+| 5 | 2.0000000000000000 | 53102 | 0.09832997227976366 | 5221.51818800001 | 0.8418382801314529% | 0.000000000000000000000000 | - | 트랜잭션 제어 |
+| 6 | 1.00000000000000000000 | 26551 | 0.15716525855899788 | 4172.894779999985 | 0.6727741699412229% | 0.000000000000000000000000 | `LastAccessInterceptor.preHandle` → `UserAccessService.updateLastAccessed` (`UserRepository`) | `users.last_accessed_at`을 오늘 첫 접근일 때만 갱신한다 |
+| 7 | 1.00000000000000000000 | 26551 | 0.12921818353357706 | 3430.8719909999913 | 0.5531416864337083% | 1.00000000000000000000 | `UnitRepository.findUnitSummaryById` | `unit`을 PK로 단건 읽는다 |
+| 8 | 1.00018831682422507627 | 26556 | 0.004346933499020953 | 115.43716600000596 | 0.018611335207455542% | 0.000000000000000000000000 | - | 트랜잭션 제어 |
+| 9 | 0.00018831682422507627 | 5 | 0.27710039999999997 | 1.385502 | 0.0002233772973307291% | 0.00000000000000000000 | 미상 | `season`에서 종료 시각이 지난 시즌을 잠금 조회한다 |
+| 10 | 0.00169485141802568641 | 45 | 0.0007732444444444444 | 0.034796000000000014 | 5.609978504484334e-06% | 0.00000000000000000000 | - | 트랜잭션 제어 |
+| 11 | 0.000075326729690030507326 | 2 | 0.0007295 | 0.001459 | 2.352269984493229e-07% | 0.00000000000000000000 | - | 트랜잭션 제어 |
+
+`query-stats-summary-0.md`에 있던 `SET application_name = 'PostgreSQL JDBC Driver'`는 이번 수집의 상위 20건에 나타나지 않았다.
+
+## 쿼리 원문
+
+[1] select o1_0.id,o1_0.content,o1_0.explanation,o1_0.is_answer,o1_0.problem_id from option o1_0 where o1_0.problem_id in ($1,$2,$3,$4,$5,$6,$7,$8,$9,$10,$11,$12,$13,$14,$15) order by o1_0.problem_id
+
+[2] select p1_0.id,p1_0.problem_type,p1_0.instruction,p1_0.content,true from bookmark b1_0 join problem p1_0 on p1_0.id=b1_0.problem_id join lesson l1_0 on l1_0.id=p1_0.lesson_id join unit u1_0 on u1_0.id=l1_0.unit_id where u1_0.id=$1 and b1_0.user_id=$2 order by b1_0.created_at
+
+[3] select a1_0.id,a1_0.content,a1_0.explanation,a1_0.problem_id from answer a1_0 where a1_0.problem_id in ($1,$2,$3,$4,$5,$6,$7,$8,$9,$10,$11,$12,$13,$14,$15) order by a1_0.problem_id
+
+[4] select u1_0.id,u1_0.created_at,u1_0.deleted_at,u1_0.email,u1_0.handle,u1_0.is_onboarded,u1_0.last_accessed_at,u1_0.level,u1_0.xp,u1_0.nickname,u1_0.profile_img_number,u1_0.provider_id,u1_0.role,u1_0.status,u1_0.updated_at from users u1_0 where u1_0.id=$1 and (u1_0.deleted_at IS NULL)
+
+[5] BEGIN READ ONLY
+
+[6] update users u1_0 set last_accessed_at=$1 where u1_0.id=$2 and (u1_0.last_accessed_at is null or u1_0.last_accessed_at<$3) and (u1_0.deleted_at IS NULL)
+
+[7] select u1_0.id,u1_0.title,u1_0.description from unit u1_0 where u1_0.id=$1
+
+[8] BEGIN
+
+[9] select s1_0.id,s1_0.ends_at,s1_0.season_key,s1_0.starts_at,s1_0.status,s1_0.tz from season s1_0 where s1_0.status=$2 and s1_0.ends_at<=$1 for no key update
+
+[10] COMMIT
+
+[11] ROLLBACK

--- a/.claude/resources/perf/492/bookmarks/record.md
+++ b/.claude/resources/perf/492/bookmarks/record.md
@@ -1,0 +1,235 @@
+# [PERF-492] GET /api/v1/bookmarks/{unitId}
+
+> 이슈: #492
+> 브랜치: refactor/492-bookmark-wrong-note-query-performance
+> 대상 디렉토리: `.claude/resources/perf/492/bookmarks/`
+
+이 파일은 대상 엔드포인트 하나만 다룬다. 같은 이슈의 다른 엔드포인트는 각자의 디렉토리에 각자의 `record.md`를 가진다.
+
+## 진행 상태
+
+> ⏳ 미완 / ✅ 완료 / ⏭️ 건너뜀
+> 재진입 시 ⏳로 표기된 가장 이른 Phase부터 재개한다.
+
+**준비 (대상당 1회)**
+
+| 1. 대상 | 2. 환경 | 3. 조건 | 4. 기준선 |
+|---|---|---|---|
+| ✅ | ✅ | ✅ | ✅ |
+
+**사이클 (반복)**
+
+| # | 기법 | 5. 설계 | 6. 스냅샷 | 7. 적용 | 8. 검증 |
+|---|---|---|---|---|---|
+| 1 | `bookmark (user_id, problem_id)` UNIQUE 인덱스 추가 | ✅ | ✅ | ✅ | ✅ |
+
+## 대상
+
+- 엔드포인트: `GET /api/v1/bookmarks/{unitId}`
+- 실행 경로: `JwtAuthFilter` → `BookmarkController` → `BookmarkFacade` → (`UnitQueryService`, `BookmarkService`, `ProblemFactory`) → 각 Repository
+- 트랜잭션 경계: `BookmarkFacade.getAllBookmarkedProblemInUnit`에 `@Transactional(readOnly = true)` 단일
+- 예상 쿼리 목록 (요청 1회 기준, 고정 3~5개)
+  1. `UserRepository.findById` - `users` PK 단건 조회. 인증 필터(`AuthTokenProvider:70`)에서 발생. 대상 API 밖에서 붙는 쿼리
+  2. `UnitRepository.findUnitSummaryById` - `Unit` 단일 테이블 PK 조회, DTO 프로젝션
+  3. `BookmarkRepository.findBookmarkedProblemDetailByUnitIdAndUserId` - `Bookmark ⋈ Problem ⋈ Lesson ⋈ Unit` 4테이블 조인, `WHERE u.id = ? AND b.userId = ?`, `ORDER BY b.createdAt ASC`
+  4. `AnswerRepository.findByProblemIdIn` - 결과에 SUBJECTIVE 문제가 있을 때만 1회 (`ProblemFactory:25`)
+  5. `OptionRepository.findAllByProblemIdIn` - 결과에 OBJECTIVE 문제가 있을 때만 1회 (`ProblemFactory:26`)
+
+- 지연 로딩 추가 쿼리 후보: 없음. 2~5번 모두 `SELECT new ...Response(...)` DTO 프로젝션이라 엔티티를 반환하지 않는다
+- N+1 후보: 없음. `ProblemFactory.create`가 문제 타입별로 ID를 모아 `IN` 절 배치 조회 2회로 끝낸다. 북마크된 문제 개수가 늘어도 쿼리 수는 늘지 않는다
+- 사전 관찰(미검증): `bookmark` 테이블에 `user_id` 인덱스가 없다(`V1__init_tables.sql:43`). `wrong_answered_note`는 `V34`에서 `(user_id, problem_id)` 유니크 인덱스가 추가되어 있다
+
+## 측정 환경
+
+> 값이 바뀌면 그 사실을 사이클 기록에 남긴다.
+
+| 항목 | 값 |
+|---|---|
+| 프로파일 | perf (`application="gravit-perf"` 확인) |
+| 커넥션 풀 크기 | 60 (`application-perf.yml` `maximum-pool-size`) |
+| 데이터 규모 | `bookmark` 156,000 / `problem` 6,900 / `option` 13,800 / `answer` 3,450 / `lesson` 230 / `unit` 66 / `users` 1,002. 대상 유닛 900002는 문제 60건(OBJECTIVE 30, SUBJECTIVE 30) |
+| 카디널리티 | `bookmark.user_id` 1,000 (유저당 156행) / `bookmark.problem_id` 6,870 / `bookmark.created_at` 행마다 다른 값 (유저 내 1초 간격). 요청당 결과 30건 (OBJECTIVE 15, SUBJECTIVE 15) |
+| 부하 조건 | VU 50, 유지 1m (ramp-up 30s + 유지 1m + ramp-down 30s = 총 2m). #490과 동일 조건 |
+| Redis 캐시 상태 | cold (measure 직전 FLUSHDB). 단 이 API는 Redis를 쓰지 않는다 |
+| DB 캐시 상태 | 제어하지 않음. Redis FLUSHDB는 PostgreSQL의 `shared_buffers`와 OS page cache를 비우지 않는다 |
+| 캐시 제어 수단 | `redis-cli -h localhost -p 6379` (PONG 확인) |
+| 시드 SQL | `../seeds.sql` (이슈 공용) |
+| 시드 모듈과 변수 | `review.sql` (신규 모듈, `answer`/`option`/`bookmark`). `user_start` 1001, `user_count` 1000, `target_unit_id` 900002, `bookmarks_per_user` 156, `target_unit_bookmarks_per_user` 30, `options_per_problem` 4. `content.sql`, `user.sql`은 이미 목표 규모라 부르지 않음 |
+| DB 접속 | `PGPASSWORD=postgres psql -h localhost -p 5433 -U postgres -d mydb` (5433은 컨테이너 5432 매핑) |
+| 관측 도구 | `pg_stat_statements` 유효 (49행), 히스토그램 버킷 146개 노출 |
+
+## 기준선 (Baseline)
+
+| 지표 | 값 |
+|---|---|
+| p95 | 473.056ms |
+| p99 | 719.1027999999997ms |
+| RPS | 166.1613138464495 |
+| 에러율 | 0 |
+| check 통과율 | 1 (19941/19941, 3개 항목 전부) |
+| 요청당 쿼리 수 | 6 (트랜잭션 제어문 제외). 트랜잭션은 요청당 3개 (`BEGIN READ ONLY` 2 + `BEGIN` 1.0046) |
+
+- med 219.35ms / max 1784.57ms / 요청 19941건
+
+### 쿼리 통계 (total_exec_time 상위)
+
+> 전체: `query-stats-summary-0.md` / k6 요약: `k6-test-summary-0.json`
+> 여기에는 진단 근거로 쓴 행만 옮긴다. 전체를 복사하지 않는다.
+
+| 요청당 | mean_ms | total_ms | 비중 | 출처 |
+|---|---|---|---|---|
+| 1.00 | 101.58188398951914 | 2025644.3486349937 | 91.2000115838526% | `BookmarkRepository.findBookmarkedProblemDetailByUnitIdAndUserId` |
+| 1.00 | 7.867449813650273 | 156884.8167340002 | 7.063380653722835% | `OptionRepository.findAllByProblemIdIn` |
+| 1.00 | 1.5959442353944158 | 31824.723998000096 | 1.432835531679759% | `AnswerRepository.findByProblemIdIn` |
+
+### 진단
+
+- 병목 성격: 쿼리 자체 비효율. 호출 횟수가 아니라 단일 쿼리 1건의 실행 비용이 문제다
+- 근거:
+  - `findBookmarkedProblemDetailByUnitIdAndUserId` 1건이 총 실행시간의 91.2%(2,025,644ms)를 차지한다. 나머지 11개 쿼리의 합이 8.8%다
+  - 그 쿼리의 요청당 호출 수는 1.00으로 예상과 같다. N+1이 아니다
+  - 행/호출이 30으로 시드한 결과 크기와 정확히 일치한다. 30행을 반환하는 데 mean 101.58ms를 쓴다. 반환 행 수 대비 실행시간이 과도하므로 내부에서 만지는 행이 30행보다 훨씬 많다고 볼 근거가 된다 (검사 행 수는 Phase 6 실행계획에서 확인)
+  - 2위 `option` 조회는 mean 7.87ms로 1위와 12.9배 차이다
+- 예상 쿼리 목록과 어긋난 지점:
+  - `UPDATE users SET last_accessed_at`이 요청당 1.00회 나간다. 예상 목록에 없었다. 출처는 `LastAccessInterceptor.preHandle` → `UserAccessService.updateLastAccessed`로, Controller보다 앞단의 인터셉터라 실행 경로 추적에서 빠졌다. 읽기 엔드포인트에 쓰기가 1회 섞인다. 비중은 0.057%
+  - `BEGIN READ ONLY`가 요청당 2.00회다. 트랜잭션 경계를 `BookmarkFacade` 하나로 봤으나 실제로는 둘이다
+
+---
+
+## 사이클 1: `bookmark (user_id, problem_id)` UNIQUE 인덱스 추가
+
+### 설계 결정
+
+| 결정 항목 | 정한 값 | 근거 |
+|---|---|---|
+| 대상 컬럼, 순서 | `(user_id, problem_id)` | `user_id`를 선두 키로 두면 156,000행이 156행으로 좁는다(선택도 0.1%). `problem_id`는 조인 키라 인덱스에 있으면 힙까지 가지 않고 꺼낼 여지가 생긴다 |
+| 유니크 여부 | UNIQUE | 북마크는 유저와 문제 단위로 하나만 존재하는 도메인 제약이다. 코드도 이미 그 전제로 동작한다 - `addBookmark`가 중복 시 `BOOKMARK_DUPLICATED`를 던지고 `deleteByProblemIdAndUserId`가 그 쌍으로 단건을 지운다. 검사와 저장 사이의 경쟁으로 중복 행이 생기는 것을 DB가 막는다 |
+| 부분 인덱스 조건 | 없음 | `bookmark`에 soft delete도 상태 컬럼도 없어(`id`, `created_at`, `problem_id`, `user_id`가 전부) 항상 걸리는 필터 조건이 없다 |
+| 커버링 | 없음 | `INCLUDE (created_at)`은 힙 접근만 줄이고 Sort 노드는 남긴다. 힙 접근 156회가 실제로 비싼지 모르는 상태에서 컬럼을 늘리지 않는다. Phase 6의 `shared hit/read`를 보고 크다고 판단되면 사이클 2에서 다룬다 |
+| 감수할 쓰기 비용 | 북마크 추가, 삭제 시 인덱스 갱신 1건 | 북마크 쓰기는 사용자당 산발적이고, 같은 인덱스가 `existsByProblemIdAndUserId`와 `deleteByProblemIdAndUserId`의 순차 스캔을 없애 쓰기 경로 자체도 빨라진다 |
+
+- 검토했지만 택하지 않은 안:
+  - `(user_id, created_at, problem_id)` - Sort 노드까지 없앨 수 있으나, 91.2%를 만든 원인은 정렬이 아니라 156,000행 스캔이다. 정렬 비용을 재보지 않은 상태에서 컬럼을 늘리지 않는다
+  - 조인 축소(`unit` 조인 제거) - 사이클 2 이후 후보
+  - 결과 캐싱 - 무효화 경로가 둘(추가, 삭제)이고 복잡도가 크다. 쿼리 튜닝으로 부족할 때 꺼낸다
+  - `LastAccessInterceptor`의 `UPDATE users` 제거 - 비중 0.057%로 이번 병목과 무관하다. 별도 이슈 사안
+- 대상 API 밖의 부수 효과: `existsByProblemIdAndUserId`, `deleteByProblemIdAndUserId`, `countByUnitIdAndUserId`가 모두 `user_id`로 걸러 이 인덱스를 탄다
+- 호출자가 예상한 효과: `bookmark`의 스캔 방식이 Seq Scan에서 Index Scan으로 바뀐다
+
+### 개선 전 지표
+
+| 지표 | 값 |
+|---|---|
+| p95 / p99 | 473.056ms / 719.1027999999997ms |
+| RPS | 166.1613138464495 |
+| 요청당 쿼리 수 | 6 (트랜잭션 제어문 제외) |
+| 대상 쿼리 calls / mean_ms / total_ms | 19941 / 101.58188398951914 / 2025644.3486349937 (91.2%) |
+
+**실행계획**
+
+> 원본: `query-plan-0.txt` (개선 후는 `query-plan-1.txt`)
+
+- EXPLAIN 파라미터: `$1` = 900002 (대상 유닛), `$2` = 1500 (유저 1001~2000의 중앙값). 이후 모든 사이클에서 동일하게 사용
+- 스캔 방식: `bookmark`는 Seq Scan, 사용 인덱스 없음 (Filter `user_id = 1500`). `problem`, `lesson`, `unit`도 Seq Scan
+- actual rows 대 반환 행 수: `bookmark` 노드가 156행을 내보내고 쿼리는 30행을 반환한다. 노드가 읽은 행은 156,000
+- Rows Removed by Filter: `bookmark` 155,844 (읽은 것의 99.9%), `unit` 회당 65 (loops 30이므로 총 1,950), `lesson` 228
+- shared hit / read: 최상단 누적 1306 / 0 (10.2MB). 이 중 `bookmark` 노드 몫이 1148 (87.9%, 9.18MB)
+- 플래너 추정 대 실측: `bookmark` Seq Scan은 rows=155 대 실측 156으로 정확하다. Hash Join(b⋈p)이 rows=1로 추정했으나 실측 30으로 30배 괴리다. 유닛 필터와 유저 필터의 상관관계를 플래너가 독립으로 가정한 결과이고, 이번 인덱스와는 별개 사안이다
+- Planning Time 3.020ms / Execution Time 14.585ms (단건). 부하 중 mean 101.582ms와의 차이는 VU 50의 경합분이다
+
+**노드별 자기 몫** (누적 actual time에서 자식 몫을 뺀 값, loops 반영)
+
+| 노드 | 자기 몫 (ms) | Execution Time 대비 |
+|---|---|---|
+| Seq Scan `bookmark` | 12.258 | 84.0% |
+| Hash Join (p⋈l) | 1.069 | 7.3% |
+| Seq Scan `problem` | 0.889 | 6.1% |
+| Seq Scan `unit` | 0.09 (0.003 × loops 30) | 0.6% |
+| 나머지 전부 | 0.170 | 1.2% |
+
+**위험 신호 판정**
+
+| 지표 | 값 | 기준 | 판정 |
+|---|---|---|---|
+| 검사 행 / 반환 행 | 156,000 / 30 = 5,200:1 | 100:1 초과 | 초과 |
+| 단일 쿼리 total_exec_time 점유율 | 91.2% | 30% 이상 | 초과 |
+| 1만 행 이상 테이블의 Seq Scan | `bookmark` 156,000행 | 신호 | 해당 |
+| 플래너 추정 대 실측 | Hash Join 1 대 30 | 10배 이상 | 초과 |
+| 동일 쿼리의 요청당 호출 횟수 | 1.00 | 1회 초과면 N+1 | 해당 없음 |
+
+- 확정 해석: `bookmark`의 Seq Scan이 비용을 먹는 노드다. 시간 기준 84.0%, 페이지 기준 87.9%로 두 지표가 같은 노드를 가리킨다. 156,000행을 읽어 155,844행(99.9%)을 버리고 156행만 남긴다
+
+### 적용 내용
+
+- `src/main/resources/db/migration/V38__add_bookmark_user_problem_unique_index.sql` 신규 - `bookmark (user_id, problem_id)` UNIQUE 인덱스 추가
+- 코드 변경은 마이그레이션 1건뿐이다. Repository, Service, Facade는 손대지 않았다. 쿼리 원문이 그대로여야 Phase 6의 실행계획과 같은 조건에서 비교된다
+- 테스트: `./gradlew test` 통과
+
+### 개선 후 지표
+
+| 구분 | 지표 | 개선 전 | 개선 후 | 변화 |
+|---|---|---|---|---|
+| 하드웨어 의존 | p95 | 473.056ms | 442.3124999999996ms | -6.5% |
+| | p99 | 719.1027999999997ms | 968.1165ms | +34.6% (악화) |
+| | med | 219.35ms | 125.126ms | -43.0% |
+| | max | 1784.57ms | 1898.165ms | +6.4% (악화) |
+| | RPS | 166.1613138464495 | 221.21615110025436 | +33.1% |
+| 하드웨어 독립 | 요청당 쿼리 수 | 6 | 6 | 변화 없음 |
+| | 대상 쿼리 mean_ms | 101.58188398951914 | 7.549862536326318 | -92.6% |
+| | 대상 쿼리 total 비중 | 91.2000115838526% (1위) | 32.318545126437755% (2위) | |
+| | 요청당 DB 시간 합 | 111.39ms | 23.36ms | -79.0% |
+| | 검사 행 / 반환 행 | 156,000 / 30 = 5,200:1 | 인덱스 탐색 60 / 30 = 2:1 | |
+| | Rows Removed by Filter (`bookmark`) | 155,844 | 0 | |
+| | 스캔 방식 | Seq Scan | Index Scan using `ix_bookmark_user_problem` | |
+| | 쿼리 전체 shared hit | 1306 (10.2MB) | 371 (2.9MB) | -71.6% |
+| | 단건 Execution Time | 14.585ms | 1.875ms | -87.1% |
+| | 캐시 hit / miss, 적중률 | - | - | 캐싱 사이클 아님 |
+
+- 에러율 0, check 통과율 1로 전후 동일하다. 응답 내용은 달라지지 않았다
+- 계획 변화: 조인 순서가 뒤집혔다. 개선 전에는 `bookmark` 156,000행을 훑어 유저 것 156행을 고른 뒤 `problem`과 해시 조인했다. 개선 후에는 유닛의 문제 60건을 바깥에 두고 문제마다 `(user_id, problem_id)` 인덱스를 찍는다 (Index Scan loops 60, 그중 30건이 매칭)
+- 개선 후 비용이 가장 큰 노드는 Hash Join(p⋈l) 0.808ms(46.1%)와 Seq Scan `problem` 0.540ms(30.8%)다
+
+### 판정
+
+- 개선 여부 (하드웨어 독립 증거 기준): **있음**. 스캔 방식이 Seq Scan에서 Index Scan으로 바뀌었고, 버린 행 155,844 → 0, 만진 페이지 1306 → 371, 요청당 DB 시간 111.39ms → 23.36ms다. 측정 편차로는 실행계획이 바뀌지 않는다
+- 예상 효과 대조: Phase 5에서 예상한 "Seq Scan → Index Scan"이 그대로 나왔다. 근거였던 `user_id` 선택도 0.1%를 플래너가 인덱스 선택으로 받아들였다
+- 남은 위험 신호:
+  - 단일 쿼리 total_exec_time 점유율 - `option` 조회가 51.80%로 새 1위다. 대상 쿼리도 32.32%로 30% 기준을 아직 넘는다
+  - 플래너 추정 대 실측 - Nested Loop가 rows=1로 추정했으나 실측 30이다. 유닛 필터와 유저 필터의 상관관계를 플래너가 독립으로 가정한 결과로, 이번 인덱스와는 별개 사안이다
+  - `problem` Seq Scan(6,900행)이 남아 있다. 1만 행 미만이라 위험 신호 기준에는 걸리지 않는다
+  - 해소된 항목: 검사 행 / 반환 행 5,200:1 → 2:1, `bookmark`의 Seq Scan, N+1 해당 없음(요청당 1.00 유지)
+- 설명되지 않은 관측: 대상 쿼리 외 나머지가 전부 호출당 느려졌다 (`option` 7.867 → 12.100, `answer` 1.596 → 2.988, `users` 조회 0.090 → 0.235, `unit` 0.099 → 0.129). 상승폭이 처리량 증가분(+33.1%)보다 크고 쿼리마다 제각각이라 부하 증가만으로는 설명되지 않는다.
+  유력한 가설은 앱과 PostgreSQL이 같은 머신에 있어, 응답 바이트가 289,985,385 → 386,109,259(+33.1%)로 늘면서 애플리케이션의 직렬화 CPU가 Postgres 몫을 잠식했다는 것이다.
+  이번 측정에 CPU 지표가 없어 확증하지 못했다. 확인하려면 측정 중 앱과 postgres의 CPU 점유를 관측하거나 DB를 별도 머신에 두고 재측정해야 한다
+- p99, max 악화: p99는 26,551건의 상위 1% 경계이므로 968ms보다 느린 요청이 약 266건 있어야 719 → 968ms로 움직인다. 단발 스파이크로는 설명되지 않는다.
+  med -43.0%, p95 -6.5%인데 p99만 +34.6%인 분포는 처리량 33% 증가로 커넥션 풀 60개에 요청이 몰린 대기열 신호로 읽는 편이 관측과 맞는다
+- 다음 사이클 진행 여부: 진행하지 않는다 (호출자가 종료를 선택). 규칙상으로는 위험 신호가 남아 계속 조건이었다
+- Phase 5에서 사이클 2로 미뤄둔 커버링(`INCLUDE (created_at)`) 건은 근거가 사라져 접는다. Sort 노드 자기 몫이 0.050ms(2.9%), `bookmark` Index Scan이 0.12ms(6.8%)로 없앨 힙 접근 비용이 거의 없다
+- 남겨두는 사이클 2 후보: `option` 조회 개선(새 1위, 51.80%, mean 12.100ms에 60행 반환), 조인 축소(`unit` 조인 제거, Seq Scan `unit`이 loops 30으로 자기 몫 0.15ms), `lesson (unit_id)` 인덱스(230행 테이블이라 효과는 미미할 수 있다)
+
+### 측정 조건의 한계
+
+`pg_stats`에서 `bookmark.user_id`의 correlation이 1이다. 시드가 유저 순으로 넣어 물리 순서가 `user_id`와 일치한다.
+실서비스는 북마크가 시간순으로 쌓여 `user_id`가 흩어지므로 correlation이 0에 가깝다.
+이 조건에서 잰 개선폭은 실서비스보다 낙관적으로 나올 수 있다. Phase 8 판정에서 감안한다.
+
+---
+
+## 최종 요약
+
+> 하드웨어 의존 증거와 독립 증거를 모두 남긴다.
+
+| 구분 | 지표 | 최초 | 최종 | 변화 |
+|---|---|---|---|---|
+| 하드웨어 의존 | p95 | 473.056ms | 442.3124999999996ms | -6.5% |
+| | p99 | 719.1027999999997ms | 968.1165ms | +34.6% (악화) |
+| | RPS | 166.1613138464495 | 221.21615110025436 | +33.1% |
+| 하드웨어 독립 | 요청당 쿼리 수 | 6 | 6 | 변화 없음 |
+| | 요청당 DB 시간 합 | 111.39ms | 23.36ms | -79.0% |
+| | 대상 쿼리 mean_ms | 101.58188398951914 | 7.549862536326318 | -92.6% |
+| | 검사 행 / 반환 행 | 156,000 / 30 = 5,200:1 | 인덱스 탐색 60 / 30 = 2:1 | |
+| | 스캔 방식 | Seq Scan | Index Scan using `ix_bookmark_user_problem` | |
+| | 쿼리 전체 shared hit | 1306 (10.2MB) | 371 (2.9MB) | -71.6% |
+| | 캐시 hit / miss, 적중률 | - | - | 캐싱 기법을 쓰지 않았다 |
+
+적용한 기법: 사이클 1 - `bookmark (user_id, problem_id)` UNIQUE 인덱스 추가 (`V38__add_bookmark_user_problem_unique_index.sql`)

--- a/.claude/resources/perf/492/bookmarks/record.md
+++ b/.claude/resources/perf/492/bookmarks/record.md
@@ -233,3 +233,21 @@
 | | 캐시 hit / miss, 적중률 | - | - | 캐싱 기법을 쓰지 않았다 |
 
 적용한 기법: 사이클 1 - `bookmark (user_id, problem_id)` UNIQUE 인덱스 추가 (`V38__add_bookmark_user_problem_unique_index.sql`)
+
+---
+
+## 후속 변경 (이 대상 종료 후)
+
+같은 이슈의 두 번째 대상 `GET /api/v1/wrong-answered-notes/{unitId}`의 사이클 1에서 **불필요한 `Unit` 조인 제거**를 적용하면서,
+`BookmarkRepository`의 두 쿼리도 함께 고쳤다. 같은 결함을 한쪽만 남기지 않기 위해서다.
+
+- `findBookmarkedProblemDetailByUnitIdAndUserId` (이 대상이 측정한 쿼리)
+- `countByUnitIdAndUserId`
+
+```
+JOIN Unit u ON u.id = l.unitId ... WHERE u.id = :unitId
+→ WHERE l.unitId = :unitId
+```
+
+따라서 **위에 적힌 쿼리 원문과 `query-plan-0.txt` / `query-plan-1.txt`는 측정 당시 기록으로는 유효하지만 현재 코드와는 다르다.**
+이 변경은 이 대상에서 재측정하지 않았다. 근거와 등가성 검증은 `../wrong-answered-notes/record.md`의 사이클 1을 참조한다.

--- a/.claude/resources/perf/492/bookmarks/test-script.js
+++ b/.claude/resources/perf/492/bookmarks/test-script.js
@@ -1,0 +1,153 @@
+// PERF-492 / GET /api/v1/bookmarks/{unitId}
+//
+// 실행: 토큰 발급, warmup, measure를 각각 따로 돌린다. 통계 리셋은 토큰 발급이 끝난 뒤에 한다.
+//
+//   (토큰 발급 - Phase 4, 8의 명령 블록 참조. $PERF_DIR/tokens.json 생성)
+//   k6 run -e PHASE=warmup -e USER_ID_START=1001 -e USER_COUNT=1000 $TARGET_DIR/test-script.js
+//   psql ... -c "SELECT pg_stat_statements_reset();"
+//   k6 run -e PHASE=measure -e USER_ID_START=1001 -e USER_COUNT=1000 \
+//     -e SUMMARY_OUT=$TARGET_DIR/k6-test-summary-0.json $TARGET_DIR/test-script.js
+
+import http from 'k6/http';
+import exec from 'k6/execution';
+import { check } from 'k6';
+
+const BASE_URL = __ENV.BASE_URL || 'http://localhost:8080';
+const USER_ID_START = Number(__ENV.USER_ID_START || 1001);
+const USER_COUNT = Number(__ENV.USER_COUNT || 1000);
+const PHASE = __ENV.PHASE || 'measure';
+
+// unitId는 고정이다. seeds.sql이 이 유닛에만 유저당 30건(OBJECTIVE 15 / SUBJECTIVE 15)을 몰아넣었다.
+// 변동은 토큰(유저 1000명)이 만든다. 유저마다 북마크한 문제 집합이 달라 같은 행을 반복 조회하지 않는다.
+const TARGET_UNIT_ID = 900002;
+
+// 이 측정이 무엇이었는지 요약 파일만 보고 알 수 있게 한다.
+const TARGET = 'bookmarks';
+const ENDPOINT = 'GET /api/v1/bookmarks/{unitId}';
+const CONDITION = {
+    vus: 50,
+    steady_state_duration: '1m',
+    ramp_up: '30s',
+    ramp_down: '30s',
+    total_duration: '2m',
+    redis_cache: 'cold (measure 직전 FLUSHDB)',
+    db_cache: '제어하지 않음. FLUSHDB는 PostgreSQL shared_buffers와 OS page cache를 비우지 않는다',
+    target_unit_id: TARGET_UNIT_ID,
+    expected_problems_per_request: 30,
+    user_id_start: USER_ID_START,
+    user_count: USER_COUNT,
+};
+
+// tokens.json은 이슈 디렉토리에 있다(대상 간 공유).
+const tokens = JSON.parse(open('../tokens.json'));
+
+if (tokens.length !== USER_COUNT) {
+    throw new Error(
+        `토큰 ${tokens.length}건 / 필요 ${USER_COUNT}건. 로그인에 실패한 userId가 있다. ` +
+        'tokens.json을 다시 만들고 userId 범위와 perf 프로파일 기동 상태를 확인하라.'
+    );
+}
+
+const scenarios = {
+    warmup: {
+        executor: 'constant-vus',
+        vus: 5,
+        duration: '30s',
+    },
+    measure: {
+        executor: 'ramping-vus',
+        startVUs: 0,
+        stages: [
+            { duration: '30s', target: 50 },
+            { duration: '1m', target: 50 },
+            { duration: '30s', target: 0 },
+        ],
+    },
+};
+
+export const options = {
+    scenarios: { [PHASE]: scenarios[PHASE] },
+    summaryTrendStats: ['avg', 'min', 'med', 'p(90)', 'p(95)', 'p(99)', 'max'],
+    thresholds: {
+        http_req_failed: ['rate<0.01'],
+        checks: ['rate>0.99'],
+    },
+};
+
+// 비JSON 응답에서 예외를 던지지 않는다. 파싱 실패는 null로 떨어뜨려 check 실패로 드러낸다.
+function parseBody(res) {
+    if (res.status !== 200 || res.body === null || res.body.length <= 2) {
+        return null;
+    }
+    try {
+        return res.json();
+    } catch (e) {
+        return null;
+    }
+}
+
+export default function () {
+    // 시나리오 전체의 반복 번호로 고른다. VU 수와 무관하게 토큰 USER_COUNT개를 균등하게 돈다.
+    const token = tokens[exec.scenario.iterationInTest % tokens.length];
+    const params = { headers: { Authorization: `Bearer ${token}` } };
+
+    const res = http.get(`${BASE_URL}/api/v1/bookmarks/${TARGET_UNIT_ID}`, params);
+
+    check(res, {
+        'status is 200': (r) => r.status === 200,
+        'body is not empty': (r) => r.body !== null && r.body.length > 2,
+        'problems 30건이 실려 있다': (r) => {
+            const body = parseBody(r);
+            return body !== null && body.problems !== undefined && body.problems.length === 30;
+        },
+    });
+}
+
+export function handleSummary(data) {
+    const m = data.metrics || {};
+    const val = (name, key) => (m[name] && m[name].values[key] !== undefined ? m[name].values[key] : null);
+    const trend = (name) => ({
+        med: val(name, 'med'),
+        p95: val(name, 'p(95)'),
+        p99: val(name, 'p(99)'),
+        max: val(name, 'max'),
+    });
+
+    const summary = {
+        phase: PHASE,
+        target: TARGET,
+        endpoint: ENDPOINT,
+        condition: CONDITION,
+        requests: val('http_reqs', 'count'),
+        rps: val('http_reqs', 'rate'),
+        failed_rate: val('http_req_failed', 'rate'),
+        checks_rate: val('checks', 'rate'),
+        checks: ((data.root_group || {}).checks || []).map((c) => ({
+            name: c.name,
+            passes: c.passes,
+            fails: c.fails,
+        })),
+        duration_ms: trend('http_req_duration'),
+        waiting_ms: trend('http_req_waiting'),
+        bytes_received: val('data_received', 'count'),
+    };
+
+    // 아래 반올림은 터미널 한 줄 출력에만 쓴다. summary 객체의 값은 손대지 않는다.
+    const num = (x, d) => (typeof x === 'number' ? x.toFixed(d) : '-');
+    const line = [
+        `[${PHASE}] ${TARGET}`,
+        `요청 ${summary.requests}건`,
+        `p95 ${num(summary.duration_ms.p95, 1)}ms`,
+        `p99 ${num(summary.duration_ms.p99, 1)}ms`,
+        `실패율 ${num(summary.failed_rate * 100, 2)}%`,
+        `check ${num(summary.checks_rate * 100, 2)}%`,
+    ].join(' / ');
+
+    const out = { stdout: `\n${line}\n\n` };
+
+    if (__ENV.SUMMARY_OUT) {
+        out[__ENV.SUMMARY_OUT] = JSON.stringify(summary, null, 2);
+    }
+
+    return out;
+}

--- a/.claude/resources/perf/492/seeds.sql
+++ b/.claude/resources/perf/492/seeds.sql
@@ -3,7 +3,12 @@
 --
 -- chapter/unit/lesson/problem/users는 이미 목표 규모에 도달해 있어 content.sql, user.sql은 부르지 않는다.
 -- (unit 66, lesson 230, problem 6900, users 1002)
--- 비어 있는 answer/option/bookmark만 review.sql로 채운다.
+-- 비어 있는 answer/option/bookmark를 review.sql로 채운다.
+--
+-- wrong_answered_note는 기존 155,700행이 전부 유닛 910001에 몰려 있어 대상 유닛 900002에는 0행이었다.
+-- 두 번째 대상(GET /api/v1/wrong-answered-notes/{unitId})을 위해 900002에 유저당 40건을 추가하고
+-- 그중 10건을 극복 처리한다. 반환 행 30건은 첫 대상(bookmark)과 같은 크기다.
+-- answer/option/bookmark 블록은 NOT EXISTS 가드가 있어 재실행해도 중복이 쌓이지 않는다.
 
 \set user_start 1001
 \set user_count 1000
@@ -12,5 +17,8 @@
 \set bookmarks_per_user 156
 \set target_unit_bookmarks_per_user 30
 \set options_per_problem 4
+
+\set target_unit_wrong_notes_per_user 40
+\set target_unit_resolved_per_user 10
 
 \i .claude/skills/optimize-performance/template/seeds/review.sql

--- a/.claude/resources/perf/492/seeds.sql
+++ b/.claude/resources/perf/492/seeds.sql
@@ -1,0 +1,16 @@
+-- PERF-492 시드
+-- 대상: GET /api/v1/bookmarks/{unitId}, GET /api/v1/wrong-answered-notes/{unitId}
+--
+-- chapter/unit/lesson/problem/users는 이미 목표 규모에 도달해 있어 content.sql, user.sql은 부르지 않는다.
+-- (unit 66, lesson 230, problem 6900, users 1002)
+-- 비어 있는 answer/option/bookmark만 review.sql로 채운다.
+
+\set user_start 1001
+\set user_count 1000
+
+\set target_unit_id 900002
+\set bookmarks_per_user 156
+\set target_unit_bookmarks_per_user 30
+\set options_per_problem 4
+
+\i .claude/skills/optimize-performance/template/seeds/review.sql

--- a/.claude/resources/perf/492/wrong-answered-notes/k6-test-summary-0.json
+++ b/.claude/resources/perf/492/wrong-answered-notes/k6-test-summary-0.json
@@ -1,0 +1,53 @@
+{
+  "phase": "measure",
+  "target": "wrong-answered-notes",
+  "endpoint": "GET /api/v1/wrong-answered-notes/{unitId}",
+  "condition": {
+    "vus": 50,
+    "steady_state_duration": "1m",
+    "ramp_up": "30s",
+    "ramp_down": "30s",
+    "total_duration": "2m",
+    "redis_cache": "cold (measure 직전 FLUSHDB)",
+    "db_cache": "제어하지 않음. FLUSHDB는 PostgreSQL shared_buffers와 OS page cache를 비우지 않는다",
+    "target_unit_id": 900002,
+    "expected_problems_per_request": 30,
+    "user_id_start": 1001,
+    "user_count": 1000,
+    "baseline_precondition": "V38 bookmark (user_id, problem_id) UNIQUE 인덱스가 이미 적용된 상태다. 이 쿼리의 LEFT JOIN Bookmark가 그 인덱스를 탄다"
+  },
+  "requests": 45872,
+  "rps": 382.23845109833474,
+  "failed_rate": 0,
+  "checks_rate": 1,
+  "checks": [
+    {
+      "name": "status is 200",
+      "passes": 45872,
+      "fails": 0
+    },
+    {
+      "name": "body is not empty",
+      "passes": 45872,
+      "fails": 0
+    },
+    {
+      "name": "problems 30건이 실려 있다",
+      "passes": 45872,
+      "fails": 0
+    }
+  ],
+  "duration_ms": {
+    "med": 97.561,
+    "p95": 192.63904999999988,
+    "p99": 253.12869999999998,
+    "max": 496.084
+  },
+  "waiting_ms": {
+    "med": 97.422,
+    "p95": 192.40229999999994,
+    "p99": 252.88765999999998,
+    "max": 495.83
+  },
+  "bytes_received": 667078851
+}

--- a/.claude/resources/perf/492/wrong-answered-notes/k6-test-summary-1-rerun.json
+++ b/.claude/resources/perf/492/wrong-answered-notes/k6-test-summary-1-rerun.json
@@ -1,0 +1,53 @@
+{
+  "phase": "measure",
+  "target": "wrong-answered-notes",
+  "endpoint": "GET /api/v1/wrong-answered-notes/{unitId}",
+  "condition": {
+    "vus": 50,
+    "steady_state_duration": "1m",
+    "ramp_up": "30s",
+    "ramp_down": "30s",
+    "total_duration": "2m",
+    "redis_cache": "cold (measure 직전 FLUSHDB)",
+    "db_cache": "제어하지 않음. FLUSHDB는 PostgreSQL shared_buffers와 OS page cache를 비우지 않는다",
+    "target_unit_id": 900002,
+    "expected_problems_per_request": 30,
+    "user_id_start": 1001,
+    "user_count": 1000,
+    "baseline_precondition": "V38 bookmark (user_id, problem_id) UNIQUE 인덱스가 이미 적용된 상태다. 이 쿼리의 LEFT JOIN Bookmark가 그 인덱스를 탄다"
+  },
+  "requests": 38750,
+  "rps": 322.9095518928733,
+  "failed_rate": 0,
+  "checks_rate": 1,
+  "checks": [
+    {
+      "name": "status is 200",
+      "passes": 38750,
+      "fails": 0
+    },
+    {
+      "name": "body is not empty",
+      "passes": 38750,
+      "fails": 0
+    },
+    {
+      "name": "problems 30건이 실려 있다",
+      "passes": 38750,
+      "fails": 0
+    }
+  ],
+  "duration_ms": {
+    "med": 104.626,
+    "p95": 253.28889999999996,
+    "p99": 480.50971,
+    "max": 1971.246
+  },
+  "waiting_ms": {
+    "med": 104.47149999999999,
+    "p95": 253.16824999999992,
+    "p99": 480.23546999999985,
+    "max": 1971.144
+  },
+  "bytes_received": 563509397
+}

--- a/.claude/resources/perf/492/wrong-answered-notes/k6-test-summary-1.json
+++ b/.claude/resources/perf/492/wrong-answered-notes/k6-test-summary-1.json
@@ -1,0 +1,65 @@
+{
+  "phase": "measure",
+  "target": "wrong-answered-notes",
+  "endpoint": "GET /api/v1/wrong-answered-notes/{unitId}",
+  "condition": {
+    "vus": 50,
+    "steady_state_duration": "1m",
+    "ramp_up": "30s",
+    "ramp_down": "30s",
+    "total_duration": "2m",
+    "redis_cache": "cold (measure 직전 FLUSHDB)",
+    "db_cache": "제어하지 않음. FLUSHDB는 PostgreSQL shared_buffers와 OS page cache를 비우지 않는다",
+    "target_unit_id": 900002,
+    "expected_problems_per_request": 30,
+    "user_id_start": 1001,
+    "user_count": 1000,
+    "baseline_precondition": "V38 bookmark (user_id, problem_id) UNIQUE 인덱스가 이미 적용된 상태다. 이 쿼리의 LEFT JOIN Bookmark가 그 인덱스를 탄다"
+  },
+  "requests": 45275,
+  "rps": 377.23077533234846,
+  "failed_rate": 0,
+  "checks_rate": 1,
+  "checks": [
+    {
+      "name": "status is 200",
+      "passes": 45275,
+      "fails": 0
+    },
+    {
+      "name": "body is not empty",
+      "passes": 45275,
+      "fails": 0
+    },
+    {
+      "name": "problems 30건이 실려 있다",
+      "passes": 45275,
+      "fails": 0
+    }
+  ],
+  "duration_ms": {
+    "med": 90.641,
+    "p95": 204.7070999999999,
+    "p99": 372.14019999999977,
+    "max": 1048.058
+  },
+  "waiting_ms": {
+    "med": 90.497,
+    "p95": 204.53359999999998,
+    "p99": 372.07953999999984,
+    "max": 1047.854
+  },
+  "bytes_received": 658397163,
+  "delta_vs_prev": {
+    "from": "k6-test-summary-0.json",
+    "requests": { "before": 45872, "after": 45275 },
+    "rps": { "before": 382.23845109833474, "after": 377.23077533234846 },
+    "duration_med_ms": { "before": 97.561, "after": 90.641 },
+    "duration_p95_ms": { "before": 192.63904999999988, "after": 204.7070999999999 },
+    "duration_p99_ms": { "before": 253.12869999999998, "after": 372.14019999999977 },
+    "duration_max_ms": { "before": 496.084, "after": 1048.058 },
+    "failed_rate": { "before": 0, "after": 0 },
+    "checks_rate": { "before": 1, "after": 1 },
+    "bytes_received": { "before": 667078851, "after": 658397163 }
+  }
+}

--- a/.claude/resources/perf/492/wrong-answered-notes/query-plan-0.txt
+++ b/.claude/resources/perf/492/wrong-answered-notes/query-plan-0.txt
@@ -1,0 +1,52 @@
+                                                                                        QUERY PLAN                                                                                        
+------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
+ Nested Loop Left Join  (cost=6.74..327.31 rows=2 width=64) (actual time=1.463..3.344 rows=30 loops=1)
+   Output: p1_0.id, p1_0.problem_type, p1_0.instruction, p1_0.content, CASE WHEN (b1_0.id IS NOT NULL) THEN true ELSE false END
+   Inner Unique: true
+   Buffers: shared hit=440
+   ->  Nested Loop  (cost=6.32..324.39 rows=2 width=63) (actual time=1.305..3.113 rows=30 loops=1)
+         Output: p1_0.id, p1_0.problem_type, p1_0.instruction, p1_0.content
+         Buffers: shared hit=320
+         ->  Seq Scan on public.unit u1_0  (cost=0.00..2.83 rows=1 width=8) (actual time=0.030..0.036 rows=1 loops=1)
+               Output: u1_0.id, u1_0.chapter_id, u1_0.description, u1_0.title
+               Filter: (u1_0.id = 900002)
+               Rows Removed by Filter: 65
+               Buffers: shared hit=2
+         ->  Nested Loop  (cost=6.32..321.54 rows=2 width=71) (actual time=1.272..3.068 rows=30 loops=1)
+               Output: p1_0.id, p1_0.problem_type, p1_0.instruction, p1_0.content, l1_0.unit_id
+               Inner Unique: true
+               Buffers: shared hit=318
+               ->  Hash Join  (cost=5.90..185.35 rows=60 width=71) (actual time=1.087..2.734 rows=60 loops=1)
+                     Output: p1_0.id, p1_0.problem_type, p1_0.instruction, p1_0.content, l1_0.unit_id
+                     Inner Unique: true
+                     Hash Cond: (p1_0.lesson_id = l1_0.id)
+                     Buffers: shared hit=95
+                     ->  Seq Scan on public.problem p1_0  (cost=0.00..161.00 rows=6900 width=71) (actual time=0.005..0.817 rows=6900 loops=1)
+                           Output: p1_0.id, p1_0.content, p1_0.instruction, p1_0.lesson_id, p1_0.problem_type
+                           Buffers: shared hit=92
+                     ->  Hash  (cost=5.88..5.88 rows=2 width=16) (actual time=0.047..0.048 rows=2 loops=1)
+                           Output: l1_0.id, l1_0.unit_id
+                           Buckets: 1024  Batches: 1  Memory Usage: 9kB
+                           Buffers: shared hit=3
+                           ->  Seq Scan on public.lesson l1_0  (cost=0.00..5.88 rows=2 width=16) (actual time=0.026..0.033 rows=2 loops=1)
+                                 Output: l1_0.id, l1_0.unit_id
+                                 Filter: (l1_0.unit_id = 900002)
+                                 Rows Removed by Filter: 228
+                                 Buffers: shared hit=3
+               ->  Index Scan using ix_wrong_answered_note_user_problem on public.wrong_answered_note wan1_0  (cost=0.42..2.27 rows=1 width=8) (actual time=0.005..0.005 rows=0 loops=60)
+                     Output: wan1_0.problem_id
+                     Index Cond: ((wan1_0.user_id = 1500) AND (wan1_0.problem_id = p1_0.id))
+                     Filter: (wan1_0.resolved_at IS NULL)
+                     Rows Removed by Filter: 0
+                     Buffers: shared hit=223
+   ->  Index Scan using ix_bookmark_user_problem on public.bookmark b1_0  (cost=0.42..1.46 rows=1 width=16) (actual time=0.007..0.007 rows=1 loops=30)
+         Output: b1_0.id, b1_0.created_at, b1_0.problem_id, b1_0.user_id
+         Index Cond: ((b1_0.user_id = 1500) AND (b1_0.problem_id = p1_0.id))
+         Buffers: shared hit=120
+ Query Identifier: 4936570048673794878
+ Planning:
+   Buffers: shared hit=325
+ Planning Time: 6.753 ms
+ Execution Time: 3.617 ms
+(48 rows)
+

--- a/.claude/resources/perf/492/wrong-answered-notes/query-plan-1.txt
+++ b/.claude/resources/perf/492/wrong-answered-notes/query-plan-1.txt
@@ -1,0 +1,46 @@
+BEGIN
+                                                                                     QUERY PLAN                                                                                     
+------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
+ Nested Loop Left Join  (cost=6.74..324.46 rows=2 width=64) (actual time=0.684..1.664 rows=30 loops=1)
+   Output: p1_0.id, p1_0.problem_type, p1_0.instruction, p1_0.content, CASE WHEN (b1_0.id IS NOT NULL) THEN true ELSE false END
+   Inner Unique: true
+   Buffers: shared hit=438
+   ->  Nested Loop  (cost=6.32..321.54 rows=2 width=63) (actual time=0.651..1.580 rows=30 loops=1)
+         Output: p1_0.id, p1_0.problem_type, p1_0.instruction, p1_0.content
+         Inner Unique: true
+         Buffers: shared hit=318
+         ->  Hash Join  (cost=5.90..185.35 rows=60 width=63) (actual time=0.602..1.429 rows=60 loops=1)
+               Output: p1_0.id, p1_0.problem_type, p1_0.instruction, p1_0.content
+               Inner Unique: true
+               Hash Cond: (p1_0.lesson_id = l1_0.id)
+               Buffers: shared hit=95
+               ->  Seq Scan on public.problem p1_0  (cost=0.00..161.00 rows=6900 width=71) (actual time=0.007..0.578 rows=6900 loops=1)
+                     Output: p1_0.id, p1_0.content, p1_0.instruction, p1_0.lesson_id, p1_0.problem_type
+                     Buffers: shared hit=92
+               ->  Hash  (cost=5.88..5.88 rows=2 width=8) (actual time=0.027..0.027 rows=2 loops=1)
+                     Output: l1_0.id
+                     Buckets: 1024  Batches: 1  Memory Usage: 9kB
+                     Buffers: shared hit=3
+                     ->  Seq Scan on public.lesson l1_0  (cost=0.00..5.88 rows=2 width=8) (actual time=0.014..0.023 rows=2 loops=1)
+                           Output: l1_0.id
+                           Filter: (l1_0.unit_id = 900002)
+                           Rows Removed by Filter: 228
+                           Buffers: shared hit=3
+         ->  Index Scan using ix_wrong_answered_note_user_problem on public.wrong_answered_note wan1_0  (cost=0.42..2.27 rows=1 width=8) (actual time=0.002..0.002 rows=0 loops=60)
+               Output: wan1_0.problem_id
+               Index Cond: ((wan1_0.user_id = 1500) AND (wan1_0.problem_id = p1_0.id))
+               Filter: (wan1_0.resolved_at IS NULL)
+               Rows Removed by Filter: 0
+               Buffers: shared hit=223
+   ->  Index Scan using ix_bookmark_user_problem on public.bookmark b1_0  (cost=0.42..1.46 rows=1 width=16) (actual time=0.002..0.002 rows=1 loops=30)
+         Output: b1_0.id, b1_0.created_at, b1_0.problem_id, b1_0.user_id
+         Index Cond: ((b1_0.user_id = 1500) AND (b1_0.problem_id = p1_0.id))
+         Buffers: shared hit=120
+ Query Identifier: 7075697947125107851
+ Planning:
+   Buffers: shared hit=297
+ Planning Time: 2.402 ms
+ Execution Time: 1.742 ms
+(40 rows)
+
+ROLLBACK

--- a/.claude/resources/perf/492/wrong-answered-notes/query-stats-summary-0.md
+++ b/.claude/resources/perf/492/wrong-answered-notes/query-stats-summary-0.md
@@ -1,0 +1,43 @@
+# query-stats-summary-0 — wrong-answered-notes
+
+상태: 0 = 원본 (단, `bookmark (user_id, problem_id)` UNIQUE 인덱스 V38이 앞 대상에서 이미 적용된 상태다)
+측정: VU 50 / 유지 1m (총 2m) / 캐시 cold / 요청 45872건
+직전 상태 대비: - (이 대상의 첫 측정)
+
+| # | 요청당 | calls | mean_ms | total_ms | 비중 | 행/호출 | 출처 | 하는 일 |
+|---|---|---|---|---|---|---|---|---|
+| 1 | 1.00000000000000000000 | 45872 | 7.283352535708062 | 334101.947518001 | 54.79509378993013% | 60.0000000000000000 | `OptionRepository.findAllByProblemIdIn` | OBJECTIVE 문제 15건의 선택지를 `problem_id IN (...)`로 읽고 `problem_id` 순으로 정렬 |
+| 2 | 1.00000000000000000000 | 45872 | 4.0971767350671575 | 187945.69119100034 | 30.82442904846952% | 30.0000000000000000 | `WrongAnsweredNoteRepository.findWrongAnsweredProblemDetailByUnitIdAndUserId` | `wrong_answered_note ⋈ problem ⋈ lesson ⋈ unit` 내부 조인 + `bookmark` LEFT JOIN, `user_id`/`unit.id`/`resolved_at IS NULL`로 걸러 문제 상세를 읽음 |
+| 3 | 1.00000000000000000000 | 45872 | 1.6740161849494228 | 76790.47043599872 | 12.594182886308074% | 15.0000000000000000 | `AnswerRepository.findByProblemIdIn` | SUBJECTIVE 문제 15건의 정답을 `problem_id IN (...)`로 읽고 `problem_id` 순으로 정렬 |
+| 4 | 1.00000000000000000000 | 45872 | 0.07258027341297645 | 3329.402302000005 | 0.5460456389368105% | 1.00000000000000000000 | `AuthTokenProvider.parseUser` | `users` PK 단건 조회 (인증 필터) |
+| 5 | 2.0000000000000000 | 91744 | 0.029648312816097106 | 2720.054811000024 | 0.4461083198997713% | 0.000000000000000000000000 | - | 트랜잭션 제어 |
+| 6 | 1.00000000000000000000 | 45872 | 0.05624162264562195 | 2579.9157139999975 | 0.423124512050705% | 1.00000000000000000000 | `UnitRepository.findUnitSummaryById` | `unit` PK 단건 조회, DTO 프로젝션 |
+| 7 | 1.00000000000000000000 | 45872 | 0.04753245295605129 | 2180.408681999994 | 0.35760251958462586% | 0.000000000000000000000000 | `UserAccessService.updateLastAccessed` (`LastAccessInterceptor.preHandle`) | `users.last_accessed_at` 갱신 |
+| 8 | 1.00008719916288803627 | 45876 | 0.0017806529775917619 | 81.68923600000696 | 0.013397615253370972% | 0.000000000000000000000000 | - | 트랜잭션 제어 |
+| 9 | 0.000087199162888036274852 | 4 | 0.01655175 | 0.066207 | 1.085841852015676e-05% | 0.00000000000000000000 | 미상 (측정 대상 API 밖. 시즌 스케줄러로 추정되나 Grep으로 특정하지 못함) | 종료 시점이 지난 `season`을 `FOR NO KEY UPDATE`로 조회 |
+| 10 | 0.00098099058249040809 | 45 | 0.0006213333333333333 | 0.02796000000000001 | 4.585638706233225e-06% | 0.00000000000000000000 | - | 트랜잭션 제어 |
+| 11 | 0.000043599581444018137426 | 2 | 0.0006875 | 0.001375 | 2.2550977185517458e-07% | 0.00000000000000000000 | - | 트랜잭션 제어 |
+
+## 쿼리 원문
+
+[1] select o1_0.id,o1_0.content,o1_0.explanation,o1_0.is_answer,o1_0.problem_id from option o1_0 where o1_0.problem_id in ($1,$2,$3,$4,$5,$6,$7,$8,$9,$10,$11,$12,$13,$14,$15) order by o1_0.problem_id
+
+[2] select p1_0.id,p1_0.problem_type,p1_0.instruction,p1_0.content,case when b1_0.id is not null then $4 else $5 end from wrong_answered_note wan1_0 join problem p1_0 on p1_0.id=wan1_0.problem_id join lesson l1_0 on l1_0.id=p1_0.lesson_id join unit u1_0 on u1_0.id=l1_0.unit_id left join bookmark b1_0 on b1_0.problem_id=p1_0.id and b1_0.user_id=$1 where wan1_0.user_id=$2 and u1_0.id=$3 and wan1_0.resolved_at is null
+
+[3] select a1_0.id,a1_0.content,a1_0.explanation,a1_0.problem_id from answer a1_0 where a1_0.problem_id in ($1,$2,$3,$4,$5,$6,$7,$8,$9,$10,$11,$12,$13,$14,$15) order by a1_0.problem_id
+
+[4] select u1_0.id,u1_0.created_at,u1_0.deleted_at,u1_0.email,u1_0.handle,u1_0.is_onboarded,u1_0.last_accessed_at,u1_0.level,u1_0.xp,u1_0.nickname,u1_0.profile_img_number,u1_0.provider_id,u1_0.role,u1_0.status,u1_0.updated_at from users u1_0 where u1_0.id=$1 and (u1_0.deleted_at IS NULL)
+
+[5] BEGIN READ ONLY
+
+[6] select u1_0.id,u1_0.title,u1_0.description from unit u1_0 where u1_0.id=$1
+
+[7] update users u1_0 set last_accessed_at=$1 where u1_0.id=$2 and (u1_0.last_accessed_at is null or u1_0.last_accessed_at<$3) and (u1_0.deleted_at IS NULL)
+
+[8] BEGIN
+
+[9] select s1_0.id,s1_0.ends_at,s1_0.season_key,s1_0.starts_at,s1_0.status,s1_0.tz from season s1_0 where s1_0.status=$2 and s1_0.ends_at<=$1 for no key update
+
+[10] COMMIT
+
+[11] ROLLBACK

--- a/.claude/resources/perf/492/wrong-answered-notes/query-stats-summary-1.md
+++ b/.claude/resources/perf/492/wrong-answered-notes/query-stats-summary-1.md
@@ -1,0 +1,43 @@
+# query-stats-summary-1 — wrong-answered-notes
+
+상태: 1 = 사이클 1 적용 후: 불필요한 `Unit` 조인 제거 (`WHERE l.unitId = :unitId`)
+측정: VU 50 / 유지 1m (총 2m) / 캐시 cold / 요청 45275건
+직전 상태 대비: 요청당 쿼리 수 6 → 6 (변화 없음). 대상 쿼리 total_ms 187945.69119100034 → 192853.78409099995 (+2.6%), mean_ms 4.0971767350671575 → 4.2596087043843 (+4.0%), 비중 30.82442904846952% → 30.991447705657233%. 쿼리 목록의 구성과 순위는 동일하고, 사라지거나 새로 생긴 쿼리는 없다. 대상 쿼리 원문에서 `join unit u1_0 on u1_0.id=l1_0.unit_id`가 빠지고 `where` 절이 `u1_0.id=$3` → `l1_0.unit_id=$3`으로 바뀌었다
+
+| # | 요청당 | calls | mean_ms | total_ms | 비중 | 행/호출 | 출처 | 하는 일 |
+|---|---|---|---|---|---|---|---|---|
+| 1 | 1.00000000000000000000 | 45275 | 7.479063274632813 | 338614.58975900203 | 54.41509172532968% | 60.0000000000000000 | `OptionRepository.findAllByProblemIdIn` | OBJECTIVE 문제 15건의 선택지를 `problem_id IN (...)`로 읽고 `problem_id` 순으로 정렬 |
+| 2 | 1.00000000000000000000 | 45275 | 4.2596087043843 | 192853.78409099995 | 30.991447705657233% | 30.0000000000000000 | `WrongAnsweredNoteRepository.findWrongAnsweredProblemDetailByUnitIdAndUserId` | `wrong_answered_note ⋈ problem ⋈ lesson` 내부 조인 + `bookmark` LEFT JOIN, `user_id`/`lesson.unit_id`/`resolved_at IS NULL`로 걸러 문제 상세를 읽음 |
+| 3 | 1.00000000000000000000 | 45275 | 1.704469572236333 | 77169.85988299926 | 12.40113430125055% | 15.0000000000000000 | `AnswerRepository.findByProblemIdIn` | SUBJECTIVE 문제 15건의 정답을 `problem_id IN (...)`로 읽고 `problem_id` 순으로 정렬 |
+| 4 | 1.00000000000000000000 | 45275 | 0.09084572125897257 | 4113.040030000008 | 0.6609622186146609% | 1.00000000000000000000 | `AuthTokenProvider.parseUser` | `users` PK 단건 조회 (인증 필터) |
+| 5 | 2.0000000000000000 | 90550 | 0.04071503327443372 | 3686.7462630000305 | 0.5924571537568539% | 0.000000000000000000000000 | - | 트랜잭션 제어 |
+| 6 | 1.00000000000000000000 | 45275 | 0.07190682279403679 | 3255.5814020000066 | 0.5231693080182709% | 1.00000000000000000000 | `UnitRepository.findUnitSummaryById` | `unit` PK 단건 조회, DTO 프로젝션 |
+| 7 | 1.00000000000000000000 | 45275 | 0.052404212103809966 | 2372.6007029999732 | 0.381275021177356% | 0.000000000000000000000000 | `UserAccessService.updateLastAccessed` (`LastAccessInterceptor.preHandle`) | `users.last_accessed_at` 갱신 |
+| 8 | 1.00015461071231363887 | 45282 | 0.004727197650280482 | 214.05696400002105 | 0.034398781631933745% | 0.000000000000000000000000 | - | 트랜잭션 제어 |
+| 9 | 0.00015461071231363887 | 7 | 0.052404714285714284 | 0.3668330000000001 | 5.894976751322098e-05% | 0.00000000000000000000 | 미상 (측정 대상 API 밖. 시즌 스케줄러로 추정되나 Grep으로 특정하지 못함) | 종료 시점이 지난 `season`을 `FOR NO KEY UPDATE`로 조회 |
+| 10 | 0.00097183876311430149 | 44 | 0.0006496818181818183 | 0.02858600000000001 | 4.593747165966352e-06% | 0.00000000000000000000 | - | 트랜잭션 제어 |
+| 11 | 0.000044174489232468249586 | 2 | 0.00075 | 0.0015 | 2.410487913296553e-07% | 0.00000000000000000000 | - | 트랜잭션 제어 |
+
+## 쿼리 원문
+
+[1] select o1_0.id,o1_0.content,o1_0.explanation,o1_0.is_answer,o1_0.problem_id from option o1_0 where o1_0.problem_id in ($1,$2,$3,$4,$5,$6,$7,$8,$9,$10,$11,$12,$13,$14,$15) order by o1_0.problem_id
+
+[2] select p1_0.id,p1_0.problem_type,p1_0.instruction,p1_0.content,case when b1_0.id is not null then true else false end from wrong_answered_note wan1_0 join problem p1_0 on p1_0.id=wan1_0.problem_id join lesson l1_0 on l1_0.id=p1_0.lesson_id left join bookmark b1_0 on b1_0.problem_id=p1_0.id and b1_0.user_id=$1 where wan1_0.user_id=$2 and l1_0.unit_id=$3 and wan1_0.resolved_at is null
+
+[3] select a1_0.id,a1_0.content,a1_0.explanation,a1_0.problem_id from answer a1_0 where a1_0.problem_id in ($1,$2,$3,$4,$5,$6,$7,$8,$9,$10,$11,$12,$13,$14,$15) order by a1_0.problem_id
+
+[4] select u1_0.id,u1_0.created_at,u1_0.deleted_at,u1_0.email,u1_0.handle,u1_0.is_onboarded,u1_0.last_accessed_at,u1_0.level,u1_0.xp,u1_0.nickname,u1_0.profile_img_number,u1_0.provider_id,u1_0.role,u1_0.status,u1_0.updated_at from users u1_0 where u1_0.id=$1 and (u1_0.deleted_at IS NULL)
+
+[5] BEGIN READ ONLY
+
+[6] select u1_0.id,u1_0.title,u1_0.description from unit u1_0 where u1_0.id=$1
+
+[7] update users u1_0 set last_accessed_at=$1 where u1_0.id=$2 and (u1_0.last_accessed_at is null or u1_0.last_accessed_at<$3) and (u1_0.deleted_at IS NULL)
+
+[8] BEGIN
+
+[9] select s1_0.id,s1_0.ends_at,s1_0.season_key,s1_0.starts_at,s1_0.status,s1_0.tz from season s1_0 where s1_0.status=$2 and s1_0.ends_at<=$1 for no key update
+
+[10] COMMIT
+
+[11] ROLLBACK

--- a/.claude/resources/perf/492/wrong-answered-notes/record.md
+++ b/.claude/resources/perf/492/wrong-answered-notes/record.md
@@ -1,0 +1,323 @@
+# [PERF-492] GET /api/v1/wrong-answered-notes/{unitId}
+
+> 이슈: #492
+> 브랜치: refactor/492-bookmark-wrong-note-query-performance
+> 대상 디렉토리: `.claude/resources/perf/492/wrong-answered-notes/`
+
+이 파일은 대상 엔드포인트 하나만 다룬다. 같은 이슈의 다른 엔드포인트는 각자의 디렉토리에 각자의 `record.md`를 가진다.
+
+## 진행 상태
+
+> ⏳ 미완 / ✅ 완료 / ⏭️ 건너뜀
+> 재진입 시 ⏳로 표기된 가장 이른 Phase부터 재개한다.
+
+**준비 (대상당 1회)**
+
+| 1. 대상 | 2. 환경 | 3. 조건 | 4. 기준선 |
+|---|---|---|---|
+| ✅ | ✅ | ✅ | ✅ |
+
+**사이클 (반복)**
+
+| # | 기법 | 5. 설계 | 6. 스냅샷 | 7. 적용 | 8. 검증 |
+|---|---|---|---|---|---|
+| 1 | 불필요한 `Unit` 조인 제거 (`WHERE l.unitId = :unitId`) | ✅ | ✅ | ✅ | ✅ |
+
+## 대상
+
+- 엔드포인트: `GET /api/v1/wrong-answered-notes/{unitId}`
+- 실행 경로: `JwtAuthFilter` → `LastAccessInterceptor` → `WrongAnsweredNoteController` → `WrongAnsweredNoteFacade` → (`UnitQueryService`, `WrongAnsweredNoteService`, `ProblemFactory`) → 각 Repository
+- 트랜잭션 경계: `WrongAnsweredNoteFacade.getAllWrongAnsweredProblemInUnit`에 `@Transactional(readOnly = true)`. `LastAccessInterceptor` → `UserAccessService.updateLastAccessed`가 별도 `@Transactional`로 앞에 붙는다
+- 예상 쿼리 목록 (요청 1회 기준, 고정 6개)
+
+  Controller 앞단 (2개)
+  1. `UserRepository.findById` - `users` PK 단건 조회. 인증 필터(`AuthTokenProvider.parseUser:67-71`)에서 발생
+  2. `UserRepository.updateLastAccessedAt` - `users` UPDATE. `LastAccessInterceptor.preHandle` → `UserAccessService.updateLastAccessed`(`@Transactional`). `WebMvcConfig:34`에서 `/**`에 등록되어 이 경로에도 걸린다. 읽기 엔드포인트에 쓰기가 1회 섞인다
+
+  Controller 이후 (4개)
+  3. `UnitRepository.findUnitSummaryById` - `Unit` 단일 테이블 PK 조회, DTO 프로젝션
+  4. `WrongAnsweredNoteRepository.findWrongAnsweredProblemDetailByUnitIdAndUserId` - `WrongAnsweredNote ⋈ Problem ⋈ Lesson ⋈ Unit` 내부 조인 + `Bookmark` LEFT JOIN(`b.problemId = p.id AND b.userId = :userId`), `WHERE wan.userId = ? AND u.id = ? AND wan.resolvedAt IS NULL`. `ORDER BY` 없음
+  5. `AnswerRepository.findByProblemIdIn` - 결과에 SUBJECTIVE 문제가 있을 때만 1회 (`ProblemFactory:25` → `AnswerQueryService:30`)
+  6. `OptionRepository.findAllByProblemIdIn` - 결과에 OBJECTIVE 문제가 있을 때만 1회 (`ProblemFactory:26` → `OptionQueryService:29`)
+
+- 대상 유닛 900002는 OBJECTIVE 30 / SUBJECTIVE 30이라 5번과 6번이 모두 조건을 통과한다. 쿼리 수는 6개로 고정이다
+- 지연 로딩 추가 쿼리 후보: 없음. 3, 4, 6번은 `SELECT new ...Response(...)` DTO 프로젝션이고, 5번만 `List<Answer>` 엔티티를 반환하지만 `Answer`는 `id`/`content`/`explanation`/`problemId` 스칼라 4개뿐이라 연관관계가 없다
+- N+1 후보: 없음. `ProblemFactory.create`가 문제 타입별로 ID를 모아 `IN` 절 배치 조회 2회로 끝낸다. 오답 문제 개수가 늘어도 쿼리 수는 늘지 않는다
+- 사전 관찰(미검증): `wrong_answered_note`에는 `V34`의 `(user_id, problem_id)` UNIQUE 인덱스가 있다. 대상 쿼리의 선두 필터가 `wan.userId`이므로 이 인덱스를 탈 여지가 있다. `resolved_at`(`V30` 추가)에는 인덱스가 없다
+
+### 기준선의 전제 (이 대상 고유)
+
+이 대상의 `-0`은 **아무것도 적용하지 않은 원본이 아니다.** 같은 이슈의 앞 대상(`GET /api/v1/bookmarks/{unitId}`)에서 추가한
+`V38__add_bookmark_user_problem_unique_index.sql`의 `bookmark (user_id, problem_id)` UNIQUE 인덱스가 이미 적용된 상태다.
+
+대상 쿼리가 `LEFT JOIN Bookmark b ON b.problemId = p.id AND b.userId = :userId`를 포함하므로 그 인덱스를 이미 탄다.
+즉 이 대상의 기준선에는 앞 대상의 개선분이 섞여 있다. 사이클 판정에서 감안한다.
+
+## 측정 환경
+
+> 값이 바뀌면 그 사실을 사이클 기록에 남긴다.
+
+| 항목 | 값 |
+|---|---|
+| 프로파일 | perf (`application="gravit-perf"` 확인, `application-perf.yml:34`) |
+| 커넥션 풀 크기 | 60 (`application-perf.yml:17` `maximum-pool-size`) |
+| 데이터 규모 | `wrong_answered_note` 195,700 / `bookmark` 156,000 / `problem` 6,900 / `option` 13,800 / `answer` 3,450 / `lesson` 230 / `unit` 66 / `users` 1,002. 대상 유닛 900002는 문제 60건(OBJECTIVE 30, SUBJECTIVE 30) |
+| 카디널리티 | `wrong_answered_note.user_id` 1,000 (유저당 195.7행) / `wrong_answered_note.problem_id` 202 / `resolved_at` NULL 185,700 · NOT NULL 10,000. 요청당 결과 30건 (OBJECTIVE 15, SUBJECTIVE 15) |
+| 부하 조건 | VU 50, 유지 1m (ramp-up 30s + 유지 1m + ramp-down 30s = 총 2m). 앞 대상 `bookmarks` 및 #490과 동일 조건 |
+| Redis 캐시 상태 | cold (measure 직전 FLUSHDB). 단 이 API는 Redis를 쓰지 않는다 |
+| DB 캐시 상태 | 제어하지 않음. Redis FLUSHDB는 PostgreSQL의 `shared_buffers`와 OS page cache를 비우지 않는다 |
+| 캐시 제어 수단 | `redis-cli -h localhost -p 6379` (PONG 확인) |
+| 시드 SQL | `../seeds.sql` (이슈 공용) |
+| 시드 모듈과 변수 | `review.sql`. `user_start` 1001, `user_count` 1000, `target_unit_id` 900002, `bookmarks_per_user` 156, `target_unit_bookmarks_per_user` 30, `options_per_problem` 4, **`target_unit_wrong_notes_per_user` 40, `target_unit_resolved_per_user` 10** (이번 대상에서 추가). `answer`/`option`/`bookmark` 블록은 가드에 걸려 `INSERT 0 0`, `wrong_answered_note`만 40,000행 적재 |
+| 시드 이력 | 진입 시 `wrong_answered_note` 155,700행이 **전부 유닛 910001**에 있었고 대상 유닛 900002에는 0행이었다. 그대로 재면 API가 빈 리스트를 반환해 `ProblemFactory`가 두 조회를 건너뛰어 6쿼리가 아니라 4쿼리가 된다. 그래서 `review.sql`에 `wrong_answered_note` 블록을 추가해 900002를 채웠다. 기존 155,700행은 지우지 않고 `user_id` 필터가 걸러낼 잡음으로 남겼다 |
+| DB 접속 | `PGPASSWORD=postgres psql -h localhost -p 5433 -U postgres -d mydb` (5433은 컨테이너 5432 매핑) |
+| 관측 도구 | `pg_stat_statements` 유효 (48행), 히스토그램 버킷 146개 노출 |
+| 앱 기동 이력 | V38 적용을 위해 앞 대상 종료 후 재기동했다. 그래서 Phase 2를 건너뛰지 않고 다시 검증했다 |
+
+## 기준선 (Baseline)
+
+| 지표 | 값 |
+|---|---|
+| p95 | 192.63904999999988ms |
+| p99 | 253.12869999999998ms |
+| RPS | 382.23845109833474 |
+| 에러율 | 0 |
+| check 통과율 | 1 (45872/45872, 3개 항목 전부. `problems` 30건 검증 포함) |
+| 요청당 쿼리 수 | 6 (트랜잭션 제어문 제외). 트랜잭션은 요청당 3개 (`BEGIN READ ONLY` 2 + `BEGIN` 1.0001) |
+
+- med 97.561ms / max 496.084ms / 요청 45,872건 / 수신 667,078,851바이트 (요청당 14,542)
+- 요청당 DB 시간 합 13.2309ms (트랜잭션 제어 포함 13.2920ms)
+
+### 쿼리 통계 (total_exec_time 상위)
+
+> 전체: `query-stats-summary-0.md` / k6 요약: `k6-test-summary-0.json`
+> 여기에는 진단 근거로 쓴 행만 옮긴다. 전체를 복사하지 않는다.
+
+| 요청당 | mean_ms | total_ms | 비중 | 출처 |
+|---|---|---|---|---|
+| 1.00 | 7.283352535708062 | 334101.947518001 | 54.79509378993013% | `OptionRepository.findAllByProblemIdIn` |
+| 1.00 | 4.0971767350671575 | 187945.69119100034 | 30.82442904846952% | `WrongAnsweredNoteRepository.findWrongAnsweredProblemDetailByUnitIdAndUserId` |
+| 1.00 | 1.6740161849494228 | 76790.47043599872 | 12.594182886308074% | `AnswerRepository.findByProblemIdIn` |
+
+**행당 비용** (mean_ms ÷ 행/호출)
+
+| 쿼리 | mean_ms | 행/호출 | ms/행 |
+|---|---|---|---|
+| `option` | 7.2834 | 60 | 0.12139 |
+| 대상 쿼리 | 4.0972 | 30 | 0.13657 |
+| `answer` | 1.6740 | 15 | 0.11160 |
+
+### 진단
+
+- 병목 성격: 대상 쿼리(`findWrongAnsweredProblemDetailByUnitIdAndUserId`)의 쿼리 자체 비효율. 호출 횟수가 아니라 단일 쿼리 1건의 실행 비용이 문제다
+- 근거:
+  - 대상 쿼리의 요청당 호출 수가 1.00이다. N+1이 아니다
+  - 행/호출 30으로 시드한 결과 크기와 정확히 일치한다. 반환 행 수 자체는 예상대로다
+  - 행당 비용 0.13657ms로 상위 3개 쿼리 중 1위다. 총 시간 비중은 30.82%로 2위지만, 1위 `option`(54.80%)은 단위 비용이 나빠서가 아니라 반환 행 수가 가장 많아서(60행) 총합이 큰 것으로 설명된다. 세 쿼리의 행 수 비 60 : 30 : 15 = 4 : 2 : 1이 비중 비 4.35 : 2.45 : 1과 거의 일치한다
+  - 대상 쿼리만 5테이블 조인이고 나머지 둘은 단일 테이블 `IN` 조회다
+  - `option.problem_id`(`ix_option_problem`, `V3:26`)와 `answer.problem_id`(`ix_answer_problem`, `V3:23`)에는 이미 인덱스가 있고 테이블도 13,800행 / 3,450행으로 작다
+  - 비중 30.82%는 위험 신호 기준(30%)을 넘는다
+- 미해결 질문: 대상 쿼리가 느린 원인이 조인인지, 조인이라면 어느 조인인지. 조인 4개 중 `Unit` 조인은 얻는 컬럼이 `u.id` 하나뿐이고 그 값이 이미 `l.unitId`에 있어 `WHERE l.unitId = :unitId`로 대체 가능하다(반정규화 없이 제거 가능). 나머지 3개(`problem` 응답 컬럼, `lesson` 경유 경로, `bookmark` LEFT JOIN의 `isBookmarked`)는 대체 경로가 없다. 실행계획으로 갈린다
+- 예상 쿼리 목록과 어긋난 지점: 없음. Phase 1에서 확정한 6개(앞단 2 + Controller 이후 4)가 개수와 출처 모두 일치한다. `BEGIN READ ONLY` 2.00회도 트랜잭션 경계 2개(`LastAccessInterceptor`는 `BEGIN`)와 맞는다
+  - 목록 밖 관측: `season ... FOR NO KEY UPDATE` 4건(2분간 총 4회, 요청당 0.000087, 비중 1.09e-05%). 요청 경로가 아닌 스케줄러로 보이나 출처를 특정하지 못했다
+
+---
+
+## 사이클 1: 불필요한 `Unit` 조인 제거
+
+### 설계 결정
+
+| 결정 항목 | 정한 값 | 근거 |
+|---|---|---|
+| 대체 조건절 | `JOIN Unit u ON u.id = l.unitId ... WHERE u.id = :unitId` → `WHERE l.unitId = :unitId` | `Unit`에서 얻는 값이 `u.id` 하나뿐이고, 조인 조건 `u.id = l.unitId`에 의해 그 값은 항상 `l.unitId`와 같다. FK 값을 이미 들고 있는데 부모 테이블을 다시 찾아가는 형태다 |
+| 적용 범위 | 불필요한 4곳 전부 (`WrongAnsweredNoteRepository` 2, `BookmarkRepository` 2) | 같은 결함을 한쪽만 고치면 왜 한쪽만 그런지 알 수 없다. `Unit` 조인 8곳 중 나머지 4곳은 `u.title` 프로젝션이나 `u.chapterId` 경유 Chapter 조인에 쓰여 제거 대상이 아니다 |
+| 마이그레이션 | 없음 | 스키마 변경이 아니라 JPQL 수정이다 |
+| 메서드 시그니처 | 유지 | 파라미터도 반환 타입도 그대로다. 호출부 변경 없음 |
+| 감수할 것 | 4곳 중 3곳은 측정되지 않은 변경 | Phase 8이 재측정하는 것은 대상 쿼리 1곳뿐이다. 나머지 3곳은 같은 형태의 변경이라 안전하다고 판단했을 뿐 효과를 잰 것이 아니다 |
+
+**등가성 검증**
+
+`lesson.unit_id`에는 FK 제약이 없다(`V1__init_tables.sql:106-112`, `V14`에도 없음). 따라서 이론적으로는 존재하지 않는 유닛을 가리키는 레슨이 있을 수 있고,
+그 경우 `JOIN Unit`(inner)은 행을 버리지만 `WHERE l.unitId`는 행을 남겨 결과가 갈린다.
+
+그러나 4개 쿼리의 호출 경로가 전부 `UnitQueryService.getUnitSummaryByUnitId`를 먼저 호출해 유닛이 없으면 `UNIT_NOT_FOUND`를 던진다.
+
+- `WrongAnsweredNoteFacade:30` → `:32`
+- `BookmarkFacade:30` → `:32`
+- `LessonFacade:60` → `:66`, `:67`
+
+유닛이 존재하지 않으면 쿼리에 도달하지 못하므로, 이 변경으로 동작이 달라지는 경로는 현재 코드에 없다.
+
+- 검토했지만 택하지 않은 안:
+  - `wrong_answered_note`에 `unit_id` 반정규화 + `(user_id, unit_id)` 인덱스 - 비싼 노드(`problem` Seq Scan + Hash Join, 74.3%)를 없앨 수 있으나, 그 노드는 **콘텐츠 양에만 비례하고 유저 수로는 커지지 않는다**. `wrong_answered_note`(195,700행)와 `bookmark`(156,000행)는 점 조회라 O(log n)이다. 영구적인 정합성 책임(문제의 레슨 이동 시 동기화)과 195,700행 백필을 지불하고 얻는 것이 응답시간 2.7%(2.686ms / med 97.561ms)라 근거가 부족하다
+  - 유닛→문제 목록 캐싱 - 같은 74.3%를 노리므로 상한이 같은데 무효화 경로 설계 비용이 추가된다
+  - `problem` 조회를 인덱스 경로로 유도 - `ix_problem_lesson`(`V3:4`)이 있으나 `problem.lesson_id` correlation -0.193으로 군집도가 낮아 플래너가 Seq Scan(cost 161)을 고른다. 뒤집으려면 `content`(TEXT)까지 커버링에 넣어야 해 설계가 성립하지 않는다
+- 대상 API 밖의 부수 효과: `BookmarkRepository.findBookmarkedProblemDetailByUnitIdAndUserId`(앞 대상이 측정한 쿼리), `BookmarkRepository.countByUnitIdAndUserId`, `WrongAnsweredNoteRepository.countByUnitIdAndUserId`에서도 `unit` 스캔 노드가 사라진다. 앞 대상 `bookmarks/record.md`에 적힌 쿼리 원문과 실행계획은 측정 당시 기록으로는 유효하나 현재 코드와는 어긋나게 된다
+- 호출자가 예상한 효과: `Seq Scan on unit` 노드와 Nested Loop 1개가 사라진다. Execution Time -1.0%(0.036ms), 버퍼 -2
+
+### 측정 조건의 한계
+
+이 대상의 기준선(`-0`)은 아무것도 적용하지 않은 원본이 아니다. 앞 대상에서 추가한 `V38`의 `bookmark (user_id, problem_id)` UNIQUE 인덱스가 이미 적용된 상태이고,
+대상 쿼리의 `LEFT JOIN Bookmark ... AND b.userId = :userId`가 실제로 그 인덱스를 탄다(`query-plan-0.txt`의 `Index Scan using ix_bookmark_user_problem`, loops 30, 120버퍼).
+그 인덱스가 없었다면 이 대상의 기준선은 더 나빴을 것이다.
+
+### 개선 전 지표
+
+| 지표 | 값 |
+|---|---|
+| p95 / p99 | 192.63904999999988ms / 253.12869999999998ms |
+| med / max | 97.561ms / 496.084ms |
+| RPS | 382.23845109833474 |
+| 요청당 쿼리 수 | 6 (트랜잭션 제어문 제외) |
+| 요청당 DB 시간 합 | 13.2309ms |
+| 대상 쿼리 calls / mean_ms / total_ms | 45872 / 4.0971767350671575 / 187945.69119100034 (30.82442904846952%) |
+
+**실행계획**
+
+> 원본: `query-plan-0.txt` (개선 후는 `query-plan-1.txt`)
+
+- EXPLAIN 파라미터: 유저 1500 (1001~2000의 중앙값), 유닛 900002. 이후 모든 사이클에서 동일하게 사용
+- 스캔 방식: `problem` Seq Scan(`ix_problem_lesson` 미사용), `lesson` Seq Scan, `unit` Seq Scan, `wrong_answered_note` Index Scan(`ix_wrong_answered_note_user_problem`), `bookmark` Index Scan(`ix_bookmark_user_problem`)
+- 실행 구조: `problem` 6,900행 전부 스캔 → 유닛의 `lesson` 2건과 Hash Join → 60행 → 그 60건마다 `wrong_answered_note` 인덱스 탐색(loops 60, 30건 통과) → 그 30건마다 `bookmark` 인덱스 탐색(loops 30)
+- actual rows 대 반환 행 수: `problem` 노드가 6,900행을 내보내고 쿼리는 30행을 반환한다
+- Rows Removed by Filter: `lesson` 228(230 중 99.1%), `unit` 65(66 중 98.5%), `wrong_answered_note` 총 10(`resolved_at IS NULL`이 극복분을 걸러낸 수, loops 60의 per-loop 표시는 반올림되어 0)
+- shared hit / read: 최상단 누적 440 / 0 (3.44MB). 노드별로는 `wrong_answered_note` 223(50.7%), `bookmark` 120(27.3%), `problem` 92(20.9%). read가 전부 0이라 디스크 접근이 없었다
+- 플래너 추정 대 실측: 최상단 `rows=2` 대 실측 30(15배 괴리). 유저 필터와 유닛 필터의 상관관계를 플래너가 독립으로 가정한 결과다. `Hash Join`은 `rows=60` 대 실측 60으로 정확하다
+- Planning Time 6.753ms / Execution Time 3.617ms. 부하 중 mean 4.097ms가 Execution Time에 가까우므로 요청마다 계획을 다시 세우지는 않는 것으로 보인다
+
+**노드별 자기 몫** (누적 actual time에서 자식 몫을 뺀 값, loops 반영. Execution Time 3.617ms 대비)
+
+| 노드 | 자기 몫 (ms) | 비중 |
+|---|---|---|
+| Hash Join (`problem` ⋈ `lesson`) | 1.869 | 51.7% |
+| Seq Scan `problem` (6,900행) | 0.817 | 22.6% |
+| Index Scan `wrong_answered_note` (loops 60) | 0.300 | 8.3% |
+| Index Scan `bookmark` (loops 30) | 0.210 | 5.8% |
+| Seq Scan `unit` (66행) | 0.036 | 1.0% |
+| Seq Scan `lesson` (230행) | 0.033 | 0.9% |
+| Hash build | 0.015 | 0.4% |
+| 나머지 (조인 노드 자기 몫) | 0.337 | 9.3% |
+
+**위험 신호 판정**
+
+| 지표 | 값 | 기준 | 판정 |
+|---|---|---|---|
+| 검사 행 / 반환 행 | 6,900 / 30 = 230:1 | 100:1 초과 | 초과 |
+| 플래너 추정 대 실측 | 최상단 2 대 30 = 15배 | 10배 이상 | 초과 |
+| 단일 쿼리 total_exec_time 점유율 | 30.82% | 30% 이상 | 초과 |
+| 1만 행 이상 테이블의 Seq Scan | `problem` 6,900행이 최대 | 1만 행 | 해당 없음 |
+| 동일 쿼리의 요청당 호출 횟수 | 1.00 | 1회 초과면 N+1 | 해당 없음 |
+
+- 확정 해석: 비용을 먹는 노드는 `problem` Seq Scan과 그 위의 Hash Join이다. 두 노드 자기 몫의 합이 2.686ms로 Execution Time의 74.3%다. 유닛의 문제 60건을 찾기 위해 6,900행 전부를 훑는다
+- **이번 사이클의 기법은 위 위험 신호를 하나도 해소하지 못한다.** `unit` 조인 제거가 없애는 것은 Seq Scan `unit` 노드(자기 몫 0.036ms = 1.0%, 2버퍼)와 Nested Loop 1개다. 74.3%를 만드는 노드는 그대로 남는다. 이 사실을 알고 선택한 기법이다 (근거는 위 설계 결정의 "검토했지만 택하지 않은 안" 참조)
+
+### 적용 내용
+
+JPQL 4곳에서 `JOIN Unit u ON u.id = l.unitId` + `WHERE u.id = :unitId`를 `WHERE l.unitId = :unitId`로 바꿨다. 총 4줄 추가 / 8줄 삭제.
+
+| 파일 | 메서드 | 이 대상의 실행 경로 |
+|---|---|---|
+| `src/main/java/gravit/code/wrongAnsweredNote/repository/WrongAnsweredNoteRepository.java:48` | `findWrongAnsweredProblemDetailByUnitIdAndUserId` | **포함** (측정 대상 쿼리) |
+| `src/main/java/gravit/code/wrongAnsweredNote/repository/WrongAnsweredNoteRepository.java:61` | `countByUnitIdAndUserId` | 미포함 (`LessonFacade`가 호출) |
+| `src/main/java/gravit/code/bookmark/repository/BookmarkRepository.java:38` | `findBookmarkedProblemDetailByUnitIdAndUserId` | 미포함 (앞 대상이 측정한 쿼리) |
+| `src/main/java/gravit/code/bookmark/repository/BookmarkRepository.java:51` | `countByUnitIdAndUserId` | 미포함 (`LessonFacade`가 호출) |
+
+- 마이그레이션 없음. 스키마 변경이 아니다
+- 메서드 시그니처, 반환 타입, 호출부 모두 그대로다
+- 남겨둔 `Unit` 조인 4곳(`ProblemSubmissionRepository:38`, `LessonRepository:25`, `LessonSubmissionRepository:27`, `:93`)은 `u.title` 프로젝션이나 `u.chapterId` 경유 Chapter 조인에 쓰여 제거 대상이 아니다
+- 테스트: `./gradlew test` 통과
+- Phase 8 재측정 전 애플리케이션 재기동 완료 (JPQL 변경이라 기동 시점에 쿼리가 다시 생성된다)
+
+### 개선 후 지표
+
+| 구분 | 지표 | 개선 전 | 개선 후 | 변화 |
+|---|---|---|---|---|
+| 하드웨어 의존 | p95 | 192.63904999999988ms | 204.7070999999999ms | +6.3% |
+| | p99 | 253.12869999999998ms | 372.14019999999977ms | +47.0% |
+| | med | 97.561ms | 90.641ms | -7.1% |
+| | max | 496.084ms | 1048.058ms | +111.3% |
+| | RPS | 382.23845109833474 | 377.23077533234846 | -1.3% |
+| 하드웨어 독립 | 요청당 쿼리 수 | 6 | 6 | 변화 없음 |
+| | 대상 쿼리 mean_ms | 4.0971767350671575 | 4.2596087043843 | +4.0% |
+| | 대상 쿼리 total 비중 | 30.82442904846952% (2위) | 30.991447705657233% (2위) | 순위 동일 |
+| | 요청당 DB 시간 합 | 13.2309ms | 13.6583ms | +3.2% |
+| | 쿼리 전체 shared hit | 440 (3.44MB) | **438 (3.42MB)** | **-2** |
+| | 검사 행 / 반환 행 | 6,900 / 30 = 230:1 | 6,900 / 30 = 230:1 | 변화 없음 |
+| | 스캔 방식 | `problem`/`lesson`/`unit` Seq Scan + Index Scan 2 | `problem`/`lesson` Seq Scan + Index Scan 2 | `unit` 노드 소멸 |
+| | 계획 노드 수 | Nested Loop 3 + Seq Scan 3 + Index Scan 2 | Nested Loop 2 + Seq Scan 2 + Index Scan 2 | -2 |
+| | 단건 Execution Time | 3.617ms | 1.742ms | -51.8% |
+| | 캐시 hit / miss, 적중률 | - | - | 캐싱 사이클 아님 |
+
+- 에러율 0, check 통과율 1로 전후 동일하다. 응답 내용은 달라지지 않았다
+- 계획 변화: `Seq Scan on unit`(자기 몫 0.036ms, 2버퍼)과 그 위의 Nested Loop 1개가 사라졌다. 나머지 구조는 동일하다 — `problem` 6,900행 Seq Scan → `lesson` 2건과 Hash Join → 60행 → `wrong_answered_note` 인덱스 탐색(loops 60) → `bookmark` 인덱스 탐색(loops 30)
+- 개선 후에도 비용이 가장 큰 노드는 Hash Join 0.824ms(47.3%)와 Seq Scan `problem` 0.578ms(33.2%)로 둘이 합쳐 80.5%다. 개선 전(74.3%)과 같은 노드다
+
+### 측정 편차 조사 (`k6-test-summary-1-rerun.json`)
+
+부하 지표가 전반적으로 악화해 보여, **코드를 그대로 둔 채 측정만 한 번 더 돌렸다.**
+
+| 측정 | 코드 | 요청 | RPS | med | p95 | p99 | max | 요청당 DB |
+|---|---|---|---|---|---|---|---|---|
+| `-0` | 변경 전 | 45,872 | 382.23845109833474 | 97.561 | 192.639 | 253.129 | 496.084 | 13.2309ms |
+| `-1` | 변경 후 | 45,275 | 377.23077533234846 | 90.641 | 204.707 | 372.140 | 1048.058 | 13.6583ms |
+| `-1` 재실행 | 변경 후 (동일) | 38,750 | 322.9095518928733 | 104.626 | 253.289 | 480.510 | 1971.246 | 14.0404ms |
+
+| 구간 | 코드 변경 | RPS 변화 | 요청당 DB 변화 | p99 변화 |
+|---|---|---|---|---|
+| `-0` → `-1` | 있음 | -1.3% | +3.2% | +47.0% |
+| `-1` → 재실행 | **없음** | **-14.4%** | +2.8% | +29.1% |
+
+**코드 변경이 없는 구간의 낙폭이 있는 구간의 11배다.** 세 측정이 단조 악화(RPS 382 → 377 → 323, max 496 → 1048 → 1971ms)이므로,
+같은 머신에서 2분짜리 380 RPS 부하를 연달아 돌린 데 따른 환경 드리프트(발열 스로틀링, 누적 배경 부하)로 본다.
+
+검토했다가 기각한 가설:
+
+- **JVM 워밍업 차이** - `-0`은 앞 대상의 측정 부하까지 처리한 JVM에서, `-1`은 재기동 직후 JVM에서 쟀다. 그러나 이미 45,275건을 처리해 데워진 상태의 재실행이 더 나빠졌으므로 기각한다
+- **dead tuple 누적** - 전 테이블 `n_dead_tup` 0이다. `update users`가 `last_accessed_at < startOfToday` 가드 때문에 하루 첫 요청 이후로는 0행을 갱신한다(세 측정 모두 `rows_per_call` 0)
+
+**결론: 이 환경의 부하 지표는 1% 수준의 변화를 판정할 해상도가 없다.** 측정 간 편차(-14.4%)가 이 기법의 예상 효과(-1.0%)보다 훨씬 크다.
+따라서 `-0` → `-1`의 부하 지표 악화는 기법에 귀속되지 않으며, 개선 여부는 하드웨어 독립 증거로만 판정한다.
+
+### 판정
+
+- **개선 여부 (하드웨어 독립 증거 기준): 사실상 없음.** 확정된 변화는 `unit` Seq Scan 노드 소멸, 버퍼 440 → 438(-2), 계획 노드 -2뿐이다.
+  요청당 쿼리 수, 검사 행/반환 행 비, 스캔 방식은 그대로다
+- 예상 효과 대조: Phase 5에서 예상한 "Seq Scan `unit` 노드와 Nested Loop 1개 소멸, 버퍼 -2"는 정확히 그대로 나왔다.
+  함께 예상한 "Execution Time -1.0%"는 측정 해상도 밖이라 확인도 반증도 되지 않았다
+- 남은 위험 신호: 5개 중 3개가 그대로다 — 검사 행/반환 행 230:1, 플래너 추정 대 실측 15배 괴리, 단일 쿼리 점유율 30.99%.
+  이번 기법이 겨냥한 항목이 아니므로 예상된 결과다. 이 셋을 해소하려면 `problem` 6,900행 스캔 경로를 없애야 하고, 그 수단은 Phase 5에서 배제한 반정규화나 캐싱이다
+- 되짚어보면 **이 대상은 개선 여지가 약했다.** 기준선 자체가 p95 192.6ms / 에러 0이었고, 요청당 DB 시간 13.2309ms가 med 응답 97.561ms의 13.6%,
+  대상 쿼리는 4.2%에 불과했다. 남은 74.3% 노드를 통째로 없애도 응답시간 상한이 2.7%다. 병목은 DB가 아니라 DB 밖 86%에 있다
+- 다음 사이클 진행 여부: 진행하지 않는다 (호출자가 종료를 선택). 종료 조건표의 "하드웨어 독립 증거에 변화가 없음"에도 해당한다
+
+---
+
+## 최종 요약
+
+> 하드웨어 의존 증거와 독립 증거를 모두 남긴다.
+
+| 구분 | 지표 | 최초 | 최종 | 변화 |
+|---|---|---|---|---|
+| 하드웨어 의존 | p95 | 192.63904999999988ms | 204.7070999999999ms | +6.3% (환경 드리프트, 기법에 귀속 불가) |
+| | p99 | 253.12869999999998ms | 372.14019999999977ms | +47.0% (동일) |
+| | RPS | 382.23845109833474 | 377.23077533234846 | -1.3% (동일) |
+| 하드웨어 독립 | 요청당 쿼리 수 | 6 | 6 | 변화 없음 |
+| | 요청당 DB 시간 합 | 13.2309ms | 13.6583ms | +3.2% (환경 드리프트) |
+| | 검사 행 / 반환 행 | 6,900 / 30 = 230:1 | 6,900 / 30 = 230:1 | 변화 없음 |
+| | 스캔 방식 | `problem`/`lesson`/`unit` Seq Scan + Index Scan 2 | `problem`/`lesson` Seq Scan + Index Scan 2 | `unit` 노드 소멸 |
+| | 쿼리 전체 shared hit | 440 (3.44MB) | 438 (3.42MB) | -2 |
+| | 계획 노드 수 | 8 | 6 | -2 |
+| | 캐시 hit / miss, 적중률 | - | - | 캐싱 기법을 쓰지 않았다 |
+
+적용한 기법: 사이클 1 - 불필요한 `Unit` 조인 제거 (`WHERE l.unitId = :unitId`, JPQL 4곳)
+
+**총평.** 이 대상은 개선 여지가 약했다. 기준선이 이미 p95 192.6ms / 에러 0이었고, DB가 응답시간의 13.6%뿐이라 쿼리 튜닝의 상한 자체가 낮았다.
+비용의 74.3%를 차지하는 `problem` 6,900행 스캔은 유저 수가 아니라 콘텐츠 양에만 비례해 커지므로, 반정규화나 캐싱으로 걷어낼 근거도 부족했다.
+그래서 마이그레이션도 정합성 책임도 없는 조인 제거만 적용하고 닫는다. 성능 수치보다는 쿼리가 정직해진 것이 이 사이클의 결과다.
+
+남겨두는 후보 (근거가 생기면 다시 꺼낸다):
+
+- `problem` 6,900행 Seq Scan + Hash Join 경로 제거 - 반정규화(`wrong_answered_note.unit_id`) 또는 유닛→문제 목록 캐싱. `problem`이 수만 행대로 커지면 근거가 생긴다
+- DB 밖 86% - 요청당 14.5KB 응답의 직렬화 비용. 이 이슈의 범위(쿼리 성능) 밖이다
+- `LastAccessInterceptor`의 `UPDATE users` - 읽기 엔드포인트에 섞인 쓰기. 비중 0.38%로 이번 병목과 무관하고 별도 이슈 사안이다
+- 측정 환경 - 같은 머신에서 부하를 연달아 돌리면 RPS가 단조 하락한다. 1% 수준의 변화를 재려면 DB를 별도 머신에 두거나 측정 간 냉각 시간을 둬야 한다

--- a/.claude/resources/perf/492/wrong-answered-notes/test-script.js
+++ b/.claude/resources/perf/492/wrong-answered-notes/test-script.js
@@ -1,0 +1,156 @@
+// PERF-492 / GET /api/v1/wrong-answered-notes/{unitId}
+//
+// 실행: 토큰 발급, warmup, measure를 각각 따로 돌린다. 통계 리셋은 토큰 발급이 끝난 뒤에 한다.
+//
+//   (토큰 발급 - Phase 4, 8의 명령 블록 참조. $PERF_DIR/tokens.json 생성)
+//   k6 run -e PHASE=warmup -e USER_ID_START=1001 -e USER_COUNT=1000 $TARGET_DIR/test-script.js
+//   psql ... -c "SELECT pg_stat_statements_reset();"
+//   k6 run -e PHASE=measure -e USER_ID_START=1001 -e USER_COUNT=1000 \
+//     -e SUMMARY_OUT=$TARGET_DIR/k6-test-summary-0.json $TARGET_DIR/test-script.js
+
+import http from 'k6/http';
+import exec from 'k6/execution';
+import { check } from 'k6';
+
+const BASE_URL = __ENV.BASE_URL || 'http://localhost:8080';
+const USER_ID_START = Number(__ENV.USER_ID_START || 1001);
+const USER_COUNT = Number(__ENV.USER_COUNT || 1000);
+const PHASE = __ENV.PHASE || 'measure';
+
+// unitId는 고정이다. seeds.sql이 이 유닛에 유저당 40건을 넣고 그중 10건을 극복 처리해,
+// resolvedAt IS NULL을 통과하는 30건(OBJECTIVE 15 / SUBJECTIVE 15)만 반환된다.
+// 앞 대상(bookmarks)과 같은 유닛, 같은 결과 크기라 두 대상을 나란히 비교할 수 있다.
+// 변동은 토큰(유저 1000명)이 만든다.
+const TARGET_UNIT_ID = 900002;
+
+// 이 측정이 무엇이었는지 요약 파일만 보고 알 수 있게 한다.
+const TARGET = 'wrong-answered-notes';
+const ENDPOINT = 'GET /api/v1/wrong-answered-notes/{unitId}';
+const CONDITION = {
+    vus: 50,
+    steady_state_duration: '1m',
+    ramp_up: '30s',
+    ramp_down: '30s',
+    total_duration: '2m',
+    redis_cache: 'cold (measure 직전 FLUSHDB)',
+    db_cache: '제어하지 않음. FLUSHDB는 PostgreSQL shared_buffers와 OS page cache를 비우지 않는다',
+    target_unit_id: TARGET_UNIT_ID,
+    expected_problems_per_request: 30,
+    user_id_start: USER_ID_START,
+    user_count: USER_COUNT,
+    baseline_precondition: 'V38 bookmark (user_id, problem_id) UNIQUE 인덱스가 이미 적용된 상태다. 이 쿼리의 LEFT JOIN Bookmark가 그 인덱스를 탄다',
+};
+
+// tokens.json은 이슈 디렉토리에 있다(대상 간 공유).
+const tokens = JSON.parse(open('../tokens.json'));
+
+if (tokens.length !== USER_COUNT) {
+    throw new Error(
+        `토큰 ${tokens.length}건 / 필요 ${USER_COUNT}건. 로그인에 실패한 userId가 있다. ` +
+        'tokens.json을 다시 만들고 userId 범위와 perf 프로파일 기동 상태를 확인하라.'
+    );
+}
+
+const scenarios = {
+    warmup: {
+        executor: 'constant-vus',
+        vus: 5,
+        duration: '30s',
+    },
+    measure: {
+        executor: 'ramping-vus',
+        startVUs: 0,
+        stages: [
+            { duration: '30s', target: 50 },
+            { duration: '1m', target: 50 },
+            { duration: '30s', target: 0 },
+        ],
+    },
+};
+
+export const options = {
+    scenarios: { [PHASE]: scenarios[PHASE] },
+    summaryTrendStats: ['avg', 'min', 'med', 'p(90)', 'p(95)', 'p(99)', 'max'],
+    thresholds: {
+        http_req_failed: ['rate<0.01'],
+        checks: ['rate>0.99'],
+    },
+};
+
+// 비JSON 응답에서 예외를 던지지 않는다. 파싱 실패는 null로 떨어뜨려 check 실패로 드러낸다.
+function parseBody(res) {
+    if (res.status !== 200 || res.body === null || res.body.length <= 2) {
+        return null;
+    }
+    try {
+        return res.json();
+    } catch (e) {
+        return null;
+    }
+}
+
+export default function () {
+    // 시나리오 전체의 반복 번호로 고른다. VU 수와 무관하게 토큰 USER_COUNT개를 균등하게 돈다.
+    const token = tokens[exec.scenario.iterationInTest % tokens.length];
+    const params = { headers: { Authorization: `Bearer ${token}` } };
+
+    const res = http.get(`${BASE_URL}/api/v1/wrong-answered-notes/${TARGET_UNIT_ID}`, params);
+
+    check(res, {
+        'status is 200': (r) => r.status === 200,
+        'body is not empty': (r) => r.body !== null && r.body.length > 2,
+        'problems 30건이 실려 있다': (r) => {
+            const body = parseBody(r);
+            return body !== null && body.problems !== undefined && body.problems.length === 30;
+        },
+    });
+}
+
+export function handleSummary(data) {
+    const m = data.metrics || {};
+    const val = (name, key) => (m[name] && m[name].values[key] !== undefined ? m[name].values[key] : null);
+    const trend = (name) => ({
+        med: val(name, 'med'),
+        p95: val(name, 'p(95)'),
+        p99: val(name, 'p(99)'),
+        max: val(name, 'max'),
+    });
+
+    const summary = {
+        phase: PHASE,
+        target: TARGET,
+        endpoint: ENDPOINT,
+        condition: CONDITION,
+        requests: val('http_reqs', 'count'),
+        rps: val('http_reqs', 'rate'),
+        failed_rate: val('http_req_failed', 'rate'),
+        checks_rate: val('checks', 'rate'),
+        checks: ((data.root_group || {}).checks || []).map((c) => ({
+            name: c.name,
+            passes: c.passes,
+            fails: c.fails,
+        })),
+        duration_ms: trend('http_req_duration'),
+        waiting_ms: trend('http_req_waiting'),
+        bytes_received: val('data_received', 'count'),
+    };
+
+    // 아래 반올림은 터미널 한 줄 출력에만 쓴다. summary 객체의 값은 손대지 않는다.
+    const num = (x, d) => (typeof x === 'number' ? x.toFixed(d) : '-');
+    const line = [
+        `[${PHASE}] ${TARGET}`,
+        `요청 ${summary.requests}건`,
+        `p95 ${num(summary.duration_ms.p95, 1)}ms`,
+        `p99 ${num(summary.duration_ms.p99, 1)}ms`,
+        `실패율 ${num(summary.failed_rate * 100, 2)}%`,
+        `check ${num(summary.checks_rate * 100, 2)}%`,
+    ].join(' / ');
+
+    const out = { stdout: `\n${line}\n\n` };
+
+    if (__ENV.SUMMARY_OUT) {
+        out[__ENV.SUMMARY_OUT] = JSON.stringify(summary, null, 2);
+    }
+
+    return out;
+}

--- a/.claude/skills/optimize-performance/template/seeds/README.md
+++ b/.claude/skills/optimize-performance/template/seeds/README.md
@@ -52,7 +52,7 @@ psql -h localhost -p 5433 -U postgres -d mydb -f $PERF_DIR/seeds.sql
 | `user.sql` | `users` | 없음 |
 | `learning.sql` | `lesson_submission`, `problem_submission`, `daily_learning_record` | `content`, `user` |
 | `league.sql` | `league`, `season`, `user_league`, `user_league_history` | `user` |
-| `review.sql` | `answer`, `option`, `bookmark` | `content`, `user` |
+| `review.sql` | `answer`, `option`, `bookmark`, `wrong_answered_note` | `content`, `user` |
 
 `\i` 순서가 곧 FK 의존 순서다. 표의 위에서 아래로 부른다.
 
@@ -85,6 +85,8 @@ psql -h localhost -p 5433 -U postgres -d mydb -f $PERF_DIR/seeds.sql
 | `bookmarks_per_user` | review | 유저당 총 북마크 수 |
 | `target_unit_bookmarks_per_user` | review | 그중 `target_unit_id`에 몰아넣을 수 (= 요청당 결과 크기). 타입 균형을 위해 짝수를 쓴다 |
 | `options_per_problem` | review | OBJECTIVE 문제당 선택지 수 |
+| `target_unit_wrong_notes_per_user` | review | 유저당 `target_unit_id`에 넣을 오답노트 수. 타입 균형을 위해 짝수를 쓴다 |
+| `target_unit_resolved_per_user` | review | 그중 극복 처리할 수. **요청당 결과 크기 = `target_unit_wrong_notes_per_user` - 이 값.** 짝수를 쓴다 |
 
 ## 모듈을 고칠 때
 

--- a/.claude/skills/optimize-performance/template/seeds/README.md
+++ b/.claude/skills/optimize-performance/template/seeds/README.md
@@ -52,6 +52,7 @@ psql -h localhost -p 5433 -U postgres -d mydb -f $PERF_DIR/seeds.sql
 | `user.sql` | `users` | 없음 |
 | `learning.sql` | `lesson_submission`, `problem_submission`, `daily_learning_record` | `content`, `user` |
 | `league.sql` | `league`, `season`, `user_league`, `user_league_history` | `user` |
+| `review.sql` | `answer`, `option`, `bookmark` | `content`, `user` |
 
 `\i` 순서가 곧 FK 의존 순서다. 표의 위에서 아래로 부른다.
 
@@ -80,6 +81,10 @@ psql -h localhost -p 5433 -U postgres -d mydb -f $PERF_DIR/seeds.sql
 | `daily_record_days` | learning | 유저당 일별 학습 기록 일수 |
 | `league_tier_count` | league | 리그 티어 수 |
 | `past_season_count` | league | 종료된 과거 시즌 수 |
+| `target_unit_id` | review | 북마크를 몰아줄 유닛 id. k6가 때리는 `unitId`와 일치시킨다 |
+| `bookmarks_per_user` | review | 유저당 총 북마크 수 |
+| `target_unit_bookmarks_per_user` | review | 그중 `target_unit_id`에 몰아넣을 수 (= 요청당 결과 크기). 타입 균형을 위해 짝수를 쓴다 |
+| `options_per_problem` | review | OBJECTIVE 문제당 선택지 수 |
 
 ## 모듈을 고칠 때
 

--- a/.claude/skills/optimize-performance/template/seeds/review.sql
+++ b/.claude/skills/optimize-performance/template/seeds/review.sql
@@ -1,0 +1,118 @@
+-- 복습 도메인 시드: answer → option → bookmark
+--
+-- 필요한 변수: user_start, user_count, target_unit_id,
+--              bookmarks_per_user, target_unit_bookmarks_per_user, options_per_problem
+--
+-- answer/option은 problem 전체를 커버한다. ProblemFactory가 문제 타입별로 하나라도 없으면
+-- ANSWER_NOT_FOUND / OPTION_NOT_FOUND 예외를 던져 측정이 500으로 끝난다.
+--
+-- bookmark는 유저마다 :target_unit_bookmarks_per_user 건을 :target_unit_id 에 몰고,
+-- 나머지를 다른 유닛의 문제에 퍼뜨린다. 대상 유닛 필터가 실제로 행을 걸러내게 하려는 것이다.
+-- created_at은 유저 안에서 행마다 다른 값을 갖는다. ORDER BY b.createdAt 이 실제 정렬을 수행해야 한다.
+--
+-- bookmark/answer/option에는 유니크 제약이 없으므로 ON CONFLICT를 쓸 수 없다.
+-- 재실행 시 중복이 쌓이지 않도록 NOT EXISTS 가드를 둔다. 가드를 지우지 마라.
+
+\echo '[review.sql] answer/option/bookmark 적재'
+
+BEGIN;
+
+-- answer: SUBJECTIVE 문제마다 1건
+INSERT INTO answer (problem_id, content, explanation)
+SELECT p.id,
+       'perf answer ' || p.id,
+       'perf answer explanation ' || p.id
+FROM problem p
+WHERE p.problem_type = 'SUBJECTIVE'
+  AND NOT EXISTS (SELECT 1 FROM answer a WHERE a.problem_id = p.id);
+
+-- option: OBJECTIVE 문제마다 :options_per_problem 건 (첫 번째가 정답)
+INSERT INTO "option" (problem_id, content, explanation, is_answer)
+SELECT p.id,
+       'perf option ' || p.id || '-' || o,
+       'perf option explanation ' || p.id || '-' || o,
+       (o = 1)
+FROM problem p
+CROSS JOIN generate_series(1, :options_per_problem) AS o
+WHERE p.problem_type = 'OBJECTIVE'
+  AND NOT EXISTS (SELECT 1 FROM "option" op WHERE op.problem_id = p.id);
+
+-- bookmark: 유저당 :bookmarks_per_user 건
+INSERT INTO bookmark (user_id, problem_id, created_at)
+SELECT src.user_id,
+       src.problem_id,
+       TIMESTAMP '2025-01-01 00:00:00'
+           + (row_number() OVER (PARTITION BY src.user_id ORDER BY src.problem_id) * INTERVAL '1 second')
+FROM (
+    WITH unseeded_users AS (
+        SELECT u.id,
+               row_number() OVER (ORDER BY u.id) - 1 AS u_idx
+        FROM users u
+        WHERE u.id BETWEEN :user_start AND :user_start + :user_count - 1
+          AND NOT EXISTS (SELECT 1 FROM bookmark b WHERE b.user_id = u.id)
+    ),
+    target_problems AS (
+        SELECT p.id,
+               row_number() OVER (PARTITION BY p.problem_type ORDER BY p.id) - 1 AS rn
+        FROM problem p
+        JOIN lesson l ON l.id = p.lesson_id
+        WHERE l.unit_id = :target_unit_id
+    ),
+    other_problems AS (
+        SELECT p.id,
+               row_number() OVER (ORDER BY p.id) - 1 AS p_idx
+        FROM problem p
+        JOIN lesson l ON l.id = p.lesson_id
+        WHERE l.unit_id <> :target_unit_id
+    ),
+    other_count AS (
+        SELECT count(*)::bigint AS n FROM other_problems
+    )
+    -- 대상 유닛: rn이 problem_type별로 매겨지므로 k 하나가 OBJECTIVE/SUBJECTIVE 각 1건을 집는다
+    SELECT u.id AS user_id, tp.id AS problem_id
+    FROM unseeded_users u
+    CROSS JOIN generate_series(0, :target_unit_bookmarks_per_user / 2 - 1) AS k
+    JOIN target_problems tp ON tp.rn = k
+
+    UNION ALL
+
+    -- 그 외 유닛: 유저마다 서로 다른 문제 집합을 집는다 (step 11은 유저 안에서 충돌하지 않는다)
+    SELECT u.id, op.id
+    FROM unseeded_users u
+    CROSS JOIN generate_series(0, :bookmarks_per_user - :target_unit_bookmarks_per_user - 1) AS k
+    CROSS JOIN other_count oc
+    JOIN other_problems op ON op.p_idx = ((u.u_idx * 37 + k * 11) % oc.n)
+) AS src;
+
+COMMIT;
+
+ANALYZE answer;
+ANALYZE "option";
+ANALYZE bookmark;
+
+-- 검증: 행 수와 카디널리티
+SELECT 'answer' AS table_name, count(*) AS rows, count(DISTINCT problem_id) AS distinct_problem
+FROM answer
+UNION ALL
+SELECT 'option', count(*), count(DISTINCT problem_id) FROM "option"
+UNION ALL
+SELECT 'bookmark', count(*), count(DISTINCT problem_id) FROM bookmark;
+
+SELECT count(DISTINCT user_id) AS distinct_user,
+       count(*) / NULLIF(count(DISTINCT user_id), 0) AS per_user,
+       min(created_at) AS min_created,
+       max(created_at) AS max_created
+FROM bookmark;
+
+-- 검증: 대상 유닛의 유저당 결과 크기와 문제 타입 분포
+SELECT b.user_id,
+       count(*) AS rows_in_target_unit,
+       count(*) FILTER (WHERE p.problem_type = 'OBJECTIVE') AS objective,
+       count(*) FILTER (WHERE p.problem_type = 'SUBJECTIVE') AS subjective
+FROM bookmark b
+JOIN problem p ON p.id = b.problem_id
+JOIN lesson l ON l.id = p.lesson_id
+WHERE l.unit_id = :target_unit_id
+GROUP BY b.user_id
+ORDER BY b.user_id
+LIMIT 3;

--- a/.claude/skills/optimize-performance/template/seeds/review.sql
+++ b/.claude/skills/optimize-performance/template/seeds/review.sql
@@ -1,7 +1,8 @@
--- 복습 도메인 시드: answer → option → bookmark
+-- 복습 도메인 시드: answer → option → bookmark → wrong_answered_note
 --
 -- 필요한 변수: user_start, user_count, target_unit_id,
---              bookmarks_per_user, target_unit_bookmarks_per_user, options_per_problem
+--              bookmarks_per_user, target_unit_bookmarks_per_user, options_per_problem,
+--              target_unit_wrong_notes_per_user, target_unit_resolved_per_user
 --
 -- answer/option은 problem 전체를 커버한다. ProblemFactory가 문제 타입별로 하나라도 없으면
 -- ANSWER_NOT_FOUND / OPTION_NOT_FOUND 예외를 던져 측정이 500으로 끝난다.
@@ -10,10 +11,17 @@
 -- 나머지를 다른 유닛의 문제에 퍼뜨린다. 대상 유닛 필터가 실제로 행을 걸러내게 하려는 것이다.
 -- created_at은 유저 안에서 행마다 다른 값을 갖는다. ORDER BY b.createdAt 이 실제 정렬을 수행해야 한다.
 --
+-- wrong_answered_note는 유저마다 :target_unit_wrong_notes_per_user 건을 :target_unit_id 에 몰고,
+-- 그중 뒤쪽 :target_unit_resolved_per_user 건을 극복 처리한다.
+-- resolvedAt IS NULL 필터가 대상 유닛 안에서 실제로 행을 걸러내게 하려는 것이다.
+-- 반환 행 수 = :target_unit_wrong_notes_per_user - :target_unit_resolved_per_user 가 된다.
+--
 -- bookmark/answer/option에는 유니크 제약이 없으므로 ON CONFLICT를 쓸 수 없다.
 -- 재실행 시 중복이 쌓이지 않도록 NOT EXISTS 가드를 둔다. 가드를 지우지 마라.
+-- wrong_answered_note만 (user_id, problem_id) 유니크 인덱스가 있어 ON CONFLICT DO NOTHING을 쓴다.
+-- 이 테이블은 대상 유닛 밖에 이미 행이 있을 수 있어 "유저에 행이 없으면" 가드가 통하지 않는다.
 
-\echo '[review.sql] answer/option/bookmark 적재'
+\echo '[review.sql] answer/option/bookmark/wrong_answered_note 적재'
 
 BEGIN;
 
@@ -84,11 +92,41 @@ FROM (
     JOIN other_problems op ON op.p_idx = ((u.u_idx * 37 + k * 11) % oc.n)
 ) AS src;
 
+-- wrong_answered_note: 대상 유닛에 유저당 :target_unit_wrong_notes_per_user 건
+-- k 하나가 OBJECTIVE/SUBJECTIVE 각 1건을 집으므로 타입이 균형을 이룬다.
+-- k가 뒤쪽 구간이면 극복 처리해 resolved_at을 채운다.
+INSERT INTO wrong_answered_note (user_id, problem_id, wrong_count, created_at, updated_at, resolved_at)
+SELECT su.id,
+       tp.id,
+       1 + (k % 3),
+       TIMESTAMP '2025-01-01 00:00:00' + (k * INTERVAL '1 second'),
+       TIMESTAMP '2025-01-01 00:00:00' + (k * INTERVAL '1 second'),
+       CASE
+           WHEN k >= (:target_unit_wrong_notes_per_user - :target_unit_resolved_per_user) / 2
+               THEN TIMESTAMP '2025-06-01 00:00:00' + (k * INTERVAL '1 second')
+           ELSE NULL
+       END
+FROM (
+    SELECT u.id
+    FROM users u
+    WHERE u.id BETWEEN :user_start AND :user_start + :user_count - 1
+) AS su
+CROSS JOIN generate_series(0, :target_unit_wrong_notes_per_user / 2 - 1) AS k
+JOIN (
+    SELECT p.id,
+           row_number() OVER (PARTITION BY p.problem_type ORDER BY p.id) - 1 AS rn
+    FROM problem p
+    JOIN lesson l ON l.id = p.lesson_id
+    WHERE l.unit_id = :target_unit_id
+) AS tp ON tp.rn = k
+ON CONFLICT (user_id, problem_id) DO NOTHING;
+
 COMMIT;
 
 ANALYZE answer;
 ANALYZE "option";
 ANALYZE bookmark;
+ANALYZE wrong_answered_note;
 
 -- 검증: 행 수와 카디널리티
 SELECT 'answer' AS table_name, count(*) AS rows, count(DISTINCT problem_id) AS distinct_problem
@@ -96,7 +134,9 @@ FROM answer
 UNION ALL
 SELECT 'option', count(*), count(DISTINCT problem_id) FROM "option"
 UNION ALL
-SELECT 'bookmark', count(*), count(DISTINCT problem_id) FROM bookmark;
+SELECT 'bookmark', count(*), count(DISTINCT problem_id) FROM bookmark
+UNION ALL
+SELECT 'wrong_answered_note', count(*), count(DISTINCT problem_id) FROM wrong_answered_note;
 
 SELECT count(DISTINCT user_id) AS distinct_user,
        count(*) / NULLIF(count(DISTINCT user_id), 0) AS per_user,
@@ -115,4 +155,19 @@ JOIN lesson l ON l.id = p.lesson_id
 WHERE l.unit_id = :target_unit_id
 GROUP BY b.user_id
 ORDER BY b.user_id
+LIMIT 3;
+
+-- 검증: 대상 유닛의 유저당 오답노트 반환 크기(미극복)와 극복 건수
+SELECT wan.user_id,
+       count(*)                                                                          AS total_in_target_unit,
+       count(*) FILTER (WHERE wan.resolved_at IS NULL)                                   AS unresolved,
+       count(*) FILTER (WHERE wan.resolved_at IS NULL AND p.problem_type = 'OBJECTIVE')  AS objective,
+       count(*) FILTER (WHERE wan.resolved_at IS NULL AND p.problem_type = 'SUBJECTIVE') AS subjective,
+       count(*) FILTER (WHERE wan.resolved_at IS NOT NULL)                               AS resolved
+FROM wrong_answered_note wan
+JOIN problem p ON p.id = wan.problem_id
+JOIN lesson l ON l.id = p.lesson_id
+WHERE l.unit_id = :target_unit_id
+GROUP BY wan.user_id
+ORDER BY wan.user_id
 LIMIT 3;

--- a/src/main/java/gravit/code/bookmark/repository/BookmarkRepository.java
+++ b/src/main/java/gravit/code/bookmark/repository/BookmarkRepository.java
@@ -35,8 +35,7 @@ public interface BookmarkRepository extends JpaRepository<Bookmark, Long> {
         FROM Bookmark b
         JOIN Problem p ON p.id = b.problemId
         JOIN Lesson l ON l.id = p.lessonId
-        JOIN Unit u ON u.id = l.unitId
-        WHERE u.id = :unitId AND b.userId = :userId
+        WHERE l.unitId = :unitId AND b.userId = :userId
         ORDER BY b.createdAt ASC
     """)
     List<ProblemDetailResponse> findBookmarkedProblemDetailByUnitIdAndUserId(
@@ -49,8 +48,7 @@ public interface BookmarkRepository extends JpaRepository<Bookmark, Long> {
         FROM Bookmark b
         JOIN Problem p ON p.id = b.problemId
         JOIN Lesson l ON l.id = p.lessonId
-        JOIN Unit u ON u.id = l.unitId
-        WHERE u.id = :unitId AND b.userId = :userId
+        WHERE l.unitId = :unitId AND b.userId = :userId
     """)
     int countByUnitIdAndUserId(
             @Param("unitId")long unitId,

--- a/src/main/java/gravit/code/wrongAnsweredNote/repository/WrongAnsweredNoteRepository.java
+++ b/src/main/java/gravit/code/wrongAnsweredNote/repository/WrongAnsweredNoteRepository.java
@@ -45,9 +45,8 @@ public interface WrongAnsweredNoteRepository extends JpaRepository<WrongAnswered
         FROM WrongAnsweredNote wan
         JOIN Problem p ON p.id = wan.problemId
         JOIN Lesson l ON l.id = p.lessonId
-        JOIN Unit u ON u.id = l.unitId
         LEFT JOIN Bookmark b on b.problemId = p.id AND b.userId = :userId
-        WHERE wan.userId = :userId AND u.id = :unitId AND wan.resolvedAt IS NULL
+        WHERE wan.userId = :userId AND l.unitId = :unitId AND wan.resolvedAt IS NULL
     """)
     List<ProblemDetailResponse> findWrongAnsweredProblemDetailByUnitIdAndUserId(
             @Param("unitId")long unitId,
@@ -59,8 +58,7 @@ public interface WrongAnsweredNoteRepository extends JpaRepository<WrongAnswered
         FROM WrongAnsweredNote wan
         JOIN Problem p ON p.id = wan.problemId
         JOIN Lesson l ON l.id = p.lessonId
-        JOIN Unit u ON u.id = l.unitId
-        WHERE u.id = :unitId AND wan.userId = :userId AND wan.resolvedAt IS NULL
+        WHERE l.unitId = :unitId AND wan.userId = :userId AND wan.resolvedAt IS NULL
     """)
     int countByUnitIdAndUserId(
             @Param("unitId")long unitId,

--- a/src/main/resources/db/migration/V38__add_bookmark_user_problem_unique_index.sql
+++ b/src/main/resources/db/migration/V38__add_bookmark_user_problem_unique_index.sql
@@ -1,0 +1,12 @@
+-- V38__add_bookmark_user_problem_unique_index.sql
+
+-- 유닛별 북마크 문제 조회(GET /api/v1/bookmarks/{unitId})가 bookmark를 user_id로 거르지만
+-- bookmark에는 PK 인덱스만 있어 매번 전체 스캔이 발생한다.
+-- 156,000행 기준 실행계획에서 155,844행(99.9%)을 필터로 버리고 156행만 남기며,
+-- 이 노드 하나가 쿼리 실행시간의 84%와 만진 페이지의 87.9%를 차지한다.
+-- user_id를 선두 키로 두어 user_id 단독으로 필터하는 북마크 개수 조회도 같은 인덱스를 타게 한다.
+-- 북마크는 유저와 문제 단위로 하나만 존재하고 BookmarkService가 이미 그 전제로 동작하므로
+-- (addBookmark가 중복 시 BOOKMARK_DUPLICATED를 던지고 deleteByProblemIdAndUserId가 그 쌍으로 단건을 지운다)
+-- UNIQUE로 제약을 명시해 조회 후 저장 사이의 경쟁으로 중복 행이 생기는 것을 DB가 막는다.
+CREATE UNIQUE INDEX IF NOT EXISTS ix_bookmark_user_problem
+    ON bookmark (user_id, problem_id);


### PR DESCRIPTION
## PR Summary

북마크 조회와 오답노트 조회의 성능을 측정하고 개선했습니다. 북마크 조회는 인덱스 부재로 매 요청 15만 6천 행을 풀스캔하던 것을 인덱스 조회로 바꿔 요청당 DB 시간을 79.0% 줄였고, 오답노트 조회는 측정 결과 병목이 약해 불필요한 조인을 걷어내는 선에서 마무리했습니다.

<br>

## Problem

**문제 1 - 북마크 조회가 매 요청 테이블 전체를 읽음** (`bookmark` 15만 6천 행, 유닛당 30건 반환 기준)

`bookmark` 테이블에는 PK 인덱스밖에 없었습니다. 유저의 북마크를 유닛 단위로 조회하는 쿼리가 `WHERE b.userId = :userId` 조건을 걸지만 탈 인덱스가 없어, 매 요청 15만 6천 행을 읽고 그중 15만 5,844행(99.9%)을 버린 뒤 156행만 남기는 동작을 했습니다.

이 쿼리 하나가 측정 구간 전체 DB 실행시간의 91.2%를 차지했고, 나머지 11개 쿼리의 합이 8.8%였습니다. 반환 행이 30건인데 평균 실행시간이 101.58ms로, 반환량 대비 비용이 과도했습니다. 북마크는 유저 수에 비례해 늘어나는 테이블이라 이 비용은 서비스가 커질수록 선형으로 악화됩니다.

<br>

**문제 2 - 오답노트, 북마크 조회에 결과를 바꾸지 않는 조인이 포함됨**

두 도메인의 조회 쿼리 4개가 모두 `JOIN Unit u ON u.id = l.unitId ... WHERE u.id = :unitId` 형태로 `Unit`을 조인하고 있었습니다. 그런데 `Unit`에서 꺼내 쓰는 값은 `u.id` 하나뿐이고, 조인 조건상 그 값은 항상 `l.unitId`와 같습니다. FK 값을 이미 들고 있는데 부모 테이블을 다시 찾아가는 형태였습니다.

옵티마이저가 `l.unit_id = :unitId`라는 조건을 스스로 도출해 `lesson`으로 밀어 넣기 때문에 실행 비용 자체는 크지 않았습니다. 다만 실행 계획에 의미 없는 스캔 노드와 조인 노드가 남고, 쿼리를 읽는 사람에게 `Unit` 테이블의 무언가가 필요하다는 잘못된 인상을 줍니다.

<br>

## Solution

**해결 1 - `bookmark (user_id, problem_id)` UNIQUE 인덱스 추가**

```sql
CREATE UNIQUE INDEX ix_bookmark_user_problem ON bookmark (user_id, problem_id);
```

`user_id`를 선두에 둔 이유는 이 컬럼이 쿼리에서 유일한 등호 조건이면서 선택도가 가장 좋기 때문입니다. 서로 다른 값이 1,000개라 15만 6천 행이 156행으로 좁혀집니다(선택도 0.1%). `problem_id`를 두 번째에 둔 것은 `Problem`과의 조인 키이기 때문입니다. 인덱스가 이 값을 들고 있으면 조인 시 힙까지 가지 않고 꺼낼 여지가 생깁니다.

UNIQUE로 만든 것은 성능이 아니라 도메인 제약 때문입니다. 북마크는 유저와 문제 단위로 하나만 존재하고 코드도 이미 그 전제로 동작합니다. 중복 시 `BOOKMARK_DUPLICATED`를 던지고, 삭제도 그 쌍으로 단건을 지웁니다. 존재 확인과 저장 사이의 경쟁으로 중복 행이 생기는 것을 DB가 막게 했습니다.

부분 인덱스는 두지 않았습니다. `bookmark`에는 soft delete도 상태 컬럼도 없어(`id`, `created_at`, `problem_id`, `user_id`가 전부) 항상 걸리는 필터 조건이 없습니다. 커버링(`INCLUDE (created_at)`)도 넣지 않았습니다. 힙 접근만 줄이고 `ORDER BY b.createdAt`의 Sort 노드는 그대로 남는데, 힙 접근이 실제로 비싼지 확인되지 않은 상태에서 인덱스 컬럼을 늘릴 근거가 없다고 봤습니다. 개선 후 실측에서 Sort 노드의 자기 몫이 0.050ms(2.9%)로 나와 이 판단이 맞았습니다.

**실행 계획** (유저 1500, 유닛 900002 기준)

| 지표 | Before | After | 변화 |
|---|---|---|---|
| 실행 계획 | Seq Scan | Index Scan using `ix_bookmark_user_problem` | |
| 스캔 행 / 반환 행 | 156,000 / 30 = 5,200:1 | 인덱스 탐색 60 / 30 = 2:1 | |
| 필터로 버린 행 | 155,844 | 0 | -100% |
| buffers | 1,306 (10.2MB) | 371 (2.9MB) | -71.6% |
| 실행시간 | 14.585ms | 1.875ms | -87.1% |

**부하 지표**

| 지표 | Before | After | 변화 |
|---|---|---|---|
| 쿼리 평균 실행시간 | 101.582ms | 7.550ms | -92.6% |
| 요청당 DB 시간 합 | 111.39ms | 23.36ms | -79.0% |
| 요청당 쿼리 수 | 6 | 6 | 변화 없음 |
| p95 | 473.056ms | 442.312ms | -6.5% |
| p99 | 719.103ms | 968.117ms | +34.6% |
| 처리량 | 166.16 RPS | 221.22 RPS | 1.33배 |

p99가 악화한 것은 처리량이 33% 늘면서 커넥션 풀 60개에 요청이 몰린 대기열 신호로 봅니다. med는 219.35ms에서 125.13ms로 43.0% 줄었고 p95도 개선되었는데 p99만 벌어진 분포이며, 단발 스파이크로 설명하기에는 해당 구간의 요청 수가 많습니다.

<br>

**해결 2 - 불필요한 `Unit` 조인 제거**

조인을 걷어내고 `WHERE l.unitId = :unitId`로 대체했습니다. 코드베이스의 `Unit` 조인 8곳 중 이 형태에 해당하는 4곳(오답노트 2, 북마크 2)에 모두 적용했습니다. 나머지 4곳은 `u.title`을 응답에 쓰거나 `u.chapterId`로 `Chapter`까지 이어가므로 제거 대상이 아닙니다.

`lesson.unit_id`에는 FK 제약이 없어 이론적으로는 존재하지 않는 유닛을 가리키는 레슨이 있을 수 있고, 그 경우 inner join과 WHERE 조건의 결과가 갈립니다. 다만 이 쿼리 4개의 호출 경로가 전부 유닛 요약 조회를 먼저 수행해 유닛이 없으면 `UNIT_NOT_FOUND`를 던지므로, 쿼리에 도달하는 시점에는 유닛 존재가 보장됩니다. 동작이 달라지는 경로는 없습니다.

**실행 계획** (오답노트 조회, 유저 1500, 유닛 900002 기준)

| 지표 | Before | After | 변화 |
|---|---|---|---|
| 실행 계획 노드 수 | 8 | 6 | -2 |
| 스캔 방식 | `problem`, `lesson`, `unit` Seq Scan + Index Scan 2 | `problem`, `lesson` Seq Scan + Index Scan 2 | `unit` 노드 소멸 |
| buffers | 440 (3.44MB) | 438 (3.42MB) | -2 |
| 스캔 행 / 반환 행 | 6,900 / 30 = 230:1 | 6,900 / 30 = 230:1 | 변화 없음 |

<br>

**측정했지만 개선하지 않기로 한 것 - 오답노트 조회의 `problem` 풀스캔**

오답노트 조회는 유닛의 문제 60건을 찾기 위해 `problem` 6,900행을 전부 훑습니다. 이 스캔과 그 위의 Hash Join이 쿼리 실행시간의 74.3%를 차지해 가장 비싼 구간입니다. 그럼에도 개선하지 않았습니다.

첫째, 이 비용은 유저 수가 아니라 콘텐츠 양에만 비례합니다. `wrong_answered_note`(19만 5,700행)와 `bookmark`(15만 6천 행) 접근은 인덱스 점 조회라 테이블이 커져도 로그 규모로만 늘어납니다. 유저가 100배 늘어도 이 쿼리는 거의 그대로입니다.

둘째, 효과의 상한이 낮습니다. 요청당 DB 시간 13.23ms가 med 응답 97.56ms의 13.6%이고, 대상 쿼리 몫은 4.2%입니다. 74.3%를 통째로 없애도 응답시간 기준 2.7%입니다. 나머지 86%는 DB 밖(요청당 14.5KB 응답의 직렬화, 커넥션 대기, 동시성 경합)에 있습니다.

검토한 대안은 `wrong_answered_note`에 `unit_id`를 반정규화하는 것과 유닛별 문제 목록을 캐싱하는 것이었습니다. 전자는 19만 5,700행 백필과 쓰기 경로 변경에 더해 문제가 다른 레슨으로 옮겨질 때의 동기화 책임을 영구히 지게 됩니다. 후자는 무효화 경로 설계가 필요한데 노리는 상한은 같습니다. 응답시간 2.7%를 얻으려고 치르기에는 비용이 크다고 판단했습니다. `problem`이 수만 행대로 커지면 다시 꺼낼 후보로 기록에 남겼습니다.

<br>

**측정 조건**

VU 50, ramp-up 30초 + 유지 1분 + ramp-down 30초, 유저 1,000명, `bookmark` 15만 6천 행, `wrong_answered_note` 19만 5,700행, `problem` 6,900행, 커넥션 풀 60. 로컬 단일 머신에서 애플리케이션과 PostgreSQL을 함께 띄워 측정했으므로 처리량과 응답시간의 절대값은 하드웨어에 의존합니다.

그래서 개선 판정은 하드웨어에 의존하지 않는 증거(실행 계획, 스캔 행 수, buffers, 요청당 쿼리 수)로 했습니다. 이 판단이 필요했던 사례가 실제로 있었습니다. 해결 2 적용 후 부하 지표가 전반적으로 나빠져 보였는데, 코드를 바꾸지 않고 같은 측정을 한 번 더 돌리자 처리량이 14.4% 더 떨어졌습니다. 코드를 바꾼 구간의 낙폭(1.3%)보다 큰 값이라, 이 환경의 부하 지표에는 1% 수준의 변화를 판정할 해상도가 없다고 보고 부하 수치를 판정 근거에서 제외했습니다.

측정 산출물은 `.claude/resources/perf/492/` 아래에 대상별로 두었습니다. 기준선과 개선 후의 k6 요약, 쿼리 통계, 실행 계획 원본, 판정 근거가 들어 있습니다.

<br>

## Related Issue
- close #492


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **개선 사항**
  - 북마크 및 오답 노트 조회 성능을 개선해 단위별 검색 처리를 최적화했습니다.
  - 북마크 데이터의 사용자·문제 조합 중복을 방지해 데이터 일관성을 강화했습니다.
  - 조회 결과와 응답 형식은 기존과 동일하게 유지됩니다.

- **성능 검증**
  - 부하 테스트와 쿼리 분석을 추가해 주요 조회 API의 처리량, 응답 시간 및 안정성을 확인했습니다.
  - 북마크와 오답 노트 API에서 오류 없이 모든 검증을 통과했습니다.

- **문서화**
  - 성능 측정 결과, 실행 계획, 테스트 조건 및 비교 분석 자료를 추가했습니다.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->